### PR TITLE
PP-76: News feed integration module

### DIFF
--- a/conf/cmi/core.entity_form_display.node.imported_article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.imported_article.default.yml
@@ -1,0 +1,119 @@
+uuid: 4c3b4c13-60a8-4442-9b71-026c00ca415e
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.node.imported_article.body
+    - field.field.node.imported_article.field_image
+    - image.style.thumbnail
+    - node.type.imported_article
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - image
+    - path
+    - scheduler
+    - text
+_core:
+  default_config_hash: 3X3P2CLtvszPB84oy7EeY3Zm9E4ymt1lwju6-um9Ock
+id: node.imported_article.default
+targetEntityType: node
+bundle: imported_article
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 12
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: image_image
+    weight: 13
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_image: true

--- a/conf/cmi/core.entity_view_display.node.imported_article.default.yml
+++ b/conf/cmi/core.entity_view_display.node.imported_article.default.yml
@@ -1,0 +1,34 @@
+uuid: 04172a5f-0fd7-4c79-af3c-96a1c2c6d046
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.node.imported_article.body
+    - field.field.node.imported_article.field_image
+    - node.type.imported_article
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - text
+    - user
+_core:
+  default_config_hash: A4sceLgPjOPsvAE06zxeJCG3fd0xjMkYLmxl4Ak-9n4
+id: node.imported_article.default
+targetEntityType: node
+bundle: imported_article
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden:
+  field_image: true
+  langcode: true

--- a/conf/cmi/core.entity_view_display.node.imported_article.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.imported_article.teaser.yml
@@ -1,0 +1,38 @@
+uuid: 088e19a1-d8ad-475b-9110-cf3b800c47d5
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.imported_article.body
+    - field.field.node.imported_article.field_image
+    - node.type.imported_article
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - text
+    - user
+_core:
+  default_config_hash: NirpcNFGmb_SGgnvImAbjF-a6ydXh0vnVqSYkN985mE
+id: node.imported_article.teaser
+targetEntityType: node
+bundle: imported_article
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_image: true
+  langcode: true

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -62,6 +62,7 @@ module:
   migrate: 0
   node: 0
   options: 0
+  paatokset_news_importer: 0
   page_cache: 0
   paragraphs_asymmetric_translation_widgets: 0
   path: 0

--- a/conf/cmi/field.field.node.imported_article.body.yml
+++ b/conf/cmi/field.field.node.imported_article.body.yml
@@ -1,0 +1,28 @@
+uuid: 69165f85-2e8f-4e4e-9aa2-13f58b4ac498
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.imported_article
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - text
+_core:
+  default_config_hash: 3L3kAZFwb6EGlYvgfTxfsfSqSOWbNnATbD9_PHmHbVM
+id: node.imported_article.body
+field_name: body
+entity_type: node
+bundle: imported_article
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/conf/cmi/field.field.node.imported_article.field_image.yml
+++ b/conf/cmi/field.field.node.imported_article.field_image.yml
@@ -1,0 +1,43 @@
+uuid: 1dca1fb3-0140-477d-9590-3e4504504314
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - node.type.imported_article
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - image
+_core:
+  default_config_hash: vRLlUxL50j91zax6CttxqCYAJms0NXItnWzIMUXG3Co
+id: node.imported_article.field_image
+field_name: field_image
+entity_type: node
+bundle: imported_article
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/conf/cmi/field.storage.node.field_image.yml
+++ b/conf/cmi/field.storage.node.field_image.yml
@@ -1,0 +1,35 @@
+uuid: 07767065-3239-4bac-8859-120fd659a224
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - file
+    - image
+    - node
+_core:
+  default_config_hash: G77bKrN0GPW84P4O29nUDfRT3-vGpmb66DcykASSADg
+id: node.field_image
+field_name: field_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.node.imported_article.yml
+++ b/conf/cmi/language.content_settings.node.imported_article.yml
@@ -1,0 +1,11 @@
+uuid: 53ed8e19-e318-474e-830f-a37b7d3ae69c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.imported_article
+id: node.imported_article
+target_entity_type_id: node
+target_bundle: imported_article
+default_langcode: fi
+language_alterable: false

