### PR TITLE
PP-222: Add new service + endpoint for Ahjo API meetings

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.routing.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.routing.yml
@@ -1,0 +1,6 @@
+ahjo_meeting_endpoint:
+  path: 'ahjo_api/meetings'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo_api\Controller\MeetingController::query'
+  requirements:
+    _access: 'TRUE'

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
@@ -1,0 +1,3 @@
+services:
+  Drupal\paatokset_ahjo_api\Service\MeetingService:
+    class: Drupal\paatokset_ahjo_api\Service\MeetingService

--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/MeetingController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/MeetingController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\paatokset_ahjo_api\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Controller for retrieving meeting data.
+ */
+class MeetingController extends ControllerBase {
+  /**
+   * Instance of MeetingService.
+   *
+   * @var \Drupal\paatokset_ahjo_api\Service\MeetingService
+   */
+  private $meetingService;
+
+  /**
+   * Class constuctor.
+   */
+  public function __construct() {
+    $this->meetingService = \Drupal::service('Drupal\paatokset_ahjo_api\Service\MeetingService');
+  }
+
+  /**
+   * Retrieves matching meeting data.
+   *
+   * See MeetingService class for parameter definition.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   Automatically injected Request object.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   Return response with queried data or errors.
+   */
+  public function query(Request $request) : Response {
+    $params = [];
+
+    $allowedParams = [
+      'from',
+      'to',
+      'agenda_published',
+      'minutes_published',
+      'policymaker',
+    ];
+
+    foreach ($allowedParams as $param) {
+      if ($request->query->get($param)) {
+        $params[$param] = $request->query->get($param);
+      }
+    }
+
+    try {
+      $meetings = $this->meetingService->query($params);
+    }
+    catch (\throwable $error) {
+      return new Response(
+        json_encode([
+          'errors' => $error->getMessage(),
+        ]),
+        Response::HTTP_BAD_REQUEST
+      );
+    }
+
+    return new Response(
+      json_encode([
+        'data' => $meetings,
+      ]),
+      Response::HTTP_OK,
+      ['content-type' => 'application/json']
+    );
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\paatokset_ahjo_api\Service;
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Service class for retrieving meeting-related data.
+ *
+ * @package Drupal\paatokset_ahjo_api\Serivces
+ */
+class MeetingService {
+  /**
+   * Machine name for meeting node type.
+   */
+  const NODE_TYPE = 'meeting';
+
+  /**
+   * Query Ahjo API meetings from database.
+   *
+   * @param array $params
+   *   Containing query parameters
+   *   $params = [
+   *     from  => (string) time string in format Y-m-d.
+   *     to    => (string) time string in format Y-m-d.
+   *     agenda_published => (bool).
+   *     minutes_published => (bool).
+   *     policymaker => (string) policymaker title.
+   *   ].
+   *
+   * @return array
+   *   of meetings.
+   */
+  public function query(array $params = []) : array {
+    $query = \Drupal::entityQuery('node')
+      ->condition('status', 1)
+      ->condition('type', self::NODE_TYPE);
+
+    if (isset($params['from'])) {
+      $this->validateTime($params['from'], 'from');
+      $query->condition('field_meeting_date', $params['from'], '>=');
+    }
+    if (isset($params['to'])) {
+      $this->validateTime($params['to'], 'to');
+      $query->condition('field_meeting_date', $params['to'], '<=');
+    }
+    if (isset($params['agenda_published'])) {
+      $query->condition('field_agenda_published', TRUE);
+    }
+    if (isset($params['minutes_published'])) {
+      $query->condition('field_minutes_published', TRUE);
+    }
+
+    // @todo Once policymakers are imported from Ahjo API, change this to use IDs
+    if (isset($params['policymaker'])) {
+      $query->condition('field_meeting_dm', $params['policymaker']);
+    }
+
+    $ids = $query->execute();
+
+    if (empty($ids)) {
+      return [];
+    }
+
+    $result = [];
+    foreach (Node::loadMultiple($ids) as $node) {
+      $date = date('Y-m-d', strtotime($node->get('field_meeting_date')->value));
+
+      $transformedResult = [
+        'title' => $node->get('title')->value,
+        'policymaker' => $node->get('field_meeting_dm')->value,
+        'start_time' => date('H:i', strtotime($node->get('field_meeting_date')->value)),
+        // @todo Once motions get imported from Ahjo API, replace this with actual data
+        'motions_list_link' => 'https://helsinki-paatokset.docker.so/',
+      ];
+
+      /*
+      @todo Once documents get are imported from Ahjo API, return actual data
+      For now, return dummy link to minutes if meeting is concluded.
+       */
+      if (strtotime('now') > strtotime($node->get('field_meeting_date')->value)) {
+        $transformedResult['minutes_link'] = 'https://helsinki-paatokset.docker.so/';
+      }
+
+      $result[$date][] = $transformedResult;
+    }
+
+    return $result;
+  }
+
+  /**
+   * Check if time is valid.
+   *
+   * @param string $time
+   *   String in time format Y-m-d.
+   * @param string $tag
+   *   Param key for identification.
+   *
+   * @throws \Exception
+   */
+  private function validateTime($time, $tag) {
+    if (!strtotime($time)) {
+      throw new \Exception("Parameter '$tag' cannot be converted to timestamp.");
+    }
+  }
+
+}


### PR DESCRIPTION
Add new service class for Ahjo API meetings + new route for querying them via HTTP requests.

Notes:
- Since minutes (pöytäkirjat) and motions lists (esitylista) are not imported from Ahjo API yet, we use dummy data for them.
- Since policymakers are imported from the old OpenAhjo API, cannot ID match them - we use title as identifier for now.

To test:
- Run `make drush-cr`
- Make sure you've run `drush mim ahjo_meetings` succesfully
- Test the meetings endpoint `ahjo_api/meetings`, examples:
  `https://helsinki-paatokset.docker.so/fi/ahjo_api/meetings` should return all meetings, keyed by date
  `https://helsinki-paatokset.docker.so/fi/ahjo_api/meetings?from=2020-01-01` should return all meetings after specified date
  `https://helsinki-paatokset.docker.so/fi/ahjo_api/meetings?policymaker=Kaupunginvaltuusto` should return all Kaupunginvaltuusto meetings
  Policymakers with whitespace in the name should work with url encoding such as  `https://helsinki-paatokset.docker.so/fi/ahjo_api/meetings?policymaker=Sosiaali-%20ja%20terveyslautakunnan%20jaosto`