### PR TITLE
PP-223: Cases integration

### DIFF
--- a/conf/cmi/core.entity_form_display.node.case.default.yml
+++ b/conf/cmi/core.entity_form_display.node.case.default.yml
@@ -1,0 +1,204 @@
+uuid: cfaaa8d5-59cd-4b37-9b7b-67c9bdf3658f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.case.field_acquired
+    - field.field.node.case.field_classification_code
+    - field.field.node.case.field_classification_title
+    - field.field.node.case.field_created
+    - field.field.node.case.field_deadline
+    - field.field.node.case.field_description
+    - field.field.node.case.field_diary_number
+    - field.field.node.case.field_diary_number_label
+    - field.field.node.case.field_personal_data
+    - field.field.node.case.field_public_reference
+    - field.field.node.case.field_publicity_class
+    - field.field.node.case.field_reference
+    - field.field.node.case.field_status
+    - node.type.case
+  module:
+    - datetime
+    - hdbt_admin_editorial
+    - path
+    - scheduler
+    - text
+id: node.case.default
+targetEntityType: node
+bundle: case
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_acquired:
+    weight: 125
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_classification_code:
+    weight: 127
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_classification_title:
+    weight: 128
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_created:
+    weight: 124
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_deadline:
+    weight: 126
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_description:
+    weight: 123
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_diary_number:
+    weight: 121
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_diary_number_label:
+    weight: 122
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_personal_data:
+    weight: 131
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_public_reference:
+    weight: 133
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_publicity_class:
+    weight: 129
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_reference:
+    weight: 132
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_status:
+    weight: 130
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/conf/cmi/core.entity_view_display.node.case.default.yml
+++ b/conf/cmi/core.entity_view_display.node.case.default.yml
@@ -1,0 +1,141 @@
+uuid: 3572959d-0e0a-4a50-a2b2-e345eecc0112
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.case.field_acquired
+    - field.field.node.case.field_classification_code
+    - field.field.node.case.field_classification_title
+    - field.field.node.case.field_created
+    - field.field.node.case.field_deadline
+    - field.field.node.case.field_description
+    - field.field.node.case.field_diary_number
+    - field.field.node.case.field_diary_number_label
+    - field.field.node.case.field_personal_data
+    - field.field.node.case.field_public_reference
+    - field.field.node.case.field_publicity_class
+    - field.field.node.case.field_reference
+    - field.field.node.case.field_status
+    - node.type.case
+  module:
+    - datetime
+    - text
+    - user
+id: node.case.default
+targetEntityType: node
+bundle: case
+mode: default
+content:
+  field_acquired:
+    weight: 105
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_classification_code:
+    weight: 107
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_classification_title:
+    weight: 108
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_created:
+    weight: 104
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_deadline:
+    weight: 106
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_description:
+    weight: 103
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_diary_number:
+    weight: 101
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_diary_number_label:
+    weight: 102
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_personal_data:
+    weight: 111
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_public_reference:
+    weight: 113
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_publicity_class:
+    weight: 109
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_reference:
+    weight: 112
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_status:
+    weight: 110
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/conf/cmi/core.entity_view_display.node.case.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.case.teaser.yml
@@ -1,0 +1,47 @@
+uuid: 4365de80-eb33-48c6-991b-245d12797134
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.case.field_acquired
+    - field.field.node.case.field_classification_code
+    - field.field.node.case.field_classification_title
+    - field.field.node.case.field_created
+    - field.field.node.case.field_deadline
+    - field.field.node.case.field_description
+    - field.field.node.case.field_diary_number
+    - field.field.node.case.field_diary_number_label
+    - field.field.node.case.field_personal_data
+    - field.field.node.case.field_public_reference
+    - field.field.node.case.field_publicity_class
+    - field.field.node.case.field_reference
+    - field.field.node.case.field_status
+    - node.type.case
+  module:
+    - user
+id: node.case.teaser
+targetEntityType: node
+bundle: case
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_acquired: true
+  field_classification_code: true
+  field_classification_title: true
+  field_created: true
+  field_deadline: true
+  field_description: true
+  field_diary_number: true
+  field_diary_number_label: true
+  field_personal_data: true
+  field_public_reference: true
+  field_publicity_class: true
+  field_reference: true
+  field_status: true
+  langcode: true