--- a/conf/cmi/node.type.imported_article.yml
+++ b/conf/cmi/node.type.imported_article.yml
@@ -1,0 +1,37 @@
+uuid: 900177b7-ca4a-4589-8281-15136be514a8
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+_core:
+  default_config_hash: sefk051KFkjD6XhIzNY6sGD5ZWDj9RznZh2VQqJsmY8
+name: 'Imported Article'
+type: imported_article
+description: 'News imported from Hel.fi RSS feed'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/conf/cmi/views.view.imported_articles.yml
+++ b/conf/cmi/views.view.imported_articles.yml
@@ -1,0 +1,390 @@
+uuid: a69fe79f-3fb2-4718-8b92-da38867e05cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - field.storage.node.field_image
+    - node.type.imported_article
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - image
+    - node
+    - text
+    - user
+_core:
+  default_config_hash: FLyYLwB0igRJ_vW6kqdSM4jaDOMbNdGQ7zBhl_4YCJQ
+id: imported_articles
+label: 'Imported articles'
+module: views
+description: 'Shows feed of newest imported articles'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 10
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_image:
+          id: field_image
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 600
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            imported_article: imported_article
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: 'Imported articles'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_image'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_image'

--- a/public/modules/custom/paatokset_news_importer/config/install/core.entity_form_display.node.imported_article.default.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/core.entity_form_display.node.imported_article.default.yml
@@ -1,0 +1,115 @@
+# core.entity_form_display.node.imported_article.default.yml
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.node.imported_article.body
+    - field.field.node.imported_article.field_image
+    - node.type.imported_article
+  enforced:
+    module:
+      - paatokset_news_importer
+  module:
+    - path
+    - scheduler
+    - text
+id: node.imported_article.default
+targetEntityType: node
+bundle: imported_article
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 12
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: image_image
+    weight: 13
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_image: true

--- a/public/modules/custom/paatokset_news_importer/config/install/core.entity_view_display.node.imported_article.default.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/core.entity_view_display.node.imported_article.default.yml
@@ -1,0 +1,27 @@
+# core.entity_view_display.node.imported_article.default.yml
+langcode: fi
+status: true
+dependencies:
+    config:
+        - field.field.node.imported_article.body
+        - node.type.imported_article
+    module:
+        - text
+        - user
+    enforced:
+        module:
+            - paatokset_news_importer
+id: node.imported_article.default
+targetEntityType: node
+bundle: imported_article
+mode: default
+content:
+    body:
+        label: hidden
+        type: text_default
+        weight: 101
+        settings: {  }
+        third_party_settings: {  }
+    links:
+        weight: 100
+hidden: {  }

--- a/public/modules/custom/paatokset_news_importer/config/install/core.entity_view_display.node.imported_article.teaser.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/core.entity_view_display.node.imported_article.teaser.yml
@@ -1,0 +1,26 @@
+# core.entity_view_display.node.imported_article.teaser.yml
+langcode: fi
+status: true
+dependencies:
+    config:
+        - core.entity_view_mode.node.teaser
+        - field.field.node.imported_article.body
+        - node.type.imported_article
+    module:
+        - text
+    enforced:
+        module:
+            - paatokset_news_importer
+id: node.imported_article.teaser
+targetEntityType: node
+bundle: imported_article
+mode: teaser
+content:
+    body:
+        label: hidden
+        type: text_summary_or_trimmed
+        weight: 101
+        settings:
+            trim_length: 600
+        third_party_settings: {  }
+hidden: {  }

