### PR TITLE
PP-215: Add minutes of discussion to policymaker pages + bloc…

### DIFF
--- a/conf/cmi/block.block.paatoksetminutesofdiscussionblock.yml
+++ b/conf/cmi/block.block.paatoksetminutesofdiscussionblock.yml
@@ -1,0 +1,25 @@
+uuid: 5d92856e-bdee-447c-b0a2-9bf0b6d0aa78
+langcode: fi
+status: true
+dependencies:
+  module:
+    - paatokset_submenus
+    - system
+  theme:
+    - helfi_paatokset
+id: paatoksetminutesofdiscussionblock
+theme: helfi_paatokset
+region: after_content
+weight: 0
+provider: null
+plugin: paatokset_minutes_of_discussion
+settings:
+  id: paatokset_minutes_of_discussion
+  label: 'Paatokset minutes of discussion block'
+  provider: paatokset_submenus
+  label_display: visible
+visibility:
+  request_path:
+    id: request_path
+    pages: '/paattajat/*/keskustelupöytäkirjat'
+    negate: false

--- a/conf/cmi/block.block.views_block__declarations_of_affiliation_block_1.yml
+++ b/conf/cmi/block.block.views_block__declarations_of_affiliation_block_1.yml
@@ -1,0 +1,29 @@
+uuid: 9828e016-108d-46a5-b240-0ab436295b81
+langcode: fi
+status: true
+dependencies:
+  config:
+    - views.view.declarations_of_affiliation
+  module:
+    - system
+    - views
+  theme:
+    - helfi_paatokset
+id: views_block__declarations_of_affiliation_block_1
+theme: helfi_paatokset
+region: after_content
+weight: 0
+provider: null
+plugin: 'views_block:declarations_of_affiliation-block_1'
+settings:
+  id: 'views_block:declarations_of_affiliation-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sidonnaisuusilmoitukset
+    negate: false

--- a/conf/cmi/views.view.declarations_of_affiliation.yml
+++ b/conf/cmi/views.view.declarations_of_affiliation.yml
@@ -323,6 +323,71 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: media
+          entity_field: name
+          plugin_id: field
       filters:
         status:
           value: '1'
@@ -414,6 +479,25 @@ display:
           required: false
           plugin_id: standard
       arguments: {  }
+      display_extenders: {  }
+      group_by: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.media.field_document'
+        - 'config:field.storage.media.field_first_name'
+        - 'config:field.storage.media.field_interest_statement_categor'
+        - 'config:field.storage.media.field_lastname'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Lohko
+    position: 2
+    display_options:
       display_extenders: {  }
     cache_metadata:
       max-age: -1

--- a/public/modules/custom/paatokset_ahjo/paatokset_ahjo.routing.yml
+++ b/public/modules/custom/paatokset_ahjo/paatokset_ahjo.routing.yml
@@ -26,3 +26,11 @@ policymaker.decisions.fi:
     _title_callback: '\Drupal\paatokset_ahjo\Controller\PolicymakerController::getDecisionsTitle'
   requirements:
     _access: 'TRUE'
+
+policymaker.discussion_minutes.fi:
+  path: 'paattajat/{organization}/keskustelupöytäkirjat'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo\Controller\PolicymakerController::discussionMinutes'
+    _title_callback: '\Drupal\paatokset_ahjo\Controller\PolicymakerController::getDiscussionMinutesTitle'
+  requirements:
+    _access: 'TRUE'