--- a/conf/cmi/field.field.node.case.field_acquired.yml
+++ b/conf/cmi/field.field.node.case.field_acquired.yml
@@ -1,0 +1,21 @@
+uuid: 4fe0f861-1d07-486d-a4e5-645c7a40e044
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_acquired
+    - node.type.case
+  module:
+    - datetime
+id: node.case.field_acquired
+field_name: field_acquired
+entity_type: node
+bundle: case
+label: Acquired
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.node.case.field_classification_code.yml
+++ b/conf/cmi/field.field.node.case.field_classification_code.yml
@@ -1,0 +1,19 @@
+uuid: 307a017f-d076-4871-9804-a8d640a3d2df
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_classification_code
+    - node.type.case
+id: node.case.field_classification_code
+field_name: field_classification_code
+entity_type: node
+bundle: case
+label: 'Classification code'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_classification_title.yml
+++ b/conf/cmi/field.field.node.case.field_classification_title.yml
@@ -1,0 +1,19 @@
+uuid: 822430d2-cbfd-4c1a-a1e9-9fadbcf648d7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_classification_title
+    - node.type.case
+id: node.case.field_classification_title
+field_name: field_classification_title
+entity_type: node
+bundle: case
+label: 'Classification title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_created.yml
+++ b/conf/cmi/field.field.node.case.field_created.yml
@@ -1,0 +1,21 @@
+uuid: e96069ca-21e9-4553-935e-e69324317394
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_created
+    - node.type.case
+  module:
+    - datetime
+id: node.case.field_created
+field_name: field_created
+entity_type: node
+bundle: case
+label: Created
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.node.case.field_deadline.yml
+++ b/conf/cmi/field.field.node.case.field_deadline.yml
@@ -1,0 +1,21 @@
+uuid: 5277f625-da5f-4161-a335-d54e8b19c24c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_deadline
+    - node.type.case
+  module:
+    - datetime
+id: node.case.field_deadline
+field_name: field_deadline
+entity_type: node
+bundle: case
+label: Deadline
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.node.case.field_description.yml
+++ b/conf/cmi/field.field.node.case.field_description.yml
@@ -1,0 +1,26 @@
+uuid: 9be2bf98-065d-40c3-a42a-6b48cfe6122a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_description
+    - node.type.case
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    full_html: '0'
+    plain_text: '0'
+id: node.case.field_description
+field_name: field_description
+entity_type: node
+bundle: case
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/conf/cmi/field.field.node.case.field_diary_number.yml
+++ b/conf/cmi/field.field.node.case.field_diary_number.yml
@@ -1,0 +1,19 @@
+uuid: 79514bdd-7c78-44ec-b0c3-4ad80e05dc52
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_diary_number
+    - node.type.case
+id: node.case.field_diary_number
+field_name: field_diary_number
+entity_type: node
+bundle: case
+label: 'Diary number'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_diary_number_label.yml
+++ b/conf/cmi/field.field.node.case.field_diary_number_label.yml
@@ -1,0 +1,19 @@
+uuid: 7cc95f2f-5010-4a95-b6d9-681b091f8274
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_diary_number_label
+    - node.type.case
+id: node.case.field_diary_number_label
+field_name: field_diary_number_label
+entity_type: node
+bundle: case
+label: 'Diary number label'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_personal_data.yml
+++ b/conf/cmi/field.field.node.case.field_personal_data.yml
@@ -1,0 +1,19 @@
+uuid: f1da4431-181d-4946-b68a-b3fe896993f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_personal_data
+    - node.type.case
+id: node.case.field_personal_data
+field_name: field_personal_data
+entity_type: node
+bundle: case
+label: 'Personal data'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_public_reference.yml
+++ b/conf/cmi/field.field.node.case.field_public_reference.yml
@@ -1,0 +1,19 @@
+uuid: 29cea8db-8ef4-4315-80e3-997c0bfffc94
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_public_reference
+    - node.type.case
+id: node.case.field_public_reference
+field_name: field_public_reference
+entity_type: node
+bundle: case
+label: 'Public reference'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_publicity_class.yml
+++ b/conf/cmi/field.field.node.case.field_publicity_class.yml
@@ -1,0 +1,19 @@
+uuid: db78053c-c22d-418b-b7d5-d1d2e30fc005
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publicity_class
+    - node.type.case
+id: node.case.field_publicity_class
+field_name: field_publicity_class
+entity_type: node
+bundle: case
+label: 'Publicity class'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_reference.yml
+++ b/conf/cmi/field.field.node.case.field_reference.yml
@@ -1,0 +1,19 @@
+uuid: e749fe06-0961-4354-9bff-26717e3600ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_reference
+    - node.type.case
+id: node.case.field_reference
+field_name: field_reference
+entity_type: node
+bundle: case
+label: Reference
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.case.field_status.yml
+++ b/conf/cmi/field.field.node.case.field_status.yml
@@ -1,0 +1,19 @@
+uuid: c0b4ebc4-7c02-4664-8603-476bc1c59718
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_status
+    - node.type.case
+id: node.case.field_status
+field_name: field_status
+entity_type: node
+bundle: case
+label: Status
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_acquired.yml
+++ b/conf/cmi/field.storage.node.field_acquired.yml
@@ -1,0 +1,20 @@
+uuid: 6c2ce13e-4a98-4d33-b027-773044eb4c4d
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_acquired
+field_name: field_acquired
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_classification_code.yml
+++ b/conf/cmi/field.storage.node.field_classification_code.yml
@@ -1,0 +1,21 @@
+uuid: 83d188a4-c713-4327-af23-ed82d6bfe477
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_classification_code
+field_name: field_classification_code
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_classification_title.yml
+++ b/conf/cmi/field.storage.node.field_classification_title.yml
@@ -1,0 +1,21 @@
+uuid: 5a869920-3cf5-4ba2-aac5-469f15897fe0
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_classification_title
+field_name: field_classification_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_created.yml
+++ b/conf/cmi/field.storage.node.field_created.yml
@@ -1,0 +1,20 @@
+uuid: bed1d2ba-347b-49f3-a115-412d7dd1aa1f
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_created
+field_name: field_created
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_deadline.yml
+++ b/conf/cmi/field.storage.node.field_deadline.yml
@@ -1,0 +1,20 @@
+uuid: fcf8ab36-5d06-48f8-ba67-72d3874ca8be
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_deadline
+field_name: field_deadline
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_description.yml
+++ b/conf/cmi/field.storage.node.field_description.yml
@@ -1,0 +1,19 @@
+uuid: a980ab23-be01-4ed0-b66b-8786537f8df9
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_description
+field_name: field_description
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_diary_number.yml
+++ b/conf/cmi/field.storage.node.field_diary_number.yml
@@ -1,0 +1,21 @@
+uuid: 2517017b-f33e-4b40-922a-ff6b807a588c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_diary_number
+field_name: field_diary_number
+entity_type: node
+type: string
+settings:
+  max_length: 25
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_diary_number_label.yml
+++ b/conf/cmi/field.storage.node.field_diary_number_label.yml
@@ -1,0 +1,21 @@
+uuid: 0033a945-294d-44fa-a186-9e3ee25f2842
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_diary_number_label
+field_name: field_diary_number_label
+entity_type: node
+type: string
+settings:
+  max_length: 30
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_personal_data.yml
+++ b/conf/cmi/field.storage.node.field_personal_data.yml
@@ -1,0 +1,21 @@
+uuid: 3939240e-edf4-45a7-a77d-bcaf0620c911
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_personal_data
+field_name: field_personal_data
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_public_reference.yml
+++ b/conf/cmi/field.storage.node.field_public_reference.yml
@@ -1,0 +1,21 @@
+uuid: 0eeefb5c-0bfd-4995-8143-e4d78ab09384
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_public_reference
+field_name: field_public_reference
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_publicity_class.yml
+++ b/conf/cmi/field.storage.node.field_publicity_class.yml
@@ -1,0 +1,21 @@
+uuid: 667fef34-01f7-4277-ab6b-2c8986d09b0f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_publicity_class
+field_name: field_publicity_class
+entity_type: node
+type: string
+settings:
+  max_length: 100
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_reference.yml
+++ b/conf/cmi/field.storage.node.field_reference.yml
@@ -1,0 +1,21 @@
+uuid: 163505bf-ac1d-4be5-b547-5a6c983c8b9d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_reference
+field_name: field_reference
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_status.yml
+++ b/conf/cmi/field.storage.node.field_status.yml
@@ -1,0 +1,21 @@
+uuid: b4e783b6-9c0f-4ed6-81bf-77d33d26aa92
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_status
+field_name: field_status
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.node.case.yml
+++ b/conf/cmi/language.content_settings.node.case.yml
@@ -1,0 +1,11 @@
+uuid: 056c3d55-8c8f-43ec-8ecc-1b8d8daac6af
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.case
+id: node.case
+target_entity_type_id: node
+target_bundle: case
+default_langcode: site_default
+language_alterable: false