--- a/public/modules/custom/paatokset_news_importer/config/install/field.field.node.imported_article.body.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/field.field.node.imported_article.body.yml
@@ -1,0 +1,26 @@
+# field.field.node.imported_article.body.yml
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.imported_article
+  module:
+    - text
+  enforced:
+    module:
+      - paatokset_news_importer
+id: node.imported_article.body
+field_name: body
+entity_type: node
+bundle: imported_article
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/public/modules/custom/paatokset_news_importer/config/install/field.field.node.imported_article.field_image.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/field.field.node.imported_article.field_image.yml
@@ -1,0 +1,41 @@
+# field.field.node.imported_article.field_image.yml
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - node.type.imported_article
+  module:
+    - image
+  enforced:
+    module:
+      - paatokset_news_importer
+id: node.imported_article.field_image
+field_name: field_image
+entity_type: node
+bundle: imported_article
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/public/modules/custom/paatokset_news_importer/config/install/field.storage.node.field_image.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/field.storage.node.field_image.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+  enforced:
+    module:
+      - paatokset_news_importer
+id: node.field_image
+field_name: field_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_news_importer/config/install/language.content_settings.node.imported_article.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/language.content_settings.node.imported_article.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.imported_article
+id: node.imported_article
+target_entity_type_id: node
+target_bundle: imported_article
+default_langcode: fi
+language_alterable: false

--- a/public/modules/custom/paatokset_news_importer/config/install/node.type.imported_article.yml
+++ b/public/modules/custom/paatokset_news_importer/config/install/node.type.imported_article.yml
@@ -1,0 +1,14 @@
+# node.type.imported_article.yml
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - paatokset_news_importer
+name: 'Imported Article'
+type: imported_article
+description: 'News imported from Hel.fi RSS feed'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/public/modules/custom/paatokset_news_importer/config/optional/views.view.imported_articles.yml
+++ b/public/modules/custom/paatokset_news_importer/config/optional/views.view.imported_articles.yml
@@ -1,0 +1,387 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - field.storage.node.field_image
+    - node.type.imported_article
+  module:
+    - image
+    - node
+    - text
+    - user
+  enforced:
+    module:
+      - paatokset_news_importer
+id: imported_articles
+label: 'Imported articles'
+module: views
+description: 'Shows feed of newest imported articles'
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 10
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_image:
+          id: field_image
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 600
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            imported_article: imported_article
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: 'Imported articles'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_image'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_image'

--- a/public/modules/custom/paatokset_news_importer/migrations/paatokset_news.yml
+++ b/public/modules/custom/paatokset_news_importer/migrations/paatokset_news.yml
@@ -1,0 +1,52 @@
+langcode: fi
+id: paatokset_news
+label: 'Päätökset news RSS feed import'
+status: true
+dependencies:
+  enforced:
+    module:
+      - paatokset_news_importer
+source:
+  plugin: imported_article
+  url: 'https://www.hel.fi/wps/wcmjspv2/filtered-news-listing.jsp?rss=rss&categories=helsinkishared%2FPaatokset'
+  ids:
+    guid:
+      type: string
+      max_length: 1024
+process:
+  title: title
+  guid: guid
+  body/value:
+    plugin: callback
+    callable: html_entity_decode
+    source: content
+  body/summary: description
+  body/format:
+    plugin: default_value
+    default_value: 'full_html'
+  uid/target_id:
+    plugin: default_value
+    default_value: '1'
+  field_image/target_id:
+    plugin: migration_lookup
+    migration: paatokset_news_images
+    source: guid
+  field_image/alt: image_alt
+  field_image/title: image_title
+  created:
+    plugin: format_date
+    from_format: 'd M Y H:i:s O'
+    to_format: 'U'
+    source: pubDate
+  status:
+    plugin: default_value
+    default_value: 1
+  type:
+    plugin: default_value
+    default_value: imported_article
+  langcode:
+    plugin: default_value
+    default_value: fi
+destination:
+  plugin: 'entity:node'
+migration_dependencies: { }

