### PR TITLE
PP-238: Policymakers search

### DIFF
--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -1,0 +1,72 @@
+uuid: 12bb4aa9-6b87-4620-bc82-d39937dacc3b
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organization_type
+    - search_api.server.elasticsearch
+  module:
+    - node
+    - search_api
+    - paatokset_search
+id: policymakers
+name: Policymakers
+description: ''
+read_only: false
+field_settings:
+  field_organization_type:
+    label: 'Organization type'
+    datasource_id: 'entity:node'
+    property_path: field_organization_type
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_organization_type
+  organ:
+    label: Organ
+    datasource_id: 'entity:node'
+    property_path: organ
+    type: string
+  sector:
+    label: Sector
+    datasource_id: 'entity:node'
+    property_path: sector
+    type: string
+  title:
+    label: Otsikko
+    datasource_id: 'entity:node'
+    property_path: title
+    type: text
+    dependencies:
+      module:
+        - node
+  url:
+    label: URI
+    property_path: search_api_url
+    type: string
+    configuration:
+      absolute: false
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: false
+      selected:
+        - policymaker
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  language_with_fallback: {  }
+  organ_json: {  }
+  rendered_item: {  }
+  sector_json: {  }
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: true
+  track_changes_in_references: true
+  cron_limit: 50
+server: elasticsearch

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/OrganJSON.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/OrganJSON.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\paatokset_search\Plugin\search_api\processor;
+
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+
+/**
+ * Adds the item's view count to the indexed data.
+ *
+ * @SearchApiProcessor(
+ *   id = "organ_json",
+ *   label = @Translation("Organ"),
+ *   description = @Translation("Adds organ info from JSON object"),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class OrganJSON extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if ($datasource) {
+      $definition = [
+        'label' => $this->t('Organ'),
+        'description' => $this->t('Organ value from JSON object'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['organ'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $datasourceId = $item->getDatasourceId();
+    if ($datasourceId == 'entity:node') {
+      $node = $item->getOriginalObject()->getValue();
+      $organData = $node->get('field_dm_org_above')->value;
+
+      if ($organData && $organData !== 'null') {
+        $parsed = json_decode($organData);
+        if (isset($parsed->organizations) && isset($parsed->organizations[0]->Name)) {
+          $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), 'entity:node', 'organ');
+          foreach ($fields as $field) {
+            $field->addValue($parsed->organizations[0]->Name);
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorJSON.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorJSON.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\paatokset_search\Plugin\search_api\processor;
+
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+
+/**
+ * Adds the item's view count to the indexed data.
+ *
+ * @SearchApiProcessor(
+ *   id = "sector_json",
+ *   label = @Translation("Sector"),
+ *   description = @Translation("Adds sector info from JSON object"),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class SectorJSON extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if ($datasource) {
+      $definition = [
+        'label' => $this->t('Sector'),
+        'description' => $this->t('Sector value from JSON object'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['sector'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $datasourceId = $item->getDatasourceId();
+    if ($datasourceId == 'entity:node') {
+      // This is a node entity so we need to find out if it has a view count.
+      $node = $item->getOriginalObject()->getValue();
+      $sectorData = $node->get('field_dm_sector')->value;
+
+      if ($sectorData && $sectorData !== 'null') {
+        $parsed = json_decode($sectorData);
+        if (isset($parsed->Sector)) {
+          $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), 'entity:node', 'sector');
+          foreach ($fields as $field) {
+            $field->addValue($parsed->Sector);
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
To test:

- Run `make new` or `drush cr && drush cim -y`
-  Check https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api. There should be a new 'Policymakers' index.
- Go to https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/policymakers. Build the index data from the controls at the bottom of the page.