### PR TITLE
PP-231: Convert env variable names to use dashes instead of underscores.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/Deriver/AhjoApiMigrationDeriver.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/Deriver/AhjoApiMigrationDeriver.php
@@ -79,8 +79,8 @@ class AhjoApiMigrationDeriver extends DeriverBase implements ContainerDeriverInt
    */
   protected function getSourceUrl(string $base_plugin_id, string $key): ?string {
     // Get either local proxy URL or OpenShift reverse proxy address.
-    if (getenv('AHJO_PROXY_BASE_URL')) {
-      $base_url = getenv('AHJO_PROXY_BASE_URL');
+    if (getenv('AHJO-PROXY-BASE-URL')) {
+      $base_url = getenv('AHJO-PROXY-BASE-URL');
     }
     elseif (getenv('DRUPAL_REVERSE_PROXY_ADDRESS')) {
       $base_url = 'https://' . getenv('DRUPAL_REVERSE_PROXY_ADDRESS');

--- a/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
+++ b/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
@@ -236,7 +236,7 @@ class AhjoOpenId implements ContainerInjectionInterface {
    */
   private function getHeaders(): ?array {
     $client_id = $this->clientId;
-    $client_secret = getenv('PAATOKSET_OPENID_SECRET');
+    $client_secret = getenv('PAATOKSET-OPENID-SECRET');
 
     if (empty($client_id) || empty($client_secret)) {
       return NULL;


### PR DESCRIPTION
**To test**
* Checkout branch
* Edit the env variable names in .env.local to use dashes instead of underscores (PAATOKSET-OPENID-SECRET and AHJO-PROXY-BASE-URL)
* Run `make up`
* Run `make shell` and then `printenv` to make sure the names were actually updated.
* Connect to VPN and make sure the authentication flow and token refreshing work here: https://helsinki-paatokset.docker.so/fi/admin/ahjo-open-id 