--- a/public/modules/custom/paatokset_news_importer/migrations/paatokset_news_images.yml
+++ b/public/modules/custom/paatokset_news_importer/migrations/paatokset_news_images.yml
@@ -1,0 +1,33 @@
+id: paatokset_news_images
+label: 'Paatokset imported news images'
+source:
+  constants:
+    uri_file: 'public://imported_article/image'
+  plugin: imported_article
+  url: 'https://www.hel.fi/wps/wcmjspv2/filtered-news-listing.jsp?rss=rss&categories=helsinkishared%2FPaatokset'
+  ids:
+    guid:
+      type: string
+      max_length: 1024
+process:
+  source_path: source_path
+  filename: filename
+  guid: guid
+  uri_file:
+    -
+      plugin: concat
+      delimiter: /
+      source:
+        - constants/uri_file
+        - filename
+    -
+      plugin: urlencode
+  uri:
+    plugin: file_copy
+    source:
+      - '@source_path'
+      - '@uri_file'
+    file_exists: 'use existing'
+    move: FALSE
+destination:
+  plugin: 'entity:file'

--- a/public/modules/custom/paatokset_news_importer/paatokset_news_importer.info.yml
+++ b/public/modules/custom/paatokset_news_importer/paatokset_news_importer.info.yml
@@ -1,0 +1,9 @@
+name: Paatokset news importer
+type: module
+package: custom
+core: 8.x
+core_version_requirement: ^8 || ^9
+dependecies:
+  - helfi_api_base
+  - migrate
+  - node

--- a/public/modules/custom/paatokset_news_importer/paatokset_news_importer.module
+++ b/public/modules/custom/paatokset_news_importer/paatokset_news_importer.module
@@ -1,0 +1,19 @@
+<?php
+
+
+/**
+ * Implements hook_theme().
+ */
+function paatokset_news_importer_theme($exitsting, $type, $theme, $path) {
+  return [
+    'node__imported_article' => [
+      'base hook' => 'node'
+    ],
+    'page__imported_article' => [
+      'base hook' => 'page'
+    ],
+    'views_view_unformatted__imported_articles' => [
+      'base hook' => 'view'
+    ]
+  ];
+}

--- a/public/modules/custom/paatokset_news_importer/src/Plugin/migrate/source/ImportedArticle.php
+++ b/public/modules/custom/paatokset_news_importer/src/Plugin/migrate/source/ImportedArticle.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Drupal\paatokset_news_importer\Plugin\migrate\source;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+use Drupal\migrate\Row;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Source plugin for retrieving articles from RSS feed.
+ *
+ * @MigrateSource(
+ *  id = "imported_article"
+ * )
+ */
+class ImportedArticle extends SourcePluginBase implements ContainerFactoryPluginInterface {
+  /**
+   * The total count.
+   *
+   * @var int
+   */
+  protected int $count = 0;
+
+  /**
+   * The http client.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected ClientInterface $httpClient;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __toString() {
+    return 'ImportedArticle';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIds() {
+    return $this->configuration['ids'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function fields() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    if ($row->hasSourceProperty('description')) {
+      $description = $row->getSourceProperty('description');
+
+      $doc = new \DOMDocument();
+      $doc->loadHTML($description);
+      $images = $doc->getElementsByTagName('img');
+
+      if (count($images) > 0) {
+        $row->setSourceProperty('source_path', $images[0]->getAttribute('src'));
+        $path_parts = preg_replace('/\?.*/', '', pathinfo($images[0]->getAttribute('src')));
+        $row->setSourceProperty('filename', $path_parts['basename']);
+        $row->setSourceProperty('image_alt', utf8_decode($images[0]->getAttribute('alt')));
+        $row->setSourceProperty('image_title', utf8_decode($images[0]->getAttribute('title')));
+      }
+    }
+
+    return parent::prepareRow($row);
+  }
+
+  /**
+   * Sends a HTTP request and returns response data as array.
+   *
+   * @param string $url
+   *   The url.
+   *
+   * @return array
+   *   The XML returned by API service.
+   */
+  protected function getContent(string $url) : array {
+    try {
+      $content = (string) $this->httpClient->request('GET', $url)->getBody();
+
+      if (!is_null($content)) {
+        return $this->xmlToArray($content);
+      }
+
+      return $content;
+    }
+    catch (GuzzleException $e) {
+    }
+    return [];
+  }
+
+  /**
+   * Returns items from xml in an array.
+   *
+   * @param string $xml
+   *   XML string.
+   *
+   * @return array
+   *   Transformed XML in array form
+   */
+  private function xmlToArray($xml) {
+    $content = new \SimpleXMLElement($xml);
+    $result = [];
+
+    if (isset($content->channel->item)) {
+      foreach ($content->channel->item as $item) {
+        $transformedItem = [];
+
+        foreach ($item as $key => $value) {
+          if ($key === 'description') {
+            // If there is no image, there is extra '/>' in the description.
+            $transformedItem[$key] = preg_replace('/\/>/', '', strip_tags($value));
+          }
+          else {
+            $transformedItem[$key] = (string) $value;
+          }
+        }
+        $transformedItem['content'] = (string) $item->xpath('content:encoded')[0];
+        $result[] = $transformedItem;
+      }
+    }
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    MigrationInterface $migration = NULL
+  ) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition, $migration);
+    $instance->httpClient = $container->get('http_client');
+
+    if (!isset($configuration['url'])) {
+      throw new \InvalidArgumentException('The "url" configuration is missing.');
+    }
+
+    if (!isset($configuration['ids'])) {
+      throw new \InvalidArgumentException('The "ids" configuration is missing.');
+    }
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function initializeIterator() : \Iterator {
+    $content = $this->getContent($this->configuration['url']);
+
+    foreach ($content as $object) {
+      yield $object;
+    }
+  }
+
+}

