### PR TITLE
PP-185: Elasticsearch base install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "druidfi/omen": "^0.2.0",
         "drupal/core-composer-scaffold": "^9.1",
         "drupal/core-recommended": "^9.1",
+        "drupal/elasticsearch_connector": "^7.0@alpha",
         "drupal/hdbt": "^1.0",
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_hauki": "^1.0",
@@ -20,6 +21,7 @@
         "drupal/helfi_tpr": "^1.0",
         "drupal/helfi_tunnistamo": "^1.0",
         "drupal/migrate_plus": "^5.1",
+        "drupal/search_api": "^1.20",
         "drush/drush": "^10.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70ab66ad28b620d6c7b77078fdca9209",
+    "content-hash": "def523edbb547b54d9f3aed38bdffb35",
     "packages": [
         {
             "name": "City-of-Helsinki/php-hauki-client",
@@ -2924,6 +2924,10 @@
                 {
                     "name": "See other contributors",
                     "homepage": "https://www.drupal.org/node/2159059/committers"
+                },
+                {
+                    "name": "sokru",
+                    "homepage": "https://www.drupal.org/user/388235"
                 },
                 {
                     "name": "ygerasimov",
@@ -14521,10 +14525,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "drupal/elasticsearch_connector": 15
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -22,6 +22,7 @@ module:
   dynamic_page_cache: 0
   easy_breadcrumb: 0
   editor: 0
+  elasticsearch_connector: 0
   entity: 0
   entity_reference_revisions: 0
   entity_usage: 0
@@ -88,6 +89,7 @@ module:
   redirect: 0
   responsive_image: 0
   scheduler: 0
+  search_api: 0
   select2: 0
   select2_icon: 0
   serialization: 0

--- a/conf/cmi/elasticsearch_connector.cluster.paatokset.yml
+++ b/conf/cmi/elasticsearch_connector.cluster.paatokset.yml
@@ -1,0 +1,19 @@
+uuid: 4a8571c1-96d6-4f8d-b775-4bcf4199759a
+langcode: fi
+status: '1'
+dependencies: {  }
+cluster_id: paatokset
+name: Päätökset
+url: 'http://elastic:9200'
+options:
+  multiple_nodes_connection: false
+  use_authentication: 0
+  authentication_type: Basic
+  username: ''
+  password: ''
+  timeout: '3'
+  rewrite:
+    rewrite_index: 1
+    index:
+      prefix: paatokset
+      suffix: ''

--- a/conf/cmi/elasticsearch_connector.index.decisions.yml
+++ b/conf/cmi/elasticsearch_connector.index.decisions.yml
@@ -1,0 +1,9 @@
+uuid: ea722357-d519-4cad-b2b3-869a3fffa3b8
+langcode: fi
+status: true
+dependencies: {  }
+index_id: decisions
+name: Decisions
+num_of_shards: 5
+num_of_replica: 1
+server: paatokset

--- a/conf/cmi/search_api.settings.yml
+++ b/conf/cmi/search_api.settings.yml
@@ -1,0 +1,6 @@
+default_cron_limit: 50
+cron_worker_runtime: 15
+default_tracker: default
+tracking_page_size: 100
+_core:
+  default_config_hash: n7m4vlCPoB3_1C7l13LKYsifmLur4QR71mOD7S_5hSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,35 @@ services:
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}-varnish.loadbalancer.server.port=6081"
       - "traefik.docker.network=stonehenge-network"
 
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    container_name: "${COMPOSE_PROJECT_NAME}-elastic"
+    environment:
+      - node.name="${COMPOSE_PROJECT_NAME}-elastic"
+      - cluster.name=es-docker-cluster
+      - cluster.initial_master_nodes="${COMPOSE_PROJECT_NAME}-elastic"
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - internal
+      - stonehenge-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-varnish.entrypoints=https"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-varnish.rule=Host(`varnish-${DRUPAL_HOSTNAME}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-varnish.tls=true"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}-varnish.loadbalancer.server.port=9200"
+      - "traefik.docker.network=stonehenge-network"
+      - "traefik.port=9200"
+
 networks:
   internal:
     external: false
@@ -65,6 +94,8 @@ networks:
     external: true
 
 volumes:
+  data01:
+    driver: local
   db_data:
   ssh:
     name: stonehenge-ssh


### PR DESCRIPTION
Add Elasticsearch base install + modules

To test:

- Run `make fresh` (or `make new`)
- Check that your Elasticsearch container is up and running (`docker-compose ps`, Docker Desktop). Try sending a request to `http://localhost:9200/_cat/indices` - you should get and empty response but not an error
- IF container is NOT running, check logs either through Docker Desktop or `docker-compose logs elastic`. If you are getting error `exited with code 78`, try running `sudo sysctl -w vm.max_map_count=524288` and restart container
- Your Elastic container should be up and running and Elasticsearch Connector module should be able to access it