### PR TITLE
PP-234: Update Case diary number fields and truncate long titles.

### DIFF
--- a/conf/cmi/core.entity_form_display.node.case.default.yml
+++ b/conf/cmi/core.entity_form_display.node.case.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.case.field_description
     - field.field.node.case.field_diary_number
     - field.field.node.case.field_diary_number_label
+    - field.field.node.case.field_full_title
     - field.field.node.case.field_personal_data
     - field.field.node.case.field_public_reference
     - field.field.node.case.field_publicity_class
@@ -30,18 +31,18 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   field_acquired:
-    weight: 125
+    weight: 16
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_classification_code:
-    weight: 127
+    weight: 18
     settings:
       size: 60
       placeholder: ''
@@ -49,7 +50,7 @@ content:
     type: string_textfield
     region: content
   field_classification_title:
-    weight: 128
+    weight: 19
     settings:
       size: 60
       placeholder: ''
@@ -57,19 +58,19 @@ content:
     type: string_textfield
     region: content
   field_created:
-    weight: 124
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_deadline:
-    weight: 126
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_description:
-    weight: 123
+    weight: 14
     settings:
       rows: 5
       placeholder: ''
@@ -77,7 +78,7 @@ content:
     type: text_textarea
     region: content
   field_diary_number:
-    weight: 121
+    weight: 12
     settings:
       size: 60
       placeholder: ''
@@ -85,7 +86,15 @@ content:
     type: string_textfield
     region: content
   field_diary_number_label:
-    weight: 122
+    weight: 13
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_full_title:
+    weight: 1
     settings:
       size: 60
       placeholder: ''
@@ -93,7 +102,7 @@ content:
     type: string_textfield
     region: content
   field_personal_data:
-    weight: 131
+    weight: 22
     settings:
       size: 60
       placeholder: ''
@@ -101,7 +110,7 @@ content:
     type: string_textfield
     region: content
   field_public_reference:
-    weight: 133
+    weight: 24
     settings:
       size: 60
       placeholder: ''
@@ -109,7 +118,7 @@ content:
     type: string_textfield
     region: content
   field_publicity_class:
-    weight: 129
+    weight: 20
     settings:
       size: 60
       placeholder: ''
@@ -117,7 +126,7 @@ content:
     type: string_textfield
     region: content
   field_reference:
-    weight: 132
+    weight: 23
     settings:
       size: 60
       placeholder: ''
@@ -125,7 +134,7 @@ content:
     type: string_textfield
     region: content
   field_status:
-    weight: 130
+    weight: 21
     settings:
       size: 60
       placeholder: ''
@@ -141,7 +150,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -149,12 +158,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 5
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -162,19 +171,19 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
+    weight: 11
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 6
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -182,7 +191,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 3
     settings:
       match_operator: CONTAINS
       size: 60
@@ -192,13 +201,13 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 10
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/conf/cmi/core.entity_view_display.node.case.default.yml
+++ b/conf/cmi/core.entity_view_display.node.case.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.case.field_description
     - field.field.node.case.field_diary_number
     - field.field.node.case.field_diary_number_label
+    - field.field.node.case.field_full_title
     - field.field.node.case.field_personal_data
     - field.field.node.case.field_public_reference
     - field.field.node.case.field_publicity_class
@@ -86,6 +87,14 @@ content:
     region: content
   field_diary_number_label:
     weight: 102
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_full_title:
+    weight: 114
     label: above
     settings:
       link_to_entity: false

--- a/conf/cmi/core.entity_view_display.node.case.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.case.teaser.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.case.field_description
     - field.field.node.case.field_diary_number
     - field.field.node.case.field_diary_number_label
+    - field.field.node.case.field_full_title
     - field.field.node.case.field_personal_data
     - field.field.node.case.field_public_reference
     - field.field.node.case.field_publicity_class
@@ -39,6 +40,7 @@ hidden:
   field_description: true
   field_diary_number: true
   field_diary_number_label: true
+  field_full_title: true
   field_personal_data: true
   field_public_reference: true
   field_publicity_class: true

--- a/conf/cmi/field.field.node.case.field_full_title.yml
+++ b/conf/cmi/field.field.node.case.field_full_title.yml
@@ -1,0 +1,19 @@
+uuid: 41fc625f-166a-4df7-9fdd-c73d8b21f52d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_full_title
+    - node.type.case
+id: node.case.field_full_title
+field_name: field_full_title
+entity_type: node
+bundle: case
+label: 'Full title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_diary_number.yml
+++ b/conf/cmi/field.storage.node.field_diary_number.yml
@@ -9,7 +9,7 @@ field_name: field_diary_number
 entity_type: node
 type: string
 settings:
-  max_length: 25
+  max_length: 255
   is_ascii: false
   case_sensitive: false
 module: core

--- a/conf/cmi/field.storage.node.field_diary_number_label.yml
+++ b/conf/cmi/field.storage.node.field_diary_number_label.yml
@@ -9,7 +9,7 @@ field_name: field_diary_number_label
 entity_type: node
 type: string
 settings:
-  max_length: 30
+  max_length: 255
   is_ascii: false
   case_sensitive: false
 module: core

--- a/conf/cmi/field.storage.node.field_full_title.yml
+++ b/conf/cmi/field.storage.node.field_full_title.yml
@@ -1,0 +1,21 @@
+uuid: 10cbb519-340d-4bd7-bbd8-bfba349fc3ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_full_title
+field_name: field_full_title
+entity_type: node
+type: string
+settings:
+  max_length: 800
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
@@ -85,14 +85,10 @@ process:
     plugin: default_value
     default_value: case
   title:
-    -
-      plugin: default_value
-      source: title
-      default_value: 'NO TITLE'
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    callable: _paatokset_ahjo_api_truncate_value
+    plugin: callback
+    source: title
+  field_full_title: title
   field_diary_number: case_id
   field_diary_number_label: case_id
   field_description: description

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
@@ -85,9 +85,14 @@ process:
     plugin: default_value
     default_value: case
   title:
-    plugin: default_value
-    source: title
-    default_value: 'NO TITLE'
+    -
+      plugin: default_value
+      source: title
+      default_value: 'NO TITLE'
+    -
+      plugin: substr
+      start: 0
+      length: 255
   field_diary_number: case_id
   field_diary_number_label: case_id
   field_description: description

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -7,6 +7,23 @@
 
 declare(strict_types = 1);
 
+use Drupal\Component\Utility\Unicode;
+
+/**
+ * Truncate text value.
+ *
+ * @param string $value
+ *   The value to work with.
+ * @param int $length
+ *   Max length of string.
+ *
+ * @return string|null $value
+ *   Truncated value.
+ */
+function _paatokset_ahjo_api_truncate_value(string $value, int $length = 255): string {
+  return Unicode::truncate($value, $length, TRUE, TRUE);
+}
+
 /**
  * Callback to check if array or text value is empty.
  *

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -86,3 +86,25 @@ function paatokset_ahjo_api_update_9001() {
   $field_schema['node_revision__field_diary_number']['fields']['field_diary_number_label_value']['length'] = 255;
   $storage_schema->set($storage_key, $field_schema);
 }
+
+/**
+ * Update diary number field max length in config.
+ */
+function paatokset_ahjo_api_update_9002() {
+  $config = \Drupal::configFactory()->getEditable('field.storage.node.field_diary_number');
+  $settings = $config->get('settings');
+  $settings['max_length'] = 255;
+  $config->set('settings', $settings);
+  $config->save();
+}
+
+/**
+ * Update diary number label field max length in config.
+ */
+function paatokset_ahjo_api_update_9003() {
+  $config = \Drupal::configFactory()->getEditable('field.storage.node.field_diary_number_label');
+  $settings = $config->get('settings');
+  $settings['max_length'] = 255;
+  $config->set('settings', $settings);
+  $config->save();
+}

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -42,3 +42,30 @@ function _paatokset_ahjo_api_meeting_minutes_published($documents): bool {
 
   return FALSE;
 }
+
+/**
+ * Update diary number and diary number label field max lengths.
+ */
+function paatokset_ahjo_api_update_9001() {
+  // Update case diary number max length.
+  $database = \Drupal::database();
+  $database->query("ALTER TABLE node__field_diary_number MODIFY field_diary_number_value VARCHAR(255)");
+  $database->query("ALTER TABLE node_revision__field_diary_number MODIFY field_diary_number_value VARCHAR(255)");
+  $storage_key = 'node.field_schema_data.field_diary_number';
+  $storage_schema = \Drupal::keyValue('entity.storage_schema.sql');
+  $field_schema = $storage_schema->get($storage_key);
+  $field_schema['node__field_diary_number']['fields']['field_diary_number_value']['length'] = 255;
+  $field_schema['node_revision__field_diary_number']['fields']['field_diary_number_value']['length'] = 255;
+  $storage_schema->set($storage_key, $field_schema);
+
+  // Update case diary label number max length.
+  $database = \Drupal::database();
+  $database->query("ALTER TABLE node__field_diary_number_label MODIFY field_diary_number_label_value VARCHAR(255)");
+  $database->query("ALTER TABLE node_revision__field_diary_number_label MODIFY field_diary_number_label_value VARCHAR(255)");
+  $storage_key = 'node.field_schema_data.field_diary_number_label';
+  $storage_schema = \Drupal::keyValue('entity.storage_schema.sql');
+  $field_schema = $storage_schema->get($storage_key);
+  $field_schema['node__field_diary_number']['fields']['field_diary_number_label_value']['length'] = 255;
+  $field_schema['node_revision__field_diary_number']['fields']['field_diary_number_label_value']['length'] = 255;
+  $storage_schema->set($storage_key, $field_schema);
+}


### PR DESCRIPTION
**To test**
* Checkout branch
* Run `drush updb; drush cim -y`
* Check that the case diary number fields have a max length of 255:
  * https://helsinki-paatokset.docker.so/fi/admin/structure/types/manage/case/fields/node.case.field_diary_number
  * https://helsinki-paatokset.docker.so/fi/admin/structure/types/manage/case/fields/node.case.field_diary_number_label/storage
* Change the `public/modules/custom/paatokset_ahjo_api/src/Plugin/Deriver/AhjoApiMigrationDeriver.php` file so that `ahjo_cases:all` points to `https://nginx-paatokset-test.agw.arodevtest.hel.fi/fi/ahjo-proxy/aggregated/cases_all`
* Run `drush cr; drush migrate-status ahjo_cases:all`. There should be about 499 unimported items
* Run `drush mim ahjo_cases:all`. This should complete without errors.
* Check the imported cases: https://helsinki-paatokset.docker.so/en/admin/content?title=Lausuntopyynt%C3%B6&type=All&status=All&langcode=All
  * There should be a few with truncated titles. Edit these and make sure the untruncated title is stored in the "Full title" field.