--- a/public/modules/custom/paatokset_news_importer/templates/node--imported-article.html.twig
+++ b/public/modules/custom/paatokset_news_importer/templates/node--imported-article.html.twig
@@ -1,0 +1,119 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+
+{%
+  set classes = [
+  'node--type-article',
+  node.isPromoted() ? 'node--promoted',
+  node.isSticky() ? 'node--sticky',
+  not node.isPublished() ? 'node--unpublished',
+  view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+]
+%}
+
+<article{{ attributes.addClass(classes) }}>
+  {% embed "@hdbt/misc/container.twig" with {container_element: 'article-header'} %}
+    {% block container_content %}
+      {% if node.body.summary|render %}
+        <div class="article__lead">
+          {{ node.body.summary }}
+        </div>
+      {% endif %}
+
+      {{ drupal_block('hdbt_content_social_sharing_block') }}
+
+      {% if content.field_author|render %}
+        <div class="article__author">
+          {{ content.field_author }}
+        </div>
+      {% endif %}
+
+      {% set created_date = node.createdtime|format_date('medium') %}
+      {% if created_date|render %}
+        <div class="article__date">
+          {{ created_date }}
+        </div>
+      {% endif %}
+    {% endblock container_content %}
+  {% endembed %}
+
+  {% if content.body|render %}
+    <div class="text text--default">
+      <div class="container text__container">
+        <div class="text__text-content">
+          {{ content.body }}
+        </div>
+      </div>
+    <div>
+  {% endif %}
+</article>

