### PR TITLE
PP-232: Handle meeting documents and agenda files

### DIFF
--- a/conf/cmi/core.entity_form_display.media.ahjo_document.default.yml
+++ b/conf/cmi/core.entity_form_display.media.ahjo_document.default.yml
@@ -1,0 +1,137 @@
+uuid: 4a637ffc-2023-4c70-872e-d611b7b744a9
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.media.ahjo_document.field_document_issued
+    - field.field.media.ahjo_document.field_document_language
+    - field.field.media.ahjo_document.field_document_native_id
+    - field.field.media.ahjo_document.field_document_orig_uri
+    - field.field.media.ahjo_document.field_document_personal_data
+    - field.field.media.ahjo_document.field_document_type
+    - field.field.media.ahjo_document.field_document_uri
+    - field.field.media.ahjo_document.field_media_ahjo_file
+    - media.type.ahjo_document
+  module:
+    - datetime
+    - json_field
+    - link
+    - path
+id: media.ahjo_document.default
+targetEntityType: media
+bundle: ahjo_document
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 11
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_document_issued:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_document_language:
+    weight: 4
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_document_native_id:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_document_orig_uri:
+    weight: 7
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_document_personal_data:
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_document_type:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_document_uri:
+    weight: 6
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_media_ahjo_file:
+    weight: 8
+    settings:
+      mode: code
+      modes:
+        - tree
+        - code
+      schema: ''
+      schema_validate: false
+    third_party_settings: {  }
+    type: json_editor
+    region: content
+  langcode:
+    type: language_select
+    weight: 10
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 13
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 9
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_form_display.media.ahjo_document.media_library.yml
+++ b/conf/cmi/core.entity_form_display.media.ahjo_document.media_library.yml
@@ -1,0 +1,35 @@
+uuid: cbbcab4c-5f99-45ef-adef-357131e340aa
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.ahjo_document.field_document_issued
+    - field.field.media.ahjo_document.field_document_language
+    - field.field.media.ahjo_document.field_document_native_id
+    - field.field.media.ahjo_document.field_document_orig_uri
+    - field.field.media.ahjo_document.field_document_personal_data
+    - field.field.media.ahjo_document.field_document_type
+    - field.field.media.ahjo_document.field_document_uri
+    - field.field.media.ahjo_document.field_media_ahjo_file
+    - media.type.ahjo_document
+id: media.ahjo_document.media_library
+targetEntityType: media
+bundle: ahjo_document
+mode: media_library
+content: {  }
+hidden:
+  created: true
+  field_document_issued: true
+  field_document_language: true
+  field_document_native_id: true
+  field_document_orig_uri: true
+  field_document_personal_data: true
+  field_document_type: true
+  field_document_uri: true
+  field_media_ahjo_file: true
+  langcode: true
+  name: true
+  path: true
+  status: true
+  uid: true

--- a/conf/cmi/core.entity_form_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_form_display.node.meeting.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.meeting.field_meeting_agenda
+    - field.field.node.meeting.field_meeting_agenda_files
     - field.field.node.meeting.field_meeting_agenda_published
     - field.field.node.meeting.field_meeting_attachment_info
     - field.field.node.meeting.field_meeting_composition
@@ -11,6 +12,7 @@ dependencies:
     - field.field.node.meeting.field_meeting_decision
     - field.field.node.meeting.field_meeting_dm
     - field.field.node.meeting.field_meeting_dm_id
+    - field.field.node.meeting.field_meeting_document_files
     - field.field.node.meeting.field_meeting_documents
     - field.field.node.meeting.field_meeting_id
     - field.field.node.meeting.field_meeting_location
@@ -27,6 +29,7 @@ dependencies:
     - field_group
     - hdbt_admin_editorial
     - json_field
+    - media_library
     - path
     - scheduler
     - text
@@ -124,6 +127,7 @@ third_party_settings:
       label: 'Previous meeting data'
     group_agenda:
       children:
+        - field_meeting_agenda_files
         - field_meeting_agenda
       parent_name: group_meeting_data
       weight: 15
@@ -140,6 +144,7 @@ third_party_settings:
     group_documents:
       children:
         - field_meeting_documents
+        - field_meeting_document_files
       parent_name: group_meeting_data
       weight: 17
       format_type: details
@@ -179,7 +184,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_meeting_agenda:
-    weight: 34
+    weight: 36
     settings:
       mode: code
       modes:
@@ -189,6 +194,13 @@ content:
       schema_validate: false
     third_party_settings: {  }
     type: json_editor
+    region: content
+  field_meeting_agenda_files:
+    type: media_library_widget
+    weight: 35
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
     region: content
   field_meeting_agenda_published:
     weight: 36
@@ -246,6 +258,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_meeting_document_files:
+    type: media_library_widget
+    weight: 5
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
     region: content
   field_meeting_documents:
     weight: 5

--- a/conf/cmi/core.entity_view_display.media.ahjo_document.default.yml
+++ b/conf/cmi/core.entity_view_display.media.ahjo_document.default.yml
@@ -1,0 +1,102 @@
+uuid: 919956b6-c0a3-4ec5-8e6f-7ade2a2eedfe
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.media.ahjo_document.field_document_issued
+    - field.field.media.ahjo_document.field_document_language
+    - field.field.media.ahjo_document.field_document_native_id
+    - field.field.media.ahjo_document.field_document_orig_uri
+    - field.field.media.ahjo_document.field_document_personal_data
+    - field.field.media.ahjo_document.field_document_type
+    - field.field.media.ahjo_document.field_document_uri
+    - field.field.media.ahjo_document.field_media_ahjo_file
+    - media.type.ahjo_document
+  module:
+    - datetime
+    - json_field
+    - link
+id: media.ahjo_document.default
+targetEntityType: media
+bundle: ahjo_document
+mode: default
+content:
+  field_document_issued:
+    weight: 4
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_document_language:
+    weight: 3
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_document_native_id:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_document_orig_uri:
+    weight: 7
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_document_personal_data:
+    weight: 5
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_document_type:
+    weight: 2
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_document_uri:
+    weight: 6
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_media_ahjo_file:
+    label: visually_hidden
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: json
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/conf/cmi/core.entity_view_display.media.ahjo_document.media_library.yml
+++ b/conf/cmi/core.entity_view_display.media.ahjo_document.media_library.yml
@@ -1,0 +1,45 @@
+uuid: bc5fb1c7-8845-4308-b91e-9a2e4296db8c
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.ahjo_document.field_document_issued
+    - field.field.media.ahjo_document.field_document_language
+    - field.field.media.ahjo_document.field_document_native_id
+    - field.field.media.ahjo_document.field_document_orig_uri
+    - field.field.media.ahjo_document.field_document_personal_data
+    - field.field.media.ahjo_document.field_document_type
+    - field.field.media.ahjo_document.field_document_uri
+    - field.field.media.ahjo_document.field_media_ahjo_file
+    - media.type.ahjo_document
+  module:
+    - image
+id: media.ahjo_document.media_library
+targetEntityType: media
+bundle: ahjo_document
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_document_issued: true
+  field_document_language: true
+  field_document_native_id: true
+  field_document_orig_uri: true
+  field_document_personal_data: true
+  field_document_type: true
+  field_document_uri: true
+  field_media_ahjo_file: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  uid: true

--- a/conf/cmi/core.entity_view_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.meeting.field_meeting_agenda
+    - field.field.node.meeting.field_meeting_agenda_files
     - field.field.node.meeting.field_meeting_agenda_published
     - field.field.node.meeting.field_meeting_attachment_info
     - field.field.node.meeting.field_meeting_composition
@@ -11,6 +12,7 @@ dependencies:
     - field.field.node.meeting.field_meeting_decision
     - field.field.node.meeting.field_meeting_dm
     - field.field.node.meeting.field_meeting_dm_id
+    - field.field.node.meeting.field_meeting_document_files
     - field.field.node.meeting.field_meeting_documents
     - field.field.node.meeting.field_meeting_id
     - field.field.node.meeting.field_meeting_location
@@ -38,6 +40,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: json
+    region: content
+  field_meeting_agenda_files:
+    type: entity_reference_entity_view
+    weight: 21
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
     region: content
   field_meeting_agenda_published:
     weight: 5
@@ -94,6 +105,15 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_meeting_document_files:
+    type: entity_reference_entity_view
+    weight: 20
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
     region: content
   field_meeting_documents:
     weight: 19

--- a/conf/cmi/core.entity_view_display.node.meeting.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.meeting.field_meeting_agenda
+    - field.field.node.meeting.field_meeting_agenda_files
     - field.field.node.meeting.field_meeting_agenda_published
     - field.field.node.meeting.field_meeting_attachment_info
     - field.field.node.meeting.field_meeting_composition
