### PR TITLE
PP-191: OpenID connect authentication flow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ vendor
 # Ignore files that are only for the current local environment
 public/sites/default/local.settings.php
 public/sites/default/local.services.yml
+.env.local
 
 # Ignore the folder created by PhpStorm
 .idea/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       #XDEBUG_ENABLE: "true"
       SIMPLETEST_BASE_URL: "http://app:8080"
       SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
+    env_file:
+      - .env
+      - .env.local
     networks:
       - internal
       - stonehenge-network

--- a/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.info.yml
+++ b/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.info.yml
@@ -1,0 +1,5 @@
+name: Päätökset Ahjo OpenID connector
+type: module
+package: Custom
+core: 8.x
+core_version_requirement: ^8 || ^9

--- a/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.links.menu.yml
+++ b/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.links.menu.yml
@@ -1,0 +1,9 @@
+paatokset_ahjo_openid.index:
+  title: 'AHJO Open ID'
+  parent: system.admin_config
+  route_name: 'paatokset_ahjo_openid.index'
+
+paatokset_ahjo_openid.settings:
+  title: 'AHJO Open ID settings'
+  parent: paatokset_ahjo_openid.index
+  route_name: 'paatokset_ahjo_openid.settings'

--- a/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.routing.yml
+++ b/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.routing.yml
@@ -1,0 +1,54 @@
+paatokset_ahjo_openid.index:
+  path: '/admin/ahjo-open-id'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo_openid\Controller\AhjoOpenIdController::index'
+  requirements:
+    _permission: 'administer content'
+  options:
+    no_cache: 'TRUE'
+
+paatokset_ahjo_openid.settings:
+  path: '/admin/ahjo-open-id/settings'
+  defaults:
+    _form: \Drupal\paatokset_ahjo_openid\Form\SettingsForm
+    _title: 'AHJO API Open ID settings'
+  requirements:
+    _permission: 'administer site configuration'
+
+paatokset_ahjo_openid.callback:
+  path: '/ahjo-api/login'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo_openid\Controller\AhjoOpenIdController::callback'
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: 'TRUE'
+    _admin_theme: 'TRUE'
+
+paatokset_ahjo_openid.auth:
+  path: '/admin/ahjo-open-id/auth/{code}'
+  defaults:
+    code: NULL
+    _controller: '\Drupal\paatokset_ahjo_openid\Controller\AhjoOpenIdController::auth'
+  requirements:
+    _permission: 'administer content'
+  options:
+    no_cache: 'TRUE'
+
+paatokset_ahjo_openid.refresh:
+  path: '/admin/ahjo-open-id/refresh-token'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo_openid\Controller\AhjoOpenIdController::refresh'
+  requirements:
+    _permission: 'administer content'
+  options:
+    no_cache: 'TRUE'
+
+paatokset_ahjo_openid.debug:
+  path: '/admin/ahjo-open-id/debug'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo_openid\Controller\AhjoOpenIdController::debug'
+  requirements:
+    _permission: 'administer content'
+  options:
+    no_cache: 'TRUE'

--- a/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.services.yml
+++ b/public/modules/custom/paatokset_ahjo_openid/paatokset_ahjo_openid.services.yml
@@ -1,0 +1,4 @@
+services:
+  paatokset_ahjo_openid:
+    class: Drupal\paatokset_ahjo_openid\AhjoOpenId
+    arguments: ['@config.factory', '@http_client', '@state', '@messenger']