--- a/conf/cmi/node.type.case.yml
+++ b/conf/cmi/node.type.case.yml
@@ -1,0 +1,32 @@
+uuid: 0e25dfff-3b19-4671-8138-4141ac65a276
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+name: Case
+type: case
+description: 'Single case, imported from Ahjo Api.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
@@ -1,0 +1,125 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - paatokset_ahjo_api
+      - paatokset_ahjo_openid
+id: ahjo_cases
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - ahjo_api
+migration_group: ahjo_api
+label: 'Ahjo API - Cases'
+source:
+  plugin: url
+  track_changes: true
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - 'public://cases.json'
+  item_selector: cases
+  fields:
+    -
+      name: title
+      label: Title
+      selector: Title
+    -
+      name: case_id
+      label: Case ID
+      selector: CaseID
+    -
+      name: case_id_label
+      label: Case ID Label
+      selector: CaseIDLabel
+    -
+      name: description
+      label: Description
+      selector: Description
+    -
+      name: created
+      label: Created
+      selector: Created
+    -
+      name: acquired
+      label: Acquired
+      selector: Acquired
+    -
+      name: deadline
+      label: Deadline
+      selector: DateCaseDeadline
+    -
+      name: classification_code
+      label: Classification Code
+      selector: ClassificationCode
+    -
+      name: classification_title
+      label: Classification Title
+      selector: ClassificationTitle
+    -
+      name: publicity_class
+      label: Publicity Class
+      selector: PublicityClass
+    -
+      name: status
+      label: Status
+      selector: Status
+    -
+      name: personal_data
+      label: Personal Data
+      selector: PersonalData
+    -
+      name: reference
+      label: Reference
+      selector: Reference
+    -
+      name: public_reference
+      label: Public Reference
+      selector: PublicReference
+  ids:
+    case_id:
+      type: string
+process:
+  type:
+    plugin: default_value
+    default_value: case
+  title:
+    plugin: default_value
+    source: title
+    default_value: 'NO TITLE'
+  field_diary_number: case_id
+  field_diary_number_label: case_id
+  field_description: description
+  field_created:
+    plugin: format_date
+    from_format: 'Y-m-d\TH:i:s.v'
+    to_format: 'Y-m-d\TH:i:s'
+    from_timezone: Europe/Helsinki
+    to_timezone: UTC
+    source: created
+  field_acquired:
+    plugin: format_date
+    from_format: 'Y-m-d\TH:i:s.v'
+    to_format: 'Y-m-d\TH:i:s'
+    from_timezone: Europe/Helsinki
+    to_timezone: UTC
+    source: acquired
+  field_deadline:
+    plugin: format_date
+    from_format: 'Y-m-d\TH:i:s.v'
+    to_format: 'Y-m-d\TH:i:s'
+    from_timezone: Europe/Helsinki
+    to_timezone: UTC
+    source: deadline
+  field_classification_code: classification_code
+  field_classification_title: classification_title
+  field_publicity_class: publicity_class
+  field_status: status
+  field_personal_data: personal_data
+  field_reference: reference
+  field_public_reference:  public_reference
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }
+