@@ -12,6 +13,7 @@ dependencies:
     - field.field.node.meeting.field_meeting_decision
     - field.field.node.meeting.field_meeting_dm
     - field.field.node.meeting.field_meeting_dm_id
+    - field.field.node.meeting.field_meeting_document_files
     - field.field.node.meeting.field_meeting_documents
     - field.field.node.meeting.field_meeting_id
     - field.field.node.meeting.field_meeting_location
@@ -37,6 +39,7 @@ content:
     region: content
 hidden:
   field_meeting_agenda: true
+  field_meeting_agenda_files: true
   field_meeting_agenda_published: true
   field_meeting_attachment_info: true
   field_meeting_composition: true
@@ -44,6 +47,7 @@ hidden:
   field_meeting_decision: true
   field_meeting_dm: true
   field_meeting_dm_id: true
+  field_meeting_document_files: true
   field_meeting_documents: true
   field_meeting_id: true
   field_meeting_location: true

--- a/conf/cmi/field.field.media.ahjo_document.field_document_issued.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_document_issued.yml
@@ -1,0 +1,21 @@
+uuid: 3b983a70-d51e-43b6-b3d1-e628308976ef
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document_issued
+    - media.type.ahjo_document
+  module:
+    - datetime
+id: media.ahjo_document.field_document_issued
+field_name: field_document_issued
+entity_type: media
+bundle: ahjo_document
+label: Issued
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.media.ahjo_document.field_document_language.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_document_language.yml
@@ -1,0 +1,23 @@
+uuid: 556682cc-8536-4605-aad9-df5f509a419c
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document_language
+    - media.type.ahjo_document
+id: media.ahjo_document.field_document_language
+field_name: field_document_language
+entity_type: media
+bundle: ahjo_document
+label: Language
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:configurable_language'
+  handler_settings:
+    target_bundles: null
+    auto_create: false
+field_type: entity_reference

--- a/conf/cmi/field.field.media.ahjo_document.field_document_native_id.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_document_native_id.yml
@@ -1,0 +1,19 @@
+uuid: e8c6431b-3933-4452-b1cf-ed7bfa4ea032
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document_native_id
+    - media.type.ahjo_document
+id: media.ahjo_document.field_document_native_id
+field_name: field_document_native_id
+entity_type: media
+bundle: ahjo_document
+label: 'Native ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.media.ahjo_document.field_document_orig_uri.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_document_orig_uri.yml
@@ -1,0 +1,23 @@
+uuid: 2e43b0d1-7517-4818-87e0-f6d33db4ff3f
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document_orig_uri
+    - media.type.ahjo_document
+  module:
+    - link
+id: media.ahjo_document.field_document_orig_uri
+field_name: field_document_orig_uri
+entity_type: media
+bundle: ahjo_document
+label: 'Original URI'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/conf/cmi/field.field.media.ahjo_document.field_document_personal_data.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_document_personal_data.yml
@@ -1,0 +1,19 @@
+uuid: 7fa28ae7-ec98-46c8-88b0-f52dab384167
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document_personal_data
+    - media.type.ahjo_document
+id: media.ahjo_document.field_document_personal_data
+field_name: field_document_personal_data
+entity_type: media
+bundle: ahjo_document
+label: 'Personal data'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.media.ahjo_document.field_document_type.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_document_type.yml
@@ -1,0 +1,19 @@
+uuid: 482db880-ab58-4b7a-85da-f0bd616c7b3f
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document_type
+    - media.type.ahjo_document
+id: media.ahjo_document.field_document_type
+field_name: field_document_type
+entity_type: media
+bundle: ahjo_document
+label: Type
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.media.ahjo_document.field_document_uri.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_document_uri.yml
@@ -1,0 +1,23 @@
+uuid: b4111a7f-89e8-4630-8d56-2c4822fe523d
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document_uri
+    - media.type.ahjo_document
+  module:
+    - link
+id: media.ahjo_document.field_document_uri
+field_name: field_document_uri
+entity_type: media
+bundle: ahjo_document
+label: 'File URI'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/conf/cmi/field.field.media.ahjo_document.field_media_ahjo_file.yml
+++ b/conf/cmi/field.field.media.ahjo_document.field_media_ahjo_file.yml
@@ -1,0 +1,21 @@
+uuid: 2f2d8566-f239-4820-b976-719eb1df92fe
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_ahjo_file
+    - media.type.ahjo_document
+  module:
+    - json_field
+id: media.ahjo_document.field_media_ahjo_file
+field_name: field_media_ahjo_file
+entity_type: media
+bundle: ahjo_document
+label: 'External file from Ahjo API'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: json_native