--- a/public/modules/custom/paatokset_ahjo/src/Controller/PolicymakerController.php
+++ b/public/modules/custom/paatokset_ahjo/src/Controller/PolicymakerController.php
@@ -36,7 +36,6 @@ class PolicymakerController extends ControllerBase {
    * Policymaker decisions route.
    */
   public function decisions($organization) {
-    // @todo implement decisions page
     $build = ['#title' => t('Decisions: @title', ['@title' => $this->policymakerService->getPolicymaker()->get('title')->value])];
     return $build;
   }
@@ -46,6 +45,29 @@ class PolicymakerController extends ControllerBase {
    */
   public static function getDecisionsTitle() {
     return t('Decisions');
+  }
+
+  /**
+   * Policymaker dicussion minutes route.
+   */
+  public function discussionMinutes() {
+    $build = ['#title' => t('Discussion minutes: @title', ['@title' => $this->policymakerService->getPolicymaker()->get('title')->value])];
+
+    $minutes = $this->policymakerService->getMinutesOfDiscussion(NULL, TRUE);
+
+    if (!empty($minutes)) {
+      $build['years'] = array_keys($minutes);
+      $build['list'] = $minutes;
+    }
+
+    return $build;
+  }
+
+  /**
+   * Return title as translatable string.
+   */
+  public static function getDiscussionMinutesTitle() {
+    return t('Discussion minutes');
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo/src/Enum/PolicymakerRoutes.php
+++ b/public/modules/custom/paatokset_ahjo/src/Enum/PolicymakerRoutes.php
@@ -7,11 +7,12 @@ namespace Drupal\paatokset_ahjo\Enum;
  */
 class PolicymakerRoutes {
   const ORGANIZATION = [
-    'Documents' => 'policymaker.documents',
+    'documents' => 'policymaker.documents',
+    'discussion_minutes' => 'policymaker.discussion_minutes',
   ];
 
   const TRUSTEE = [
-    'Decisions' => 'policymaker.decisions',
+    'decisions' => 'policymaker.decisions',
   ];
 
   /**

--- a/public/modules/custom/paatokset_submenus/paatokset_submenus.module
+++ b/public/modules/custom/paatokset_submenus/paatokset_submenus.module
@@ -33,7 +33,8 @@ function paatokset_submenus_theme($existing, $type, $theme, $path) {
 function paatokset_submenus_preprocess_block(&$variables) {
   $plugins = [
     'agendas_submenu',
-    'agendas_submenu_documents'
+    'agendas_submenu_documents',
+    'paatokset_minutes_of_discussion'
   ];
 
   if (in_array($variables['plugin_id'], $plugins)) {
@@ -45,7 +46,7 @@ function paatokset_submenus_preprocess_block(&$variables) {
       $variables['type'] = 'decisions';
     }
 
-    if($variables['plugin_id'] === 'agendas_submenu_documents') {
+    if(in_array($variables['plugin_id'], ['agendas_submenu_documents', 'paatokset_minutes_of_discussion'])) {
       $variables['type'] = 'documents';
     }
   }
@@ -80,7 +81,7 @@ function paatokset_submenus_preprocess_block__policymaker_side_nav(&$variables) 
  * Implements hook_theme_suggestion_block_alter().
  */
 function paatokset_submenus_theme_suggestions_block_alter(&$suggestions, $variables) {
-  if(isset($variables['elements']['#plugin_id']) && $variables['elements']['#plugin_id'] === 'agendas_submenu_documents') {
+  if(isset($variables['elements']['#plugin_id']) && in_array($variables['elements']['#plugin_id'], ['agendas_submenu_documents', 'paatokset_minutes_of_discussion'])) {
     $suggestions[] = 'block__agendas_submenu';
   }
 }

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/MinutesOfDiscussionBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/MinutesOfDiscussionBlock.php
@@ -33,13 +33,12 @@ class MinutesOfDiscussionBlock extends BlockBase {
    * Build the attributes.
    */
   public function build() {
-    $data = $this->policymakerService->getMinutesOfDiscussion();
+    $minutes = $this->policymakerService->getMinutesOfDiscussion(NULL, TRUE);
 
     return [
       '#cache' => ['contexts' => ['url.path', 'url.query_args']],
-      '#title' => 'Viranhaltijapäätökset',
-      '#years' => $data['years'],
-      '#list' => $data['list'],
+      '#years' => array_keys($minutes),
+      '#list' => $minutes,
     ];
   }
 


### PR DESCRIPTION
Added list + entry to sidenav on for minutes of discussion media entities on policymaker pages
Added block display for declarations of affiliation view 

To test:

- Make sure you have the latest data from paatokset_policymakers -migration
- Add media of type `declaration_of_affiliation` and `minutes_of_discussion`
- View a policymaker page for the policymaker which's meeting you referenced in the newly added minutes of discussion media
- You should see `Discussion minutes` -link in the left side navigation. Following the link should take you to a page with list of referred media entities
- Add a basic page with url `/sidonnaisuusilmoitukset`. Declarations of affiliation list should be displayed there 