--- a/public/modules/custom/paatokset_news_importer/templates/page--imported-article.html.twig
+++ b/public/modules/custom/paatokset_news_importer/templates/page--imported-article.html.twig
@@ -1,0 +1,84 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ */
+#}
+
+{% set page_classes = [
+    'page-type--article',
+    'wrapper',
+  ]
+%}
+
+<div{{ create_attribute({'class': page_classes} ) }}>
+  {% if page.header_top or page.header_bottom %}
+    <header role="banner">
+      {% if page.header_top %}
+        {{ page.header_top }}
+      {% endif %}
+
+      {% if page.header_bottom %}
+        {{ page.header_bottom }}
+      {% endif %}
+    </header>
+  {% endif %}
+
+  {% if page.messages %}
+    {{ page.messages }}
+  {% endif %}
+
+  {% if page.breadcrumb %}
+    {{ page.breadcrumb }}
+  {% endif %}
+
+  {% if page.tools %}
+    {{ page.tools }}
+  {% endif %}
+
+  <main role="main">
+    <a id="main-content" tabindex="-1"></a>
+
+    {% if page.before_content %}
+      {{ page.before_content }}
+    {% endif %}
+
+    <div class="layout-content">
+      {{ page.content }}
+    </div>{# /.layout-content #}
+
+    {% if page.sidebar_first %}
+      <aside class="layout-sidebar-first" role="complementary">
+        {{ page.sidebar_first }}
+      </aside>
+    {% endif %}
+
+    {% if page.sidebar_second %}
+      <aside class="layout-sidebar-second" role="complementary">
+        {{ page.sidebar_second }}
+      </aside>
+    {% endif %}
+
+    {% if page.after_content %}
+      {{ page.after_content }}
+    {% endif %}
+  </main>
+</div>
+
+{% if page.footer_top or page.footer_bottom %}
+  {% set footer_variant = '' %}
+  {% if page.footer_color %}
+    {% set footer_variant = 'footer--' ~ page.footer_color|clean_class %}
+  {% endif %}
+
+  <footer role="contentinfo" class="footer {{ footer_variant }}">
+    {% include '@hdbt/misc/koro.twig' with {koro: koro, flip: false } %}
+    {% if page.footer_top %}
+      {{ page.footer_top }}
+    {% endif %}
+
+    {% if page.footer_bottom %}
+      {{ page.footer_bottom }}
+    {% endif %}
+  </footer>
+{% endif %}

--- a/public/modules/custom/paatokset_news_importer/templates/views-view-unformatted--imported-articles.html.twig
+++ b/public/modules/custom/paatokset_news_importer/templates/views-view-unformatted--imported-articles.html.twig
@@ -1,0 +1,40 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a view of unformatted rows.
+ *
+ * Available variables:
+ * - title: The title of this group of rows. May be empty.
+ * - rows: A list of the view's row items.
+ *   - attributes: The row's HTML attributes.
+ *   - content: The row's content.
+ * - view: The view object.
+ * - default_row_class: A flag indicating whether default classes should be
+ *   used on rows.
+ *
+ * @see template_preprocess_views_view_unformatted()
+ *
+ * @ingroup themeable
+ */
+#}
+{% if title %}
+  <h3>{{ title }}</h3>
+{% endif %}
+{% for row in rows %}
+  {%
+    set row_classes = [
+      default_row_class ? 'views-row',
+    ]
+  %}
+
+  {% if loop.first %}
+    <div{{ row.attributes.addClass(row_classes, 'views-row__first') }}>
+      {{- row.content -}}
+    </div>
+  {% else %}
+    <div{{ row.attributes.addClass(row_classes) }}>
+      {{- row.content -}}
+    </div>
+  {% endif %}
+
+{% endfor %}

--- a/public/modules/custom/paatokset_news_importer/tests/src/Kernel/ImportedArticleMigrationTest.php
+++ b/public/modules/custom/paatokset_news_importer/tests/src/Kernel/ImportedArticleMigrationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\paatokset_news_importer\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\migrate\MigrateMessageInterface;
+use Drupal\node\Entity\Node;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+use Drupal\Tests\helfi_api_base\Traits\MigrationTestTrait;
+use Drupal\Tests\paatokset_news_importer\Traits\ImportedArticleTestTrait;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Tests Imported article source plugin.
+ */
+class ImportedArticleMigrationTest extends KernelTestBase implements MigrateMessageInterface {
+  use ApiTestTrait;
+  use ImportedArticleTestTrait;
+  use MigrationTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'migrate',
+    'field',
+    'text',
+    'image',
+    'file',
+    'user',
+    'node',
+    'language',
+    'content_translation',
+    'paatokset_news_importer',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig([
+      'system',
+      'migrate',
+      'field',
+      'file',
+      'image',
+      'text',
+      'node',
+      'user',
+      'language',
+      'content_translation',
+      'paatokset_news_importer',
+    ]);
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+
+    ConfigurableLanguage::createFromLangcode('fi')->save();
+  }
+
+  /**
+   * Tests paatokset_news migration.
+   *
+   * @dataProvider importedArticleData
+   */
+  public function testImportedArticleMigration(int $id, array $expected) : void {
+    $response = $this->createResponseXml(2);
+
+    $this->container->set('http_client', $this->createMockHttpClient([
+      new Response(200, [], $response),
+    ]));
+
+    $configuration = [
+      'urls' => 'http://localhost/rssfeed',
+    ];
+
+    $this->executeMigration('paatokset_news', ['source' => $configuration]);
+    $importedArticles = Node::loadMultiple();
+
+    $this->assertCount(2, $importedArticles);
+    $this->assertEquals(TRUE, $importedArticles[$id]->hasTranslation('fi'));
+    $resultNode = $importedArticles[$id]->getTranslation('fi');
+    $this->assertEquals($expected['title'], $resultNode->getTitle());
+    $this->assertEquals($expected['created'], $resultNode->getCreatedTime());
+    $this->assertEquals($expected['lead'], $resultNode->getTranslation('fi')->get('body')->summary);
+    $this->assertEquals($expected['content'], $resultNode->getTranslation('fi')->get('body')->value);
+  }
+
+  /**
+   * Dataprovider for the test.
+   *
+   * @return array
+   *   Excepted mock data
+   */
+  public function importedArticleData() : array {
+    return [
+      [
+        1,
+        [
+          'title' => 'Title for item 1.',
+          'created' => '1621456588',
+          'lead' => 'Description for item 1.',
+          'content' => 'Content for item 1.',
+        ],
+      ],
+      [
+        2,
+        [
+          'title' => 'Title for item 2.',
+          'created' => '1621456588',
+          'lead' => 'Description for item 2.',
+          'content' => 'Content for item 2.',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/public/modules/custom/paatokset_news_importer/tests/src/Kernel/Plugin/migrate/source/ImportedArticleTest.php
+++ b/public/modules/custom/paatokset_news_importer/tests/src/Kernel/Plugin/migrate/source/ImportedArticleTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\paatokset_news_importer\Kernel\Plugin\migrate\source;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
+use Drupal\migrate\Plugin\MigrateSourcePluginManager;
+use Drupal\paatokset_news_importer\Plugin\migrate\source\ImportedArticle;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\Tests\paatokset_news_importer\Traits\ImportedArticleTestTrait;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Tests ImportedArticle source plugin.
+ *
+ * @coversDefaultClass \Drupal\paatokset_news_importer\Plugin\migrate\source\ImportedArticle
+ * @group paatokset_news_importer
+ */
+class ImportedArticleTest extends KernelTestBase {
+  use ApiTestTrait;
+  use ImportedArticleTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'migrate',
+    'system',
+    'paatokset_news_importer',
+  ];
+
+  /**
+   * The migration plugin manager.
+   *
+   * @var null|\Drupal\migrate\Plugin\MigrationPluginManagerInterface
+   */
+  protected ?MigrationPluginManagerInterface $migrationPluginManager;
+
+  /**
+   * The source plugin manager.
+   *
+   * @var null|\Drupal\migrate\Plugin\MigrateSourcePluginManager
+   */
+  protected ?MigrateSourcePluginManager $sourcePluginManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig(['migrate', 'system']);
+
+    $this->sourcePluginManager = $this->container->get('plugin.manager.migrate.source');
+    $this->migrationPluginManager = $this->container->get('plugin.manager.migration');
+  }
+
+  /**
+   * Excpect failure without "url" congifuration.
+   */
+  public function testMissingUrl() : void {
+    $this->expectException(\InvalidArgumentException::class);
+    $migration = $this->createMock(MigrationInterface::class);
+
+    ImportedArticle::create($this->container, ['ids' => ['guid' => ['type' => 'string']]], 'imported_article', [], $migration);
+  }
+
+  /**
+   * Expect failulre without "id" configuration.
+   */
+  public function testMissingIds() : void {
+    $this->expectException(\InvalidArgumentException::class);
+    $migration = $this->createMock(MigrationInterface::class);
+
+    ImportedArticle::create($this->container, ['url' => 'http://localhost/rss'], 'imported_article', [], $migration);
+  }
+
+  /**
+   * Tests imported_article source plugin.
+   */
+  public function testSourcePlugin() : void {
+    $migration = $this->migrationPluginManager->createStubMigration([
+      'source' => [
+        'plugin' => 'imported_article',
+        'url' => 'http://localhost/rss',
+        'ids' => ['guid' => ['type' => 'string']],
+      ],
+      'process' => [],
+      'destination' => [
+        'plugin' => 'null',
+      ],
+    ]);
+
+    $configuration = [
+      'url' => 'http://localhost/rss',
+      'ids' => ['guid' => ['type' => 'string']],
+    ];
+
+    $this->container->set('http_client', $this->createMockHttpClient([
+      new Response(200, [], $this->createResponseXml(3)),
+      new Response(200, [], $this->createResponseXml(3)),
+    ]));
+
+    /** @var \Drupal\paatokset_news_importer\Plugin\migrate\source\ImportedArticle */
+    $source = $this->sourcePluginManager->createInstance('imported_article', $configuration, $migration);
+    $this->assertEquals((string) $source, 'ImportedArticle');
+
+    $source->rewind();
+    $this->assertEquals($source->current()->getSource()['guid'], '1');
+
+    $source->next();
+    $this->assertEquals($source->current()->getSource()['guid'], '2');
+  }
+
+}

--- a/public/modules/custom/paatokset_news_importer/tests/src/Traits/ImportedArticleTestTrait.php
+++ b/public/modules/custom/paatokset_news_importer/tests/src/Traits/ImportedArticleTestTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\paatokset_news_importer\Traits;
+
+/**
+ * Provides shared functionality for Imported artcile tests.
+ */
+trait ImportedArticleTestTrait {
+
+  /**
+   * Create mock XML responses.
+   *
+   * @param int $count
+   *   The number of response items.
+   *
+   * @return string
+   *   The generated XML String
+   */
+  private function createResponseXml($count) : string {
+    $contentSchema = "http://purl.org/rss/1.0/modules/content/";
+    $xml = new \SimpleXmlElement('<rss version="2.0" xmlns:content="' . $contentSchema . '"></rss>');
+    $channel = $xml->addChild('channel');
+
+    for ($i = 0; $i < $count; $i++) {
+      $child = $channel->addChild('item');
+      $child->addChild('title', 'Title for item ' . ($i + 1) . '.');
+      $child->addChild('guid', (string) ($i + 1));
+      $child->addChild('pubDate', '19 May 2021 23:36:28 +0300');
+      $child->addChild('content:encoded', 'Content for item ' . ($i + 1) . '.', $contentSchema);
+      $child->addChild('description', '<img src="image.com"/><br/>Description for item ' . ($i + 1) . '.');
+    }
+
+    return $xml->asXML();
+  }
+
+}


### PR DESCRIPTION
Add news feed integration module, changes:

- New custom module paatokset_news_importer
- Added new node type imported_article
- Custom module contains migrations
- Module contains view for imported_articles feed, will be styled later
- Contains template for imported articles, which is basically a copy+paste of article template

To test:

- `make drush-cr; make drush-cim`
- paatokset_news_importer should ne installed now
- run new custom migrations: `PARTIAL_MIGRATE=1 drush migrate:import paatokset_news_images; PARTIAL_MIGRATE=1 drush migrate:import paatokset_news` - env variable set here prevents helfi_api_base event subscriber from failing the migration, but does not affect this one
- Content of type imported_article should be imported from the RSS feed