--- a/conf/cmi/field.field.node.meeting.field_meeting_agenda_files.yml
+++ b/conf/cmi/field.field.node.meeting.field_meeting_agenda_files.yml
@@ -1,0 +1,29 @@
+uuid: 0d31101e-9d42-44e2-a615-9511e56def02
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meeting_agenda_files
+    - media.type.ahjo_document
+    - node.type.meeting
+id: node.meeting.field_meeting_agenda_files
+field_name: field_meeting_agenda_files
+entity_type: node
+bundle: meeting
+label: 'Agenda documents'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      ahjo_document: ahjo_document
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.node.meeting.field_meeting_document_files.yml
+++ b/conf/cmi/field.field.node.meeting.field_meeting_document_files.yml
@@ -1,0 +1,29 @@
+uuid: 1e353a11-da80-45fa-b41d-3bc5bac69542
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meeting_document_files
+    - media.type.ahjo_document
+    - node.type.meeting
+id: node.meeting.field_meeting_document_files
+field_name: field_meeting_document_files
+entity_type: node
+bundle: meeting
+label: 'Meeting documents (files)'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      ahjo_document: ahjo_document
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.storage.media.field_document_issued.yml
+++ b/conf/cmi/field.storage.media.field_document_issued.yml
@@ -1,0 +1,20 @@
+uuid: 26ba8882-d2a3-46a1-844c-192452c36f50
+langcode: fi
+status: true
+dependencies:
+  module:
+    - datetime
+    - media
+id: media.field_document_issued
+field_name: field_document_issued
+entity_type: media
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_document_language.yml
+++ b/conf/cmi/field.storage.media.field_document_language.yml
@@ -1,0 +1,20 @@
+uuid: eafd4fab-9a20-4a6d-b7ff-2ebe94e7ad84
+langcode: fi
+status: true
+dependencies:
+  module:
+    - language
+    - media
+id: media.field_document_language
+field_name: field_document_language
+entity_type: media
+type: entity_reference
+settings:
+  target_type: configurable_language
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_document_native_id.yml
+++ b/conf/cmi/field.storage.media.field_document_native_id.yml
@@ -1,0 +1,21 @@
+uuid: 2017af60-34b7-48d6-8792-e5a318cc8bc6
+langcode: fi
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_document_native_id
+field_name: field_document_native_id
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_document_orig_uri.yml
+++ b/conf/cmi/field.storage.media.field_document_orig_uri.yml
@@ -1,0 +1,19 @@
+uuid: 77f8498f-5fe3-4797-8640-c5cefeececc2
+langcode: fi
+status: true
+dependencies:
+  module:
+    - link
+    - media
+id: media.field_document_orig_uri
+field_name: field_document_orig_uri
+entity_type: media
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_document_personal_data.yml
+++ b/conf/cmi/field.storage.media.field_document_personal_data.yml
@@ -1,0 +1,21 @@
+uuid: 2887b94c-82bf-4a4d-9bf6-3dab8a12bb71
+langcode: fi
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_document_personal_data
+field_name: field_document_personal_data
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_document_type.yml
+++ b/conf/cmi/field.storage.media.field_document_type.yml
@@ -1,0 +1,21 @@
+uuid: 66fefb54-615a-4d72-969a-01a09a9b7038
+langcode: fi
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_document_type
+field_name: field_document_type
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_document_uri.yml
+++ b/conf/cmi/field.storage.media.field_document_uri.yml
@@ -1,0 +1,19 @@
+uuid: 90100076-d0e2-4ff3-8058-e23e861846ae
+langcode: fi
+status: true
+dependencies:
+  module:
+    - link
+    - media
+id: media.field_document_uri
+field_name: field_document_uri
+entity_type: media
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_media_ahjo_file.yml
+++ b/conf/cmi/field.storage.media.field_media_ahjo_file.yml
@@ -1,0 +1,19 @@
+uuid: 5ad3e891-9eef-494c-b6e0-19b5a2238d53
+langcode: fi
+status: true
+dependencies:
+  module:
+    - json_field
+    - media
+id: media.field_media_ahjo_file
+field_name: field_media_ahjo_file
+entity_type: media
+type: json_native
+settings: {  }
+module: json_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_meeting_agenda_files.yml
+++ b/conf/cmi/field.storage.node.field_meeting_agenda_files.yml
@@ -1,0 +1,20 @@
+uuid: 3a8fb6aa-d20d-46d5-b8b3-ac7491e74663
+langcode: fi
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_meeting_agenda_files
+field_name: field_meeting_agenda_files
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_meeting_document_files.yml
+++ b/conf/cmi/field.storage.node.field_meeting_document_files.yml
@@ -1,0 +1,20 @@
+uuid: 9e38e9cb-7c2f-4253-8ace-16f2be0600e7
+langcode: fi
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_meeting_document_files
+field_name: field_meeting_document_files
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.media.ahjo_document.yml
+++ b/conf/cmi/language.content_settings.media.ahjo_document.yml
@@ -1,0 +1,11 @@
+uuid: ed14b1df-4be6-4038-962d-c7e3ac25f8df
+langcode: fi
+status: true
+dependencies:
+  config:
+    - media.type.ahjo_document
+id: media.ahjo_document
+target_entity_type_id: media
+target_bundle: ahjo_document
+default_langcode: site_default
+language_alterable: false

