### PR TITLE
PP-257: PP-257: fixed accessibility issues in policymaker calendar

### DIFF
--- a/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-calendar.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-calendar.html.twig
@@ -34,9 +34,13 @@
                 {{ open_minutes }}
                 <i class="hds-icon hds-icon--angle-right"></i>
               </a>
-            {% elseif row.motions_list_link %}
-              <a href="{{row.motions_list_link}}">{{ open_motions }}</a>
-              <i class="hds-icon hds-icon--angle-right"></i>
+            </td>
+          {% elseif row.motions_list_link %}
+            <td>
+              <a href="{{row.motions_list_link}}">
+                {{ open_motions }}
+                <i class="hds-icon hds-icon--angle-right"></i>
+              </a>
             </td>
           {% endif %}
         </tr>

--- a/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-calendar.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-calendar.html.twig
@@ -14,29 +14,35 @@
     {% endif %}
   </div>
   <table class="policymaker-calendar__table">
-    <tr class="policymaker-calendar__table-header policymaker-calendar__table-row">
-      <th>{{ date }}</th>
-      <th>{{ time }}</th>
-      <th>{{ additional_info }}</th>
-    </tr>
-    {% for date, meeting in meetings %}
-      {% for row in meeting %}
-      <tr class="policymaker-calendar__table-row">
-        <th>{{ date|date("d.m.Y") }}</th>
-        <th>{{ row.start_time}}</th>
-        <th>Some info</th>
-        <th>
-          {% if row.minutes_link %}
-            <a href="{{row.minutes_link}}">{{ open_minutes }}</a>
-            <i class="hds-icon hds-icon--angle-right"></i>
-          {% elseif row.motions_list_link %}
-            <a href="{{row.motions_list_link}}">{{ open_motions }}</a>
-            <i class="hds-icon hds-icon--angle-right"></i>
-          {% endif %}
-        </th>
+    <thead>
+      <tr class="policymaker-calendar__table-header policymaker-calendar__table-row">
+        <th>{{ date }}</th>
+        <th>{{ time }}</th>
+        <th>{{ additional_info }}</th>
       </tr>
+    </thead>
+    <tbody>
+      {% for date, meeting in meetings %}
+        {% for row in meeting %}
+        <tr class="policymaker-calendar__table-row">
+          <td>{{ date|date("d.m.Y") }}</td>
+          <td>{{ row.start_time}}</td>
+          <td>Some info</td>
+          {% if row.minutes_link %}
+            <td>
+              <a href="{{row.minutes_link}}">
+                {{ open_minutes }}
+                <i class="hds-icon hds-icon--angle-right"></i>
+              </a>
+            {% elseif row.motions_list_link %}
+              <a href="{{row.motions_list_link}}">{{ open_motions }}</a>
+              <i class="hds-icon hds-icon--angle-right"></i>
+            </td>
+          {% endif %}
+        </tr>
+        {% endfor %}
       {% endfor %}
-    {% endfor %}
+    </tbody>
   </table>
 </div>
 {% endif %}

--- a/public/themes/custom/helfi_paatokset/src/scss/components/block/_policymaker_calendar.scss
+++ b/public/themes/custom/helfi_paatokset/src/scss/components/block/_policymaker_calendar.scss
@@ -10,30 +10,17 @@
   display: table;
   border-collapse: collapse;
 
-  tr:first-child th {
-    padding-top: 0;
+  thead {
+    background-color: white;
   }
 
-  th {
+  th,
+  td {
     background-color: $color-white;
     color: $color-black;
     padding: $spacing-and-half 0;
     padding-right: $spacing-and-half;
     font-weight: 400;
-  }
-
-  th a {
-    color: $color-black;
-  }
-
-  .hds-icon--angle-right {
-    width: 1rem;
-    height: 1rem;
-    margin-left: $spacing;
-
-    @media (max-width: $breakpoint-s) {
-      margin-left: $spacing-xs;
-    }
   }
 
   @media (max-width: $breakpoint-s) {
@@ -46,6 +33,7 @@
 .policymaker-calendar__table-header {
   th {
     font-weight: 500;
+    padding-top: 0;
   }
 
   @media (max-width: $breakpoint-s) {
@@ -61,7 +49,7 @@
   border-bottom: 1px solid $color-black-20;
 
   &:hover {
-    background-color: none;
+    background-color: transparent;
   }
 
   th:last-of-type {
@@ -74,28 +62,49 @@
     display: flex;
     flex-wrap: wrap;
     width: 100%;
+    padding: 16px 0;
 
     th {
       padding: $spacing-half;
+    }
+
+    td {
+      padding: $spacing-half;
+      border-bottom: none !important;
 
       &:first-of-type {
         font-weight: 500;
-        margin-top: $spacing;
       }
 
-      &:last-of-type {
-        margin-bottom: $spacing;
+      &:last-of-type a {
+        display: flex;
+        align-items: center;
+        color: $color-black;
+        white-space: nowrap;
+    
+        .hds-icon--angle-right {
+          width: 16px;
+          height: 16px;
+        }
       }
     }
 
     th:nth-of-type(1),
-    th:nth-of-type(2) {
+    th:nth-of-type(2),
+    td:nth-of-type(1),
+    td:nth-of-type(2) {
       width: 50%;
       padding-right: 0;
     }
 
+    td:nth-of-type(2) {
+      text-align: right;
+    }
+
     th:nth-of-type(3),
-    th:nth-of-type(4) {
+    th:nth-of-type(4),
+    td:nth-of-type(3),
+    td:nth-of-type(4) {
       width: 100%;
     }
   }


### PR DESCRIPTION
Ticket: https://helsinkisolutionoffice.atlassian.net/browse/PP-257

Fixed table structure according to comments specified in ticket. Fixed also mobile view that had some alignment issues.

How to test: 

Checkout branch and run `drush cr`. Go to some policymaker page i.ex. https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto and make sure it has some upcoming meetings (edit some to the future if not) so that the calendar will be visible on the page. 
Check the table structure that it is correct now.