--- a/public/modules/custom/paatokset_ahjo_proxy/static/cases.json
+++ b/public/modules/custom/paatokset_ahjo_proxy/static/cases.json
@@ -1,0 +1,525 @@
+{
+  "cases": [
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011830?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011830",
+          "Title": "Aloituspaikat, yleisopetuksen 7. luokka, lukuvuosi 2022-2023",
+          "Created": "2021-10-20T09:07:07.170",
+          "Acquired": "2021-10-20T00:00:00.000",
+          "ClassificationCode": "12 00 01",
+          "ClassificationTitle": "Koulutuksen ja opetuksen suunnittelu",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011830"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011828?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011828",
+          "Title": "Aloituspaikat, yleisopetuksen 1. luokka, lukuvuosi 2022-2023",
+          "Created": "2021-10-20T09:04:53.810",
+          "Acquired": "2021-10-20T00:00:00.000",
+          "ClassificationCode": "12 00 01",
+          "ClassificationTitle": "Koulutuksen ja opetuksen suunnittelu",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011828"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011819?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011819",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 2, logistiikan tuntiopettaja, työavain KASKO-03-267-21",
+          "Created": "2021-10-20T09:01:34.260",
+          "Acquired": "2021-09-20T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011819"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011821?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011821",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 2, logistiikan tuntiopettaja, työavain KASKO-03-266-21",
+          "Created": "2021-10-20T09:01:33.323",
+          "Acquired": "2021-09-20T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011821"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011759?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011759",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 2, logistiikan tuntiopettaja, työavain KASKO-03-269-21",
+          "Created": "2021-10-19T11:15:24.527",
+          "Acquired": "2021-09-20T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011759"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011749?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011749",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 2, logistiikan määräaikainen tuntiopettaja, työavain KASKO-03-270-21 ",
+          "Created": "2021-10-19T09:27:24.843",
+          "Acquired": "2021-09-20T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011749"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011743?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011743",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, logistiikan tuntiopettaja, työavain KASKO-03-272-21",
+          "Created": "2021-10-19T09:17:55.473",
+          "Acquired": "2021-09-20T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011743"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011741?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011741",
+          "Title": "Hankinta, kuuntelumikseri, Stadin ammatti- ja aikuisopisto, kampus 3",
+          "Created": "2021-10-19T08:24:36.560",
+          "Acquired": "2021-10-19T00:00:00.000",
+          "ClassificationCode": "02 08 01 01",
+          "ClassificationTitle": "Hankinta ilman kilpailutusta",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011741"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011731?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011731",
+          "Title": "Hankinta, esitystekniikka, Etu-Töölön lukio, kasvatuksen ja koulutuksen toimiala",
+          "Created": "2021-10-18T15:11:44.577",
+          "Acquired": "2021-10-18T00:00:00.000",
+          "ClassificationCode": "02 08 01 00",
+          "ClassificationTitle": "Kilpailutus",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011731"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011679?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011679",
+          "Title": "Hankinta, palakone, Stadin ammatti- ja aikuisopisto, kampus 5",
+          "Created": "2021-10-18T09:12:54.947",
+          "Acquired": "2021-10-18T00:00:00.000",
+          "ClassificationCode": "02 08 01 00",
+          "ClassificationTitle": "Kilpailutus",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011679"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011713?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011713",
+          "Title": "Opetuksen järjestäminen, painotetun, kaksikielisen ja englanninkielisen opetuksen enimmäis- ja vähimmäisoppilasmäärät",
+          "Created": "2021-10-18T09:09:25.110",
+          "Acquired": "2021-10-18T00:00:00.000",
+          "ClassificationCode": "12 01 01",
+          "ClassificationTitle": "Oppilaan opetuksen järjestäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011713"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011711?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011711",
+          "Title": "Opetuksen järjestäminen, painotettu kaksikielinen ja englanninkielinen opetuksen opintopolku",
+          "Created": "2021-10-18T09:05:01.903",
+          "Acquired": "2021-10-18T00:00:00.000",
+          "ClassificationCode": "12 01 01",
+          "ClassificationTitle": "Oppilaan opetuksen järjestäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011711"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011662?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011662",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 1, koulutustarkastaja, työavain KASKO-03-278-21",
+          "Created": "2021-10-15T15:16:45.067",
+          "Acquired": "2021-09-22T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011662"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011626?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011626",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 1, koulutustarkastaja, työavain KASKO-03-279-21",
+          "Created": "2021-10-15T08:54:21.593",
+          "Acquired": "2021-09-22T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011626"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011590?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011590",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 1, graafinen kouluttaja, työavain KASKO-03-227-21",
+          "Created": "2021-10-14T11:43:18.313",
+          "Acquired": "2021-08-10T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011590"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011610?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011610",
+          "Title": "Päiväkodit, ympärivuorokautiset päiväkodit ja ryhmäperhepäiväkodit,\ntilapäiset sulkemiset syyslomalla 18.-22.10.2021",
+          "Created": "2021-10-14T09:53:04.403",
+          "Acquired": "2021-10-14T00:00:00.000",
+          "ClassificationCode": "05 01 02",
+          "ClassificationTitle": "Päiväkotihoito",
+          "Status": "Ratkaistu",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011610"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011566?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011566",
+          "Title": "Tutkimuslupa, käsitys Itämeren ympäristöongelmista, Viron ja Suomen lukio",
+          "Created": "2021-10-14T08:23:31.097",
+          "Acquired": "2021-10-13T00:00:00.000",
+          "ClassificationCode": "13 02 01",
+          "ClassificationTitle": "Tutkimusluvat",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011566"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011504?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011504",
+          "Title": "Hankinta, kamerakalusto, Stadin ammatti- ja aikuisopisto, kampus 3",
+          "Created": "2021-10-12T14:44:29.813",
+          "Acquired": "2021-10-12T00:00:00.000",
+          "ClassificationCode": "02 08 01 00",
+          "ClassificationTitle": "Kilpailutus",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011504"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011458?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011458",
+          "Title": "Kokousajat, ruotsinkielinen jaosto, kokousajat 2022",
+          "Created": "2021-10-12T09:55:22.740",
+          "Acquired": "2021-10-11T00:00:00.000",
+          "ClassificationCode": "00 00 02",
+          "ClassificationTitle": "Luottamus- ja toimielinten kokoonpano ja toiminta",
+          "Status": "Vireillä",
+          "Language": "sv",
+          "CaseID": "HEL-2021-011458"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011538?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011538",
+          "Title": "Opetuksen järjestäminen, Oulunkylän ala-aste, kielikylpyopetus, 1.8.2022 alkaen",
+          "Created": "2021-10-12T08:30:27.717",
+          "Acquired": "2021-10-13T00:00:00.000",
+          "ClassificationCode": "12 01 01",
+          "ClassificationTitle": "Oppilaan opetuksen järjestäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011538"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011437?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011437",
+          "Title": "Hankinta, media-alan valolaitteisto, Stadin ammatti- ja aikuisopisto, kampus 3",
+          "Created": "2021-10-11T15:43:03.323",
+          "Acquired": "2021-10-11T00:00:00.000",
+          "ClassificationCode": "02 08 01 00",
+          "ClassificationTitle": "Kilpailutus",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011437"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011409?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011409",
+          "Title": "Kokousajat, kasvatus- ja koulutuslautakunnan suomenkielinen jaosto 2022",
+          "Created": "2021-10-11T13:02:53.953",
+          "Acquired": "2021-10-11T00:00:00.000",
+          "ClassificationCode": "00 00 02",
+          "ClassificationTitle": "Luottamus- ja toimielinten kokoonpano ja toiminta",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011409"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011421?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011421",
+          "Title": "Oppilaan koulupaikan määräytyminen ja oppilaaksi ottamisen perusteet, Kasvatuksen ja koulutuksen toimiala",
+          "Created": "2021-10-11T11:28:13.820",
+          "Acquired": "2021-10-11T00:00:00.000",
+          "ClassificationCode": "12 01 00",
+          "ClassificationTitle": "Oppilasvalinnat ja oppilaaksi otto, opiskelijavalinnat ja opiskelijaksi otto",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011421"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011386?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011386",
+          "Title": "Hankinta, sähkömoottori-opetuslaitteisto, Stadin ammatti- ja aikuisopisto, kampus 5",
+          "Created": "2021-10-11T10:12:12.943",
+          "Acquired": "2021-10-11T00:00:00.000",
+          "ClassificationCode": "02 08 02 01",
+          "ClassificationTitle": "Hankinta ilman kilpailutusta",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011386"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011368?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011368",
+          "Title": "Hankinta, henkilönostin, Stadin ammatti- ja aikuisopisto, Kampus 4",
+          "Created": "2021-10-11T07:41:10.883",
+          "Acquired": "2021-10-11T00:00:00.000",
+          "ClassificationCode": "02 08 01 01",
+          "ClassificationTitle": "Hankinta ilman kilpailutusta",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011368"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011357?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011357",
+          "Title": "Hankinta, 3D-käsiskanneri, Stadin ammatti- ja aikuisopisto, kampus 3",
+          "Created": "2021-10-08T14:30:55.233",
+          "Acquired": "2021-10-08T00:00:00.000",
+          "ClassificationCode": "02 08 01 00",
+          "ClassificationTitle": "Kilpailutus",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011357"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011312?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011312",
+          "Title": "Virkasuhteen täyttäminen, Stadin ammatti- ja aikuisopisto, kampus 5, tuntiopettaja, VALMA, työavain KASKO-03-262-21",
+          "Created": "2021-10-08T07:54:21.713",
+          "Acquired": "2021-09-20T00:00:00.000",
+          "ClassificationCode": "01 01 01 01",
+          "ClassificationTitle": "Työ- ja virkasuhteen täyttäminen",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011312"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011208?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011208",
+          "Title": "Työ- ja loma-ajat lukuvuonna 2022-2023, Helsingin aikuislukio",
+          "Created": "2021-10-06T10:50:07.830",
+          "Acquired": "2021-10-06T00:00:00.000",
+          "ClassificationCode": "12 00 01",
+          "ClassificationTitle": "Koulutuksen ja opetuksen suunnittelu",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011208"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011203?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011203",
+          "Title": "Työ- ja loma-ajat lukuvuonna 2022-2023, Helsingin kaupungin suomenkieliset lukiot , Kasvatuksen ja koulutuksen toimiala",
+          "Created": "2021-10-06T10:44:38.020",
+          "Acquired": "2021-10-06T00:00:00.000",
+          "ClassificationCode": "12 00 01",
+          "ClassificationTitle": "Koulutuksen ja opetuksen suunnittelu",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011203"
+      },
+      {
+          "links": [
+              {
+                  "rel": "self",
+                  "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases/HEL-2021-011211?apireqlang=fi"
+              }
+          ],
+          "CaseIDLabel": "HEL 2021-011211",
+          "Title": "Työ- ja loma-ajat lukuvuonna 2022-2023, Helsingin kaupungin suomenkielinen esi- ja perusopetus",
+          "Created": "2021-10-06T10:30:07.500",
+          "Acquired": "2021-10-06T00:00:00.000",
+          "ClassificationCode": "12 00 01",
+          "ClassificationTitle": "Koulutuksen ja opetuksen suunnittelu",
+          "Status": "Vireillä",
+          "Language": "fi",
+          "CaseID": "HEL-2021-011211"
+      }
+  ],
+  "page": 0,
+  "count": 1,
+  "nextCount": 0,
+  "prevCount": 0,
+  "links": [
+      {
+          "rel": "self",
+          "href": "https://ahjo.hel.fi:9802/ahjorest/v1/cases?q=&sectors=U420300&page=0&size=30&resolved=false&count_limit=1&public=false&apireqlang=fi"
+      }
+  ],
+  "size": 30
+}


### PR DESCRIPTION
Added migration of cases from Ahjo API data + new content type for cases

To test:
- Run `make drush-cim && make drush-cr`
- Move `public/modules/custom/paatokset_ahjo_proxy/static/cases.json` to `public/sites/default/files`
- Run `make shell` and run `drush mim ahjo_cases`
- New cases should be imported correctly from the json file to content type `Case` 