--- a/conf/cmi/media.type.ahjo_document.yml
+++ b/conf/cmi/media.type.ahjo_document.yml
@@ -1,0 +1,27 @@
+uuid: b2b857c9-31e2-4457-82b2-6ddc9c4f7576
+langcode: fi
+status: true
+dependencies:
+  module:
+    - crop
+    - paatokset_ahjo_api
+third_party_settings:
+  crop:
+    image_field: null
+id: ahjo_document
+label: 'Ahjo Document'
+description: 'External file from Ahjo API.'
+source: ahjo_file
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_ahjo_file
+field_map:
+  title: name
+  id: field_document_native_id
+  uri: field_document_uri
+  orig_uri: field_document_orig_uri
+  type: field_document_type
+  issued: field_document_issued
+  personaldata: field_document_personal_data
+  language: field_document_language

--- a/conf/cmi/views.view.meetings.yml
+++ b/conf/cmi/views.view.meetings.yml
@@ -237,6 +237,73 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Päivitetty
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
         field_meeting_date:
           id: field_meeting_date
           table: node__field_meeting_date
@@ -508,6 +575,51 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+          group: 1
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Otsikko
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              admin: '0'
+              content_producer: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
         field_meeting_id_value:
           id: field_meeting_id_value
           table: node__field_meeting_id
@@ -551,34 +663,21 @@ display:
             group_items: {  }
           plugin_id: string
       sorts:
-        created:
-          id: created
+        changed:
+          id: changed
           table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
+          field: changed
           relationship: none
           group_type: group
           admin_label: ''
+          order: DESC
           exposed: false
           expose:
             label: ''
           granularity: second
-        field_meeting_date_value:
-          id: field_meeting_date_value
-          table: node__field_meeting_date
-          field: field_meeting_date_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: minute
-          plugin_id: datetime
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
       title: Meetings
       header: {  }
       footer: {  }
@@ -586,6 +685,10 @@ display:
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_meetings.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_meetings.yml
@@ -172,6 +172,39 @@ process:
     -
       callable: _paatokset_ahjo_api_meeting_minutes_published
       plugin: callback
+  field_meeting_document_files:
+    plugin: ahjo_entity_generate
+    source: meeting_documents
+    access_check: false
+    source_key: NativeId
+    value_key: field_document_native_id
+    bundle_key: bundle
+    bundle: ahjo_document
+    entity_type: media
+    ignore_case: true
+    values:
+      field_document_native_id: NativeId
+      field_media_ahjo_file: root_json
+  field_meeting_agenda_files:
+    plugin: sub_process
+    source: meeting_agenda
+    process:
+      target_id:
+        -
+          plugin: single_value
+          source: PDF
+        -
+          plugin: ahjo_entity_generate
+          access_check: false
+          source_key: NativeId
+          value_key: field_document_native_id
+          bundle_key: bundle
+          bundle: ahjo_document
+          entity_type: media
+          ignore_case: true
+          values:
+            field_document_native_id: NativeId
+            field_media_ahjo_file: root_json
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/media/Source/ExternalAhjoFile.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/media/Source/ExternalAhjoFile.php
@@ -6,7 +6,6 @@ namespace Drupal\paatokset_ahjo_api\Plugin\media\Source;
 
 use Drupal\media\MediaInterface;
 use Drupal\media\MediaSourceBase;