--- a/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
+++ b/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
@@ -49,6 +49,8 @@ class AhjoOpenId implements ContainerInjectionInterface {
   /**
    * Constructs AhjoOpenId Controller.
    *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
    * @param \GuzzleHttp\ClientInterface $http_client
    *   HTTP Client.
    * @param \Drupal\Core\State\StateInterface $state
@@ -103,7 +105,7 @@ class AhjoOpenId implements ContainerInjectionInterface {
   public function getAuthAndRefreshTokens(string $code = NULL) {
     $request = $this->httpClient->request(
       'POST',
-      $this->authUrl,
+      $this->tokenUrl,
       [
         'http_errors' => FALSE,
         'headers' => $this->getHeaders(),
@@ -136,7 +138,7 @@ class AhjoOpenId implements ContainerInjectionInterface {
     $refresh_token = $this->state->get('ahjo_api_refresh_token');
     $request = $this->httpClient->request(
       'POST',
-      $this->authUrl,
+      $this->tokenUrl,
       [
         'http_errors' => FALSE,
         'headers' => $this->getHeaders(),
@@ -206,10 +208,15 @@ class AhjoOpenId implements ContainerInjectionInterface {
    * Get headers for HTTP requests.
    *
    * @return array|null
+   *   Headers for the request or NULL if config is missing.
    */
   private function getHeaders(): ?array {
     $client_id = $this->clientId;
     $client_secret = getenv('PAATOKSET_OPENID_SECRET');
+
+    if (empty($client_id) || empty($client_secret)) {
+      return NULL;
+    }
     return ['Authorization' => 'Basic ' . base64_encode($client_id . ':' . $client_secret)];
   }
 

--- a/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
+++ b/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_openid;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Handler for AHJO API Open ID connector.
+ *
+ * @package Drupal\paatokset_ahjo_openid
+ */
+class AhjoOpenId implements ContainerInjectionInterface {
+
+  /**
+   * State API.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  private $state;
+
+  /**
+   * The config for the integration.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * HTTP Client.
+   *
+   * @var GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * Messenger interface.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs AhjoOpenId Controller.
+   *
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   HTTP Client.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   State API.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, ClientInterface $http_client, StateInterface $state, MessengerInterface $messenger) {
+    $this->httpClient = $http_client;
+    $this->state = $state;
+    $this->messenger = $messenger;
+    $this->config = $config_factory->get('paatokset_ahjo_openid.settings');
+
+    $this->authUrl = $this->config->get('auth_url');
+    $this->tokenUrl = $this->config->get('token_url');
+    $this->callbackUrl = $this->config->get('callback_url');
+    $this->clientId = $this->config->get('client_id');
+    $this->openIdScope = $this->config->get('scope');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('http_client'),
+      $container->get('state'),
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * Get authentication URL.
+   *
+   * @return string|null
+   *   Auth URL.
+   */
+  public function getAuthUrl(): ?string {
+    if (empty($this->authUrl) || empty($this->callbackUrl) || empty($this->clientId) ||empty($this->openIdScope)) {
+      return NULL;
+    }
+    return $this->authUrl . '?client_id=' . $this->clientId . '&scope=' . $this->openIdScope . '&response_type=code&redirect_uri=' . $this->callbackUrl;
+  }
+
+  /**
+   * Get Auth and refresh tokens.
+   */
+  public function getAuthAndRefreshTokens(string $code = NULL) {
+    $request = $this->httpClient->request(
+      'POST',
+      $this->authUrl,
+      [
+        'http_errors' => FALSE,
+        'headers' => $this->getHeaders(),
+        'form_params' => [
+          'client_id' => $this->clientId,
+          'grant_type' => 'authorization_code',
+          'code' => $code,
+          'redirect_uri' => $this->callbackUrl,
+        ],
+      ]
+    );
+
+    $data = json_decode((string) $request->getBody());
+
+    if (isset($data->access_token) && isset($data->refresh_token)) {
+      $this->setAuthToken($data->access_token, $data->expires_in);
+      $this->state->set('ahjo_api_refresh_token', $data->refresh_token);
+    }
+
+    return $data;
+  }
+
+  /**
+   * Refresh AUTH token.
+   *
+   * @return string
+   *   Auth token.
+   */
+  public function refreshAuthToken(): ?string {
+    $refresh_token = $this->state->get('ahjo_api_refresh_token');
+    $request = $this->httpClient->request(
+      'POST',
+      $this->authUrl,
+      [
+        'http_errors' => FALSE,
+        'headers' => $this->getHeaders(),
+        'form_params' => [
+          'client_id' => $this->clientId,
+          'grant_type' => 'refresh_token',
+          'refresh_token' => $refresh_token,
+        ],
+      ]
+    );
+
+    $data = json_decode((string) $request->getBody());
+
+    if (!empty($data->access_token) && !empty($data->refresh_token)) {
+      $this->setAuthToken($data->access_token, $data->expires_in);
+      $this->state->set('ahjo_api_refresh_token', $data->refresh_token);
+      return $data->access_token;
+    }
+    return NULL;
+  }
+
+  /**
+   * Check if token is still valid.
+   *
+   * @return bool
+   *   Auth token.
+   */
+  public function checkAuthToken(): bool {
+    $auth_expiration = (int) $this->state->get('ahjo-api-auth-expiration');
+    if (time() > $auth_expiration) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Gets the auth token state variable.
+   *
+   * @return string
+   *   Auth token.
+   */
+  public function getAuthToken(): ?string {
+    return $this->state->get('ahjo-api-auth-key');
+  }
+
+  /**
+   * Get token expiry data and time.
+   */
+  public function getAuthTokenExpiration(): int {
+    return (int) $this->state->get('ahjo-api-auth-expiration');
+  }
+
+  /**
+   * Sets the auth token state variable.
+   *
+   * @param string $token
+   *   Auth token.
+   * @param int $expiration
+   *   Token lifetime.
+   */
+  private function setAuthToken(string $token, int $expiration): void {
+    $this->state->set('ahjo-api-auth-key', $token);
+    $this->state->set('ahjo-api-auth-expiration', time() + $expiration);
+  }
+
+  /**
+   * Get headers for HTTP requests.
+   *
+   * @return array|null
+   */
+  private function getHeaders(): ?array {
+    $client_id = $this->clientId;
+    $client_secret = getenv('PAATOKSET_OPENID_SECRET');
+    return ['Authorization' => 'Basic ' . base64_encode($client_id . ':' . $client_secret)];
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_openid/src/Controller/AhjoOpenIdController.php
+++ b/public/modules/custom/paatokset_ahjo_openid/src/Controller/AhjoOpenIdController.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_openid\Controller;
+
+use Drupal\Core\Url;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\paatokset_ahjo_openid\AhjoOpenId;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * AHJO Open ID page controller.
+ *
+ * @package Drupal\paatokset_ahjo_openid\Controller
+ */
+class AhjoOpenIdController extends ControllerBase {
+
+  /**
+   * Open ID Connector service.
+   *
+   * @var \Drupal\paatokset_ahjo_openid\AhjoOpenId
+   */
+  protected $ahjoOpenId;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(AhjoOpenId $ahjo_open_id) {
+    $this->ahjoOpenId = $ahjo_open_id;
+  }
+
+  /**
+   * Create and inject.
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('paatokset_ahjo_openid')
+    );
+  }
+
+  /**
+   * Debug API.
+   */
+  public function index() {
+    return [
+      'heading' => [
+        '#markup' => '<h1>AHJO Open ID connector</h1>',
+      ],
+      'div_1' => $this->getDivider(),
+      'auth_flow' => $this->getAuthFlowMarkup(),
+      'div_2' => $this->getDivider(),
+      'token_info' => $this->getTokenInfo(),
+    ];
+  }
+
+  /**
+   * Get auth flow link.
+   *
+   * @return array
+   *   Markup array.
+   */
+  private function getAuthFlowMarkup(): array {
+    $auth_url = $this->ahjoOpenId->getAuthUrl();
+
+    if ($auth_url) {
+      $link_markup = '<p>To start authentication flow, go to <a href="' . $auth_url . '">' . $auth_url . '</a></p>';
+    }
+    else {
+      $link_markup = '<p>Configuration needs to be added before authentication.</p>';
+    }
+
+
+    return [
+      'title' => ['#markup' => '<h2>Authentication flow</h2>'],
+      'link' => [
+        '#markup' => $link_markup,
+      ],
+    ];
+  }
+
+  /**
+   * Get token info.
+   *
+   * @return array
+   *   Markup array.
+   */
+  private function getTokenInfo(): array {
+    $refresh_url = Url::fromRoute('paatokset_ahjo_openid.refresh', [], ['absolute' => TRUE])->toString();
+    if ($this->ahjoOpenId->checkAuthToken()) {
+      $token_expiration = $this->ahjoOpenId->getAuthTokenExpiration();
+      $token_status = '<p>Token is still valid until: ' . date(DATE_RFC2822, $token_expiration) . '</p>';
+    }
+    else {
+      $token_status = '<p>Token has expired or has not been set.</p>';
+    }
+    return [
+      'title' => ['#markup' => '<h2>Token info</h2>'],
+      'status' => ['#markup' => $token_status],
+      'link' => [
+        '#markup' => '<p><a href="' . $refresh_url . '">Refresh token.</a></p>',
+      ],
+    ];
+  }
+
+  /**
+   * Get section divider markup.
+   *
+   * @return array
+   *   Markup array.
+   */
+  private function getDivider() {
+    return [
+      '#markup' => '<hr />',
+    ];
+  }
+
+  /**
+   * Authentication flow.
+   */
+  public function callback(Request $request) {
+    $code = $request->query->get('code');
+    if (!empty($code)) {
+      $authentication_url = Url::fromRoute('paatokset_ahjo_openid.auth', ['code' => $code], ['absolute' => TRUE])->toString();
+      print 'Continue to <a href="' . $authentication_url . '">' . $authentication_url . '</a>';
+    }
+    print '<br />';
+    die('...');
+  }
+
+  /**
+   * Get access and auth tokens.
+   */
+  public function auth($code = NULL) {
+    $code = (string) $code;
+    $data = $this->ahjoOpenId->getAuthAndRefreshTokens($code);
+
+    if (isset($data->access_token) && isset($data->refresh_token)) {
+      print 'Token successfully stored.<br /><br />';
+      print 'ACCESS:<br />';
+      print (string) $data->access_token;
+      print '<br />';
+      print 'EXPIRES IN:<br />';
+      print (string) $data->expires_in;
+      print '<br />';
+      print 'REFRESH:<br />';
+      print (string) $data->refresh_token;
+      print '<br />';
+    }
+    else {
+      print 'Unable to authenticate.';
+      print '<br /><br />';
+    }
+    $index_url = Url::fromRoute('paatokset_ahjo_openid.index', [], ['absolute' => TRUE])->toString();
+
+    print '<br /><br />';
+    print '<a href="' . $index_url . '">Go back.</a>';
+    die;
+  }
+
+  /**
+   * Refresh Access token.
+   */
+  public function refresh() {
+    $token = $this->ahjoOpenId->refreshAuthToken();
+    if (!empty($token)) {
+      print 'Access token has been refreshed and stored.<br /><br />';
+      print (string) $token;
+      print '<br />';
+    }
+    else {
+      print 'Could not refresh access token.<br /><br />';
+    }
+
+    $index_url = Url::fromRoute('paatokset_ahjo_openid.index', [], ['absolute' => TRUE])->toString();
+
+    print '<br /><br />';
+    print '<a href="' . $index_url . '">Go back.</a>';
+    die();
+  }
+
+  /**
+   * Misc debug functionality.
+   */
+  public function debug() {
+    $this->ahjoOpenId->introSpectToken();
+    die('...');
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_openid/src/Form/SettingsForm.php
+++ b/public/modules/custom/paatokset_ahjo_openid/src/Form/SettingsForm.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\paatokset_ahjo_openid\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class SettingsForm.
+ *
+ * @package Drupal\paatokset_ahjo_openid\Form
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'paatokset_ahjo_openid_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditableConfigNames() {
+    return [
+      'paatokset_ahjo_openid.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('paatokset_ahjo_openid.settings');
+
+    $form['auth_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('URL for authorization flow'),
+      '#default_value' => $config->get('auth_url'),
+    ];
+
+    $form['token_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('URL for access and refresh tokens'),
+      '#default_value' => $config->get('token_url'),
+    ];
+
+    $form['callback_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Internal callback URL.'),
+      '#default_value' => $config->get('callback_url'),
+    ];
+
+    $form['client_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Client ID'),
+      '#default_value' => $config->get('client_id'),
+    ];
+
+    $form['scope'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Scope for authorization request'),
+      '#default_value' => $config->get('scope'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('paatokset_ahjo_openid.settings');
+
+    $settings = [
+      'auth_url',
+      'token_url',
+      'callback_url',
+      'client_id',
+      'scope',
+    ];
+
+    foreach ($settings as $setting) {
+      $config->set($setting, $form_state->getValue($setting));
+    }
+
+    $config->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_openid/src/Form/SettingsForm.php
+++ b/public/modules/custom/paatokset_ahjo_openid/src/Form/SettingsForm.php
@@ -6,7 +6,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Class SettingsForm.
+ * Settings form for the AHJO API Open ID connector.
  *
  * @package Drupal\paatokset_ahjo_openid\Form
  */


### PR DESCRIPTION
This requires VPN and IT account access, so testing will be limited to some surface areas and checking that the code makes sense.

**To test:**
* Checkout branch
* Create a new file in the project root: `.env.local`
* Add this content in the file: `PAATOKSET_OPENID_SECRET=insert_client_secret_here` (not the real secret, but this can't be tested anyway without VPN access)
* Run `make up`
* Run `make shell`
* Inside the container, run `printenv`. Make sure the content you added in the env.local file is there 
* Inside the container, run `drush en paatokset_ahjo_openid`
* Check that the status page works:  https://helsinki-paatokset.docker.so/fi/admin/ahjo-open-id
* Check that the config page works: https://helsinki-paatokset.docker.so/fi/admin/ahjo-open-id/settings
* Read code changes. Is there anything that would require more documentation?