### PR TITLE
PP-231: Add subscriber callback controller.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.routing.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.routing.yml
@@ -4,3 +4,19 @@ ahjo_meeting_endpoint:
     _controller: '\Drupal\paatokset_ahjo_api\Controller\MeetingController::query'
   requirements:
     _access: 'TRUE'
+
+paatokset_ahjo_api.subscriber:
+  path: 'ahjo_api/subscriber/{id}'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo_api\Controller\AhjoSubscriberController::callback'
+  requirements:
+    _permission: 'access content'
+  methods: [GET, POST]
+
+paatokset_ahjo_api.queue_list:
+  path: 'ahjo_api/callback-queue/{id}'
+  defaults:
+    _controller: '\Drupal\paatokset_ahjo_api\Controller\AhjoSubscriberController::listQueue'
+    id: all
+  requirements:
+    _permission: 'administer content'

--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * AHJO subscriber controller.
+ *
+ * @package Drupal\paatokset_ahjo_api\Controller
+ */
+class AhjoSubscriberController extends ControllerBase {
+
+  private const QUEUE_NAME = 'ahjo_api_subscriber_queue';
+
+  /**
+   * Queue Factory.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queueFactory;
+
+  /**
+   * The logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(QueueFactory $queue_factory, LoggerChannelFactoryInterface $logger_factory) {
+    $this->queueFactory = $queue_factory;
+    $this->logger = $logger_factory->get('ahjo_api_subscriber');
+  }
+
+  /**
+   * Create and inject.
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('queue'),
+      $container->get('logger.factory')
+    );
+  }
+
+  /**
+   * Handle subscriber callback.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   HTTP request.
+   * @param string $id
+   *   Subscriber callback ID (decisions, meetings, etc).
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   JSON response for debugging.
+   */
+  public function callback(Request $request, string $id): JsonResponse {
+    $queue = $this->queueFactory->get(self::QUEUE_NAME);
+
+    $data = [
+      'id' => $id,
+      'request' => $request->request->all(),
+    ];
+
+    $item_id = $queue->createItem($data);
+    $data['item_id'] = $item_id;
+
+    if ($item_id) {
+      $this->logger->info('Added item @item_id to @id queue.', [
+        '@item_id' => $item_id,
+        '@id' => $id,
+      ]);
+    }
+
+    return new JsonResponse($data);
+  }
+
+  /**
+   * List subscriber queue contents.
+   *
+   * @param string $id
+   *   Subsciber callback ID to filter (decisions, meetings, etc).
+   *
+   * @return JsonResponse
+   *   Queue contents.
+   */
+  public function listQueue(string $id): JsonResponse {
+    $data = [];
+    $items = [];
+
+    $queue = $this->queueFactory->get(self::QUEUE_NAME);
+
+    while ($item = $queue->claimItem()) {
+      if ($id === 'all' || $item->data['id'] === $id) {
+        $data[] = $item;
+      }
+
+      $items[] = $item;
+    }
+
+    // Release claimed items.
+    foreach ($items as $item) {
+      $queue->releaseItem(($item));
+    }
+
+    return new JsonResponse($data);
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
@@ -90,7 +90,7 @@ class AhjoSubscriberController extends ControllerBase {
    * @param string $id
    *   Subsciber callback ID to filter (decisions, meetings, etc).
    *
-   * @return JsonResponse
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   Queue contents.
    */
   public function listQueue(string $id): JsonResponse {


### PR DESCRIPTION
This adds a queue to handle subscriber callbacks from the Ahjo API and methods to debug the queue contents. Doesn't actually process anything yet, since we need to test what kind of data the API actually posts.

**To test:**
- Checkout branch, run `make drush-cr`
- Open this URL: https://helsinki-paatokset.docker.so/fi/ahjo_api/subscriber/test
  - The data should contain an item_id
- Open this URL: https://helsinki-paatokset.docker.so/fi/ahjo_api/callback-queue
  - This should list an item the with the same item_id you just saw
- Make a POST request with some form-data or x-www-form-urlencoded parameters to https://helsinki-paatokset.docker.so/fi/ahjo_api/subscriber/test
  - Check the callback-queue URL again. The POST requests and the data you sent should be included in the list
- Send more POST requests to: https://helsinki-paatokset.docker.so/fi/ahjo_api/subscriber/[something else in here]
  - Check that you can list only those requests by visiting https://helsinki-paatokset.docker.so/fi/ahjo_api/callback-queue/[something else in here]