-use Drupal\json_field\Plugin\Field\FieldType\JSONItem;
 
 /**
  * Source wrapping around an external document from Ahjo.
@@ -23,6 +22,9 @@ use Drupal\json_field\Plugin\Field\FieldType\JSONItem;
  */
 class ExternalAhjoFile extends MediaSourceBase {
 
+  /**
+   * {@inheritdoc}
+   */
   public function getMetadataAttributes() {
     return [
       'title' => $this->t('Title'),
@@ -36,6 +38,9 @@ class ExternalAhjoFile extends MediaSourceBase {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getMetadata(MediaInterface $media, $attribute_name) {
     // Get file attributes from JSON source field.
     $json_field = $media->get($this->configuration['source_field']);
@@ -48,7 +53,7 @@ class ExternalAhjoFile extends MediaSourceBase {
     $data = json_decode($json_field->value);
 
     switch ($attribute_name) {
-      // This is used to set the name of the media entity if the user leaves the field blank.
+      // Default name if left blank (through migrations for example).
       case 'default_name':
         return $data->Title;
 
@@ -87,7 +92,15 @@ class ExternalAhjoFile extends MediaSourceBase {
     }
   }
 
-
+  /**
+   * Get local URI for external file.
+   *
+   * @param string $native_id
+   *   Native ID of file.
+   *
+   * @return string
+   *   Local URI through proxy to get past OpenID authentication.
+   */
   private function getAhjoFileUri(string $native_id): string {
     return 'https://example.com/' . urlencode($native_id);
   }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/media/Source/ExternalAhjoFile.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/media/Source/ExternalAhjoFile.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Plugin\media\Source;
+
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaSourceBase;
+use Drupal\json_field\Plugin\Field\FieldType\JSONItem;
+
+/**
+ * Source wrapping around an external document from Ahjo.
+ *
+ * @see \Drupal\file\FileInterface
+ *
+ * @MediaSource(
+ *   id = "ahjo_file",
+ *   label = @Translation("External file from Ahjo API"),
+ *   description = @Translation("Document from Ahjo API."),
+ *   allowed_field_types = {"json_native"},
+ *   default_thumbnail_filename = "generic.png"
+ * )
+ */
+class ExternalAhjoFile extends MediaSourceBase {
+
+  public function getMetadataAttributes() {
+    return [
+      'title' => $this->t('Title'),
+      'id' => $this->t('ID'),
+      'uri' => $this->t('URL'),
+      'orig_uri' => $this->t('Original File URI'),
+      'type' => $this->t('Type'),
+      'issued' => $this->t('Issued'),
+      'personaldata' => $this->t('Personal Data'),
+      'language' => $this->t('Language'),
+    ];
+  }
+
+  public function getMetadata(MediaInterface $media, $attribute_name) {
+    // Get file attributes from JSON source field.
+    $json_field = $media->get($this->configuration['source_field']);
+    $data = json_decode($json_field->value);
+
+    // Fallback if JSON field is empty.
+    if (!$json_field) {
+      return parent::getMetadata($media, $attribute_name);
+    }
+
+    switch ($attribute_name) {
+      // This is used to set the name of the media entity if the user leaves the field blank.
+      case 'default_name':
+        return $data->Title;
+
+      case 'title':
+        return $data->Title;
+
+      case 'type':
+        return $data->Type;
+
+      case 'id':
+        return $data->NativeId;
+
+      case 'uri':
+        return $this->getAhjoFileUri($data->NativeID);
+
+      case 'orig_uri':
+        return $this->FileURI;
+
+      case 'issued':
+        return $data->Issued;
+
+      case 'language':
+        return $data->Language;
+
+      case 'personal_data':
+        return $data->PersonalData;
+
+      default:
+        return $data->$attribute_name ?? parent::getMetadata($media, $attribute_name);
+    }
+  }
+
+
+  private function getAhjoFileUri(string $native_id): string {
+    return 'https://example.com/' . $native_id;
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoEntityGenerate.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoEntityGenerate.php
@@ -70,13 +70,16 @@ class AhjoEntityGenerate extends EntityLookup {
 
     // Creates an entity if the lookup determines it doesn't exist.
     $lookup_value = $value[$this->lookupSourceKey] ?? [];
+
     if (!($result = parent::transform($lookup_value, $migrateExecutable, $row, $destinationProperty))) {
       $result = $this->generateEntity($value);
     }
-    /** @var \Drupal\Core\Entity\FieldableEntityInterface $existing */
-    elseif ($existing = $this->entityTypeManager->getStorage($this->lookupEntityType)
+
+    // Updates either the existing or created entity.
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
+    if ($entity = $this->entityTypeManager->getStorage($this->lookupEntityType)
       ->load($result)) {
-      $this->updateEntity($existing, $value);
+      $this->updateEntity($entity, $value);
     }
 
     return $result;
@@ -136,13 +139,7 @@ class AhjoEntityGenerate extends EntityLookup {
       }
     }
     foreach ($this->configuration['values'] as $key => $property) {
-      if ($property === 'root_json') {
-        $source_value = $value;
-      }
-      else {
-        $source_value = $value[$property] ?? NULL;
-      }
-
+      $source_value = $value[$property] ?? NULL;
       $this->preprocessValue($key, $source_value);
       NestedArray::setValue($entity_values, explode(Row::PROPERTY_SEPARATOR, $key), $source_value, TRUE);
     }
@@ -162,7 +159,7 @@ class AhjoEntityGenerate extends EntityLookup {
     if ($value === NULL) {
       return;
     }
-    if ($name === 'root_json') {
+    if ($name === 'PDF' || $name === 'root_json') {
       $value = json_encode($value);
     }
   }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoEntityGenerate.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoEntityGenerate.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Plugin\migrate\process;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate_plus\Plugin\migrate\process\EntityLookup;
+
+/**
+ * This plugin generates entities within the process plugin.
+ *
+ * Based on EntityGenerate. Works with multiple values array.
+ * For single value use "plugin: single_value".
+ *
+ * Available configuration keys:
+ * - source_key: (required) the source field property that math the entity
+ * field in `value_key`.
+ * - values: (required) entity fields mapped to the source field properties.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "ahjo_entity_generate"
+ * )
+ *
+ * @see EntityLookup, EntityGenerate
+ */
+class AhjoEntityGenerate extends EntityLookup {
+
+  /**
+   * The lookup source key.
+   *
+   * @var string
+   */
+  protected string $lookupSourceKey;
+
+  /**
+   * The row from the source to process.
+   *
+   * @var \Drupal\migrate\Row
+   */
+  protected Row $row;
+
+  /**
+   * The migrate executable.
+   *
+   * @var \Drupal\migrate\MigrateExecutableInterface
+   */
+  protected MigrateExecutableInterface $migrateExecutable;
+
+  /**
+   * Performs the associated process.
+   *
+   * {@inheritdoc}
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function transform($value, MigrateExecutableInterface $migrateExecutable, Row $row, $destinationProperty) {
+    // If the source data is an empty array, return the same.
+    if (gettype($value) === 'array' && count($value) === 0) {
+      return [];
+    }
+    $this->row = $row;
+    $this->migrateExecutable = $migrateExecutable;
+    $this->lookupSourceKey = $this->configuration['source_key'];
+
+    // Creates an entity if the lookup determines it doesn't exist.
+    $lookup_value = $value[$this->lookupSourceKey] ?? [];
+    if (!($result = parent::transform($lookup_value, $migrateExecutable, $row, $destinationProperty))) {
+      $result = $this->generateEntity($value);
+    }
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $existing */
+    elseif ($existing = $this->entityTypeManager->getStorage($this->lookupEntityType)
+      ->load($result)) {
+      $this->updateEntity($existing, $value);
+    }
+
+    return $result;
+  }
+
+  /**
+   * Generates an entity for a given value.
+   *
+   * @param mixed $value
+   *   Value to use in creation of the entity.
+   *
+   * @return int|string|null
+   *   The entity id of the generated entity.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function generateEntity($value) {
+    if (empty($value)) {
+      return;
+    }
+    if (!is_array($value)) {
+      return;
+    }
+
+    $entity = $this->entityTypeManager
+      ->getStorage($this->lookupEntityType)
+      ->create($this->entity($value));
+    $entity->save();
+
+    return $entity->id();
+  }
+
+  /**
+   * Fabricate an entity.
+   *
+   * This is intended to be extended by implementing classes to provide for more
+   * dynamic default values, rather than just static ones.
+   *
+   * @param array $value
+   *   Primary value to use in creation of the entity.
+   *
+   * @return array
+   *   Entity value array.
+   */
+  protected function entity(array $value): array {
+    $entity_values = [];
+
+    if ($this->lookupBundleKey) {
+      $entity_values[$this->lookupBundleKey] = $this->lookupBundle;
+    }
+    // Gather any static default values for properties/fields.
+    if (isset($this->configuration['default_values']) && is_array($this->configuration['default_values'])) {
+      foreach ($this->configuration['default_values'] as $key => $default_value) {
+        NestedArray::setValue($entity_values, explode(Row::PROPERTY_SEPARATOR, $key), $default_value, TRUE);
+      }
+    }
+    foreach ($this->configuration['values'] as $key => $property) {
+      if ($property === 'root_json') {
+        $source_value = $value;
+      }
+      else {
+        $source_value = $value[$property] ?? NULL;
+      }
+
+      $this->preprocessValue($key, $source_value);
+      NestedArray::setValue($entity_values, explode(Row::PROPERTY_SEPARATOR, $key), $source_value, TRUE);
+    }
+
+    return $entity_values;
+  }
+
+  /**
+   * Preprocess a parameter value if needed.
+   *
+   * @param string $name
+   *   The name of the param.
+   * @param mixed $value
+   *   The value of the param.
+   */
+  protected function preprocessValue(string $name, &$value): void {
+    if ($value === NULL) {
+      return;
+    }
+    if ($name === 'root_json') {
+      $value = json_encode($value);
+    }
+  }
+
+  /**
+   * Update entity fields.
+   *
+   * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+   *   The entity to update.
+   * @param array $values
+   *   The new values.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  protected function updateEntity(FieldableEntityInterface $entity, array $values): void {
+    $updated = FALSE;
+    foreach ($this->configuration['values'] as $field_name => $property) {
+      if ($field_name == $this->lookupValueKey || $field_name == $this->lookupBundleKey) {
+        continue;
+      }
+
+      if ($property === 'root_json') {
+        $source_value = $values;
+      }
+      else {
+        $source_value = $values[$property] ?? NULL;
+      }
+
+      $this->preprocessValue($property, $source_value);
+
+      $field = $entity->get($field_name);
+      if ($field->isEmpty() && !isset($source_value)) {
+        continue;
+      }
+      if ($field->value == $source_value) {
+        continue;
+      }
+      $field->set(0, $source_value);
+      $updated = TRUE;
+    }
+
+    if ($updated) {
+      $entity->save();
+    }
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -97,10 +97,12 @@ class AhjoAggregatorCommands extends DrushCommands {
     switch ($endpoint) {
       case 'meetings':
         $timestamp_key = 'start';
+        $timestamp_key_end = 'end';
         break;
 
       default:
         $timestamp_key = 'handledsince';
+        $timestamp_key_end = 'handledbefore';
         break;
     }
 
@@ -119,7 +121,7 @@ class AhjoAggregatorCommands extends DrushCommands {
     }
 
     if (!empty($options['end'])) {
-      $query_string .= '&handledbefore=' . $options['end'];
+      $query_string .= '&'. $timestamp_key_end . '=' . $options['end'];
     }
 
     if ($endpoint === 'cases' || $endpoint === 'decisions') {

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -121,7 +121,7 @@ class AhjoAggregatorCommands extends DrushCommands {
     }
 
     if (!empty($options['end'])) {
-      $query_string .= '&'. $timestamp_key_end . '=' . $options['end'];
+      $query_string .= '&' . $timestamp_key_end . '=' . $options['end'];
     }
 
     if ($endpoint === 'cases' || $endpoint === 'decisions') {


### PR DESCRIPTION
This adds handling for meeting documents and agenda files as media entities in Drupal.

**To test**
- Checkout branch
- Run `make new` or SSH into the container and run `drush cr; drush cim -y`
- You might have to reset the Helsinki Kanava settings after config import: https://helsinki-paatokset.docker.so/fi/admin/config/helsinki-kanava/settings
- Inside the container, run: `drush ap:fs; drush mim ahjo_meetings:latest`
- Check that Ahjo Document media items were created:  https://helsinki-paatokset.docker.so/fi/admin/content/media?name=&type=ahjo_document&status=All&langcode=All
  - Check a few and make sure fields were actually populated based on the data stored in the JSON field. The Issued field might be empty on most files.
- Check that the meetings listing has content: https://helsinki-paatokset.docker.so/fi/admin/content/meetings
  - Find a meeting with both Agenda and Minutes published and go into the edit view
  - Make sure the meeting has media references in the **Meeting Data > Agenda** and **Meeting Data > Meeting Documents** sections