### PR TITLE
PP-197: Added first/last name fields to policymakers

### DIFF
--- a/conf/cmi/core.entity_form_display.node.policymaker.default.yml
+++ b/conf/cmi/core.entity_form_display.node.policymaker.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.policymaker.field_first_name
+    - field.field.node.policymaker.field_last_name
     - field.field.node.policymaker.field_organization_type
     - field.field.node.policymaker.field_policymaker_contact_link
     - field.field.node.policymaker.field_policymaker_id
@@ -30,6 +32,22 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_first_name:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_last_name:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_policymaker_contact_link:
     weight: 3
     settings:

--- a/conf/cmi/core.entity_view_display.node.policymaker.default.yml
+++ b/conf/cmi/core.entity_view_display.node.policymaker.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.policymaker.field_first_name
+    - field.field.node.policymaker.field_last_name
     - field.field.node.policymaker.field_organization_type
     - field.field.node.policymaker.field_policymaker_contact_link
     - field.field.node.policymaker.field_policymaker_id
@@ -21,6 +23,22 @@ targetEntityType: node
 bundle: policymaker
 mode: default
 content:
+  field_first_name:
+    weight: 6
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_last_name:
+    weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_policymaker_contact_link:
     weight: 0
     label: hidden

--- a/conf/cmi/field.field.node.policymaker.field_first_name.yml
+++ b/conf/cmi/field.field.node.policymaker.field_first_name.yml
@@ -1,0 +1,19 @@
+uuid: 1c7f0e2d-a6c3-461a-abad-2f33775bdd87
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_first_name
+    - node.type.policymaker
+id: node.policymaker.field_first_name
+field_name: field_first_name
+entity_type: node
+bundle: policymaker
+label: 'First name'
+description: 'First name field for single-person policymakers.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.policymaker.field_last_name.yml
+++ b/conf/cmi/field.field.node.policymaker.field_last_name.yml
@@ -1,0 +1,19 @@
+uuid: 53ddd92f-7873-4bc7-a722-0dc2e34f9577
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_last_name
+    - node.type.policymaker
+id: node.policymaker.field_last_name
+field_name: field_last_name
+entity_type: node
+bundle: policymaker
+label: 'Last name'
+description: 'Last name field for single-person policymakers.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_first_name.yml
+++ b/conf/cmi/field.storage.node.field_first_name.yml
@@ -1,0 +1,21 @@
+uuid: f25c1c28-bd0d-42dd-a7dc-35a22d1e48c9
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_first_name
+field_name: field_first_name
+entity_type: node
+type: string
+settings:
+  max_length: 75
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_last_name.yml
+++ b/conf/cmi/field.storage.node.field_last_name.yml
@@ -1,0 +1,21 @@
+uuid: 25a968f2-55f4-4f16-9155-2066ae75c6fc
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_last_name
+field_name: field_last_name
+entity_type: node
+type: string
+settings:
+  max_length: 75
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Added first/last name fields to policymaker node type.

To test:

- Run `make drush-cim`
- Check `https://helsinki-paatokset.docker.so/fi/admin/structure/types/manage/policymaker/fields` to see fields.