### PR TITLE
PP-252 policymaker fixes

### DIFF
--- a/conf/cmi/core.entity_view_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.default.yml
@@ -35,7 +35,11 @@ bundle: meeting
 mode: default
 content:
   field_meeting_agenda:
+<<<<<<< HEAD
     type: json
+=======
+    weight: 15
+>>>>>>> PP-252: Add custom link to meetings to minutes page.
     label: above
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.default.yml
@@ -39,7 +39,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 14
+    weight: 15
     region: content
   field_meeting_agenda_files:
     type: entity_reference_entity_view
@@ -58,14 +58,14 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   field_meeting_attachment_info:
     type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 8
+    weight: 9
     region: content
   field_meeting_composition:
     type: json
@@ -88,7 +88,7 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 13
+    weight: 14
     region: content
   field_meeting_dm:
     type: string
@@ -96,7 +96,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 9
+    weight: 10
     region: content
   field_meeting_dm_id:
     type: string
@@ -104,7 +104,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 10
+    weight: 11
     region: content
   field_meeting_document_files:
     type: entity_reference_entity_view
@@ -128,7 +128,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   field_meeting_location:
     type: string
@@ -136,7 +136,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   field_meeting_minutes_published:
     type: boolean
@@ -146,7 +146,7 @@ content:
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   field_meeting_next:
     type: json
@@ -161,7 +161,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 11
+    weight: 12
     region: content
   field_meeting_prev:
     type: json
@@ -176,7 +176,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 12
+    weight: 13
     region: content
   field_meeting_sequence_number:
     type: number_integer
@@ -185,7 +185,7 @@ content:
       thousand_separator: ''
       prefix_suffix: true
     third_party_settings: {  }
-    weight: 7
+    weight: 8
     region: content
   field_meeting_status:
     type: string
@@ -193,12 +193,17 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  meeting_link:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
     region: content
 hidden:
   langcode: true

--- a/conf/cmi/core.entity_view_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.default.yml
@@ -35,11 +35,7 @@ bundle: meeting
 mode: default
 content:
   field_meeting_agenda:
-<<<<<<< HEAD
     type: json
-=======
-    weight: 15
->>>>>>> PP-252: Add custom link to meetings to minutes page.
     label: above
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.contact_card.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.contact_card.yml
@@ -63,6 +63,7 @@ hidden:
   call_charge_info: true
   created: true
   description: true
+  hide_description: true
   langcode: true
   latitude: true
   longitude: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -30,6 +30,7 @@ hidden:
   created: true
   description: true
   email: true
+  hide_description: true
   langcode: true
   latitude: true
   longitude: true

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -1,4 +1,4 @@
-uuid: null
+uuid: 1ca8c7d7-8c15-4632-b077-d42d694b4d1d
 langcode: en
 status: true
 dependencies:

--- a/public/modules/custom/paatokset_ahjo/js/meetings_calendar.js
+++ b/public/modules/custom/paatokset_ahjo/js/meetings_calendar.js
@@ -39,12 +39,12 @@
                   <h5 class="meeting-title">{{meeting.title}}</h5>
                   <div class="meeting-start-time">{{ meeting.start_time}}</div>
                   <template v-if="meeting.decision_link">
-                    <a :href="meeting.minutes_link">
+                    <a :href="meeting.decision_link">
                       {{ openDecisions }}
                       <i class="hds-icon hds-icon--angle-right"></i>
                     </a>
                   </template>
-                  <template v-else-if="meeting.minutes_link && meeting.motions_list_link">
+                  <template v-else-if="meeting.minutes_link">
                     <a :href="meeting.minutes_link">
                       {{ openMinutes }}
                       <i class="hds-icon hds-icon--angle-right"></i>
@@ -61,13 +61,13 @@
               <template v-else>
                 <div class="no-meetings meeting-title">{{ Drupal.t('Ei kokouksia')}}</div>
               </template>
-              
+
             </li>
           </ol>
         </div>
       </div>
       `
-      
+
       /* URL to get all meetings */
       const yearAgo = dayjs().subtract(1, "year").format("YYYY-MM-DD");
       const dataURL = window.location.origin + '/fi/ahjo_api/meetings?from=' + yearAgo;
@@ -97,7 +97,7 @@
                   day.meetings = self.meetings[date]
                 }
               });
-              
+
               self.daysWithMeetings = temp;
             })
           },
@@ -227,9 +227,9 @@
             const previousMonth = dayjs(`${this.year}-${this.month}-01`).subtract(1, "month");
 
             const visibleNumberOfDaysFromPreviousMonth = firstDayOfTheMonthWeekday ? firstDayOfTheMonthWeekday - 1 : 6;
-        
+
             const previousMonthLastMondayDayOfMonth = dayjs(this.currentMonthDays[0].date).subtract(visibleNumberOfDaysFromPreviousMonth, "day").date();
-            
+
             //Doesn't add previous days if the first day of the month is saturday or sunday
             if(firstDayOfTheMonthWeekday !== 6 && firstDayOfTheMonthWeekday !== 0) {
               return [...Array(visibleNumberOfDaysFromPreviousMonth)].map((day, index) => {
@@ -245,7 +245,7 @@
             const lastDayOfTheMonthWeekday = dayjs(`${this.year}-${this.month}-${this.currentMonthDays.length}`).day();
             const nextMonth = dayjs(`${this.year}-${this.month}-01`).add(1, "month");
             const visibleNumberOfDaysFromNextMonth = lastDayOfTheMonthWeekday ? 7 - lastDayOfTheMonthWeekday : lastDayOfTheMonthWeekday;
-        
+
             return [...Array(visibleNumberOfDaysFromNextMonth)].map((day, index) => {
               return {
                 date: dayjs(`${nextMonth.year()}-${nextMonth.month() + 1}-${index + 1}`).format("YYYY-MM-DD"),

--- a/public/modules/custom/paatokset_ahjo/templates/component/document.html.twig
+++ b/public/modules/custom/paatokset_ahjo/templates/component/document.html.twig
@@ -29,12 +29,4 @@
       {% endif %}
     </a>
   </div>
-  {% if document.origin_url %}
-    <div class="paatokset_download-link-container">
-      <a class="paatokset__link-plain" href="{{ document.origin_url }}" download>
-        {% include '@hdbt/misc/icon.twig' with {icon: 'document'} %}
-        {{ 'Lataa tulostettava versio (PDF)'|trans }}
-      </a>
-    </div>
-  {% endif %}
 </div>

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_trustees.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_trustees.yml
@@ -67,6 +67,14 @@ process:
     plugin: default_value
     source: name
     default_value: 'NO TITLE'
+  field_first_name:
+    plugin: callback
+    callable: _paatokset_ahjo_api_get_first_name
+    source: name
+  field_last_name:
+    plugin: callback
+    callable: _paatokset_ahjo_api_get_last_name
+    source: name
   field_trustee_title: title
   field_trustee_id: agent_id
   field_trustee_council_group: council_group

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.info.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.info.yml
@@ -7,3 +7,4 @@ core_version_requirement: ^8 || ^9
 dependencies:
   - drupal:paatokset_ahjo_proxy
   - drupal:paatokset_ahjo_openid
+  - drupal:paatokset_policymakers

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -9,6 +9,9 @@ declare(strict_types = 1);
 
 use Drupal\Core\Render\Element;
 use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Link;
 
 /**
  * Implements hook_theme().
@@ -141,9 +144,9 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
   $variables['accordions'][] = [
     'Kaupinginhallituksen jaostot' => $hallituksen_jaosto,
     'Lautakunnat ja jaostot' => array_merge($lautakunta, $accorion_contents['jaosto'][1]),
-    'Viranhaltijat' => $accorion_contents['viranhaltija'][1], 
-    'Luottamushenkilöpäättäjät' => $accorion_contents['trustee'][1], 
-    'Luottamushenkilöt' => $trustees, 
+    'Viranhaltijat' => $accorion_contents['viranhaltija'][1],
+    'Luottamushenkilöpäättäjät' => $accorion_contents['trustee'][1],
+    'Luottamushenkilöt' => $trustees,
   ];
 
   $variables['title'] = $variables['elements']['content']['label'];
@@ -325,6 +328,40 @@ function _paatokset_ahjo_api_meeting_minutes_published($documents): bool {
   }
 
   return FALSE;
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function paatokset_ahjo_api_entity_extra_field_info(): array {
+  $extra['node']['meeting']['display']['meeting_link'] = [
+    'label' => t('Meeting minutes link.'),
+    'description' => t('Meeting minutes link under policymaker page.'),
+    'weight' => 0,
+    'visible' => FALSE,
+  ];
+
+  return $extra;
+}
+
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function paatokset_ahjo_api_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode): void {
+  if ($entity->id() === NULL) {
+    return;
+  }
+
+  /** @var \Drupal\node\NodeInterface $entity */
+  if ($display->getComponent('meeting_link')) {
+    /** @var \Drupal\paatokset_ahjo_api\Service\MeetingService $meetingService */
+    $meetingService = \Drupal::service('paatokset_ahjo_meetings');
+    $link = $meetingService->getMeetingLink($entity);
+    if ($link instanceof Link) {
+      $build['meeting_link'] = $link->toRenderable();
+    }
+  }
 }
 
 /**

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -330,6 +330,35 @@ function _paatokset_ahjo_api_meeting_minutes_published($documents): bool {
   return FALSE;
 }
 
+
+/**
+ * Get first name.
+ *
+ * @param mixed $value
+ *   The value to work with.
+ *
+ * @return string
+ *   First name from formatted name string.
+ */
+function _paatokset_ahjo_api_get_first_name($value): string {
+  $bits = explode(', ', (string) $value);
+  return (string) array_shift(array_slice($bits, -1));
+}
+
+/**
+ * Get last name.
+ *
+ * @param mixed $value
+ *   The value to work with.
+ *
+ * @return string
+ *   First name from formatted name string.
+ */
+function _paatokset_ahjo_api_get_last_name($value): string {
+  $bits = explode(', ', (string) $value);
+  return (string) array_shift(array_slice($bits, 0, 1));
+}
+
 /**
  * Implements hook_entity_extra_field_info().
  */

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -7,6 +7,7 @@ use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Service class for retrieving meeting-related data.
@@ -188,6 +189,49 @@ class MeetingService {
     }
   }
 
+  /**
+   * Get Meeting minutes Link.
+   *
+   * @param NodeInterface $node
+   *   Meeting node.
+   *
+   * @return Link|null
+   *   URL as string, if possible to get.
+   */
+  public function getMeetingLink(NodeInterface $node): ?Link {
+
+    if (!$node->hasField('field_meeting_id') || !$node->hasField('field_meeting_dm_id')) {
+      return NULL;
+    }
+
+    $meeting_id = $node->get('field_meeting_id')->value;
+    $policymaker_id = $node->get('field_meeting_dm_id')->value;
+
+    if (!$meeting_id || !$policymaker_id) {
+      return NULL;
+    }
+
+    /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
+    $policymakerService = \Drupal::service('paatokset_policymakers');
+    $url = $policymakerService->getMinutesRoute($meeting_id, $policymaker_id);
+    if (!$url instanceof Url) {
+      return NULL;
+    }
+
+    $text = t('Meeting minutes.');
+
+    return Link::fromTextAndUrl($text, $url);
+  }
+
+  /**
+   * Get Meeting minutes URL.
+   *
+   * @param NodeInterface $node
+   *   Meeting node.
+   *
+   * @return string|null
+   *   URL as string, if possible to get.
+   */
   public function getMeetingUrl(NodeInterface $node): ?string {
     /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
     $policymakerService = \Drupal::service('paatokset_policymakers');

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -310,11 +310,13 @@ class MeetingService {
    *   Meeting entity.
    * @param string $document_type
    *   Document type, for example: 'esityslista', 'pöytäkirja'.
+   * @param string $langcode
+   *   Document language, defaults to 'fi'.
    *
    * @return \Drupal\media\MediaInterface|null
    *   Meeting minutes media entity, if one exists for the meeting.
    */
-  public function getDocumentFromEntity(NodeInterface $entity, string $document_type): ?MediaInterface {
+  public function getDocumentFromEntity(NodeInterface $entity, string $document_type, string $langcode = 'fi'): ?MediaInterface {
     if (!$entity->hasField('field_meeting_documents') || $entity->get('field_meeting_documents')->isEmpty()) {
       return NULL;
     }
@@ -322,6 +324,10 @@ class MeetingService {
     $minutes_id = NULL;
     foreach ($entity->get('field_meeting_documents') as $field) {
       $json = json_decode($field->value, TRUE);
+      if (isset($json['Language']) && $json['Language'] !== $langcode) {
+        continue;
+      }
+
       if (isset($json['Type']) && isset($json['NativeId']) && $json['Type'] === $document_type) {
         $minutes_id = $json['NativeId'];
         break;

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -105,7 +105,7 @@ class MeetingService {
       if ($node->get('field_meeting_minutes_published')->value) {
         $transformedResult['minutes_link'] = $this->getMeetingUrl($node);
       }
-      else if ($node->get('field_meeting_agenda_published')->value) {
+      elseif ($node->get('field_meeting_agenda_published')->value) {
         $transformedResult['motions_list_link'] = $this->getMeetingUrl($node);
       }
 
@@ -192,10 +192,10 @@ class MeetingService {
   /**
    * Get Meeting minutes Link.
    *
-   * @param NodeInterface $node
+   * @param \Drupal\node\NodeInterface $node
    *   Meeting node.
    *
-   * @return Link|null
+   * @return \Drupal\Core\Link|null
    *   URL as string, if possible to get.
    */
   public function getMeetingLink(NodeInterface $node): ?Link {
@@ -226,7 +226,7 @@ class MeetingService {
   /**
    * Get Meeting minutes URL.
    *
-   * @param NodeInterface $node
+   * @param \Drupal\node\NodeInterface $node
    *   Meeting node.
    *
    * @return string|null

--- a/public/modules/custom/paatokset_ahjo_api/templates/content/node--meeting.html.twig
+++ b/public/modules/custom/paatokset_ahjo_api/templates/content/node--meeting.html.twig
@@ -100,6 +100,13 @@
         </div>
       {% endif %}
     </div>
-  </div>
 
+    {% if content.meeting_link|render %}
+      <div>
+        {{ content.meeting_link }}
+      </div>
+    {% endif %}
+
+
+  </div>
 </article>

--- a/public/modules/custom/paatokset_policymakers/js/policymaker_members.js
+++ b/public/modules/custom/paatokset_policymakers/js/policymaker_members.js
@@ -58,53 +58,7 @@
         el: '#policymaker-members-vue',
         template: markup,
         data: {
-          members: [
-            {
-              'first_name': 'Aki',
-              'last_name': 'Hyödynmaa',
-              'role': 'Varajäsen',
-              'links': [],
-              'deputyOf': 'Salla Korhonen',
-              'email' : 'etunimi.sukunimi@email.com',
-              'party' : 'Vasemmisto'
-            },
-            {
-              'first_name': 'Antti',
-              'last_name': 'Vuorela',
-              'role': 'Varapuheenjohtaja',
-              'links': [],
-              'deputyOf': null,
-              'email' : 'etunimi.sukunimi@email.com',
-              'party' : 'Kokoomus'
-            },
-            {
-              'first_name': 'Mikko',
-              'last_name': 'Mallikas',
-              'role': 'Varajäsen',
-              'links': [],
-              'deputyOf': null,
-              'email' : 'etunimi.sukunimi@email.com',
-              'party' : 'Kokoomus'
-            },
-            {
-              'first_name': 'Testi',
-              'last_name': 'Testinen',
-              'role': 'Joku rooli',
-              'links': [],
-              'deputyOf': null,
-              'email' : 'etunimi.sukunimi@email.com',
-              'party' : 'Kokoomus'
-            },
-            {
-              'first_name': 'Joku',
-              'last_name': 'Jokunen',
-              'role': 'Varajäsen',
-              'links': [],
-              'deputyOf': null,
-              'email' : 'etunimi.sukunimi@email.com',
-              'party' : 'Kokoomus'
-            }
-          ],
+          members: [],
           isReady: false,
           search: '',
           filters: {
@@ -122,8 +76,6 @@
         },
         methods: {
           getJson() {
-            /*
-            Remove comment once dataURL is set
             const self = this;
             $.getJSON(dataURL, function(data) {
               self.members = data;
@@ -135,7 +87,7 @@
             })
             .done(function( json ) {
               self.isReady = true;
-            })*/
+            })
 
             const parties = this.members.map(a => a.party).filter(function (el) {
               return el != null;
@@ -155,14 +107,17 @@
             this.active_checkboxes = temp_filters;
           },
           processEmail(email) {
-            return email.replace("@", " (at) ")
+            if (email) {
+              return email.replace("@", " (at) ")
+            }
+            return null;
           }
         },
         computed: {
           filteredMembers() {
             let temp_results = this.members;
             temp_results = temp_results.filter(result => {
-              return result.first_name.toLowerCase().includes(this.search.toLowerCase()) || result.last_name.toLowerCase().includes(this.search.toLowerCase()) 
+              return result.first_name.toLowerCase().includes(this.search.toLowerCase()) || result.last_name.toLowerCase().includes(this.search.toLowerCase())
             })
 
             if(!this.active_checkboxes.includes('deputy_member')) {

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -470,7 +470,14 @@ class PolicymakerService {
         continue;
       }
 
-      $document_timestamp = strtotime($document->get('field_document_issued')->value);
+      // If document doesn't have issued date, use meeting date (e.g agendas).
+      if ($document->hasField('field_document_issued') && !$document->get('field_document_issued')->isEmpty()) {
+        $document_timestamp = strtotime($document->get('field_document_issued')->value);
+      }
+      else {
+        $document_timestamp = $meeting_timestamp;
+      }
+
 
       $result = [
         'publish_date' => date('d.m.Y', $document_timestamp),
@@ -553,8 +560,14 @@ class PolicymakerService {
     }
 
     if ($document instanceof MediaInterface) {
-      $document_timestamp = strtotime($document->get('field_document_issued')->value);
-      $publishDate = date('d.m.Y', $document_timestamp);
+      if ($document->hasField('field_document_issued') && !$document->get('field_document_issued')->isEmpty()) {
+        $document_timestamp = strtotime($document->get('field_document_issued')->value);
+        $publishDate = date('d.m.Y', $document_timestamp);
+      }
+      else {
+        $publishDate = FALSE;
+      }
+
       $fileUrl = $meetingService->getUrlFromAhjoDocument($document);
     }
 

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -233,11 +233,17 @@ class PolicymakerService {
    *
    * @param string $id
    *   Meeting ID.
+   * @param string|null $policymaker_id
+   *   Policymaker ID. NULL if using default.
    *
    * @return Drupal\Core\Url|null
    *   URL object, if route is valid.
    */
-  public function getMinutesRoute(string $id): ?Url {
+  public function getMinutesRoute(string $id, ?string $policymaker_id = NULL): ?Url {
+    if (!empty($policymaker_id)) {
+      $this->setPolicyMaker($policymaker_id);
+    }
+
     if ($this->policymaker->get('field_organization_type')->value === 'Luottamushenkilö') {
       return NULL;
     }
@@ -558,6 +564,7 @@ class PolicymakerService {
     }
     else {
       $pageTitle = t('Meeting');
+      $documentTitle = NULL;
     }
 
     if ($document instanceof MediaInterface) {

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -469,9 +469,9 @@ class PolicymakerService {
    */
   private function getTrusteeNodesByName(array $names): ?array {
     $query = \Drupal::entityQuery('node')
-    ->condition('status', 1)
-    ->condition('type', 'trustee')
-    ->condition('title', $names, 'IN');
+      ->condition('status', 1)
+      ->condition('type', 'trustee')
+      ->condition('title', $names, 'IN');
 
     $ids = $query->execute();
 
@@ -487,6 +487,8 @@ class PolicymakerService {
    *
    * @param string $name
    *   Name to format.
+   * @param bool $alt_format
+   *   Use alternative formatting (multiple last names).
    *
    * @return string
    *   Name formatted to: Lastname, Firstname
@@ -494,8 +496,8 @@ class PolicymakerService {
   private function formatTrusteeName(string $name, $alt_format = FALSE): string {
     $bits = explode(' ', $name);
     if ($alt_format && count($bits) > 2) {
-      $last_names = implode(' ' , array_slice($bits, -2));
-      $first_names = implode(' ' , array_slice($bits, 0 , -2));
+      $last_names = implode(' ', array_slice($bits, -2));
+      $first_names = implode(' ', array_slice($bits, 0, -2));
     }
     else {
       $last_names = array_pop($bits);
@@ -565,7 +567,6 @@ class PolicymakerService {
       else {
         $document_timestamp = $meeting_timestamp;
       }
-
 
       $result = [
         'publish_date' => date('d.m.Y', $document_timestamp),
@@ -689,9 +690,8 @@ class PolicymakerService {
   /**
    * Get agenda items.
    *
-   * @param \Drupal\Core\Field\FieldItemListInterface $field
+   * @param \Drupal\Core\Field\FieldItemListInterface $list_field
    *   Field to get agenda items from.
-   *
    * @param string $langcode
    *   Langcode to use.
    *

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -538,7 +538,8 @@ class PolicymakerService {
     $meeting_timestamp = strtotime($meeting->get('field_meeting_date')->value);
 
     $dateLong = date('d.m.Y', $meeting_timestamp);
-    $dateShort = date('m/Y', $meeting_timestamp);
+    $meetingNumber = $meeting->get('field_meeting_sequence_number')->value;
+    $meetingYear = date('Y', $meeting_timestamp);
     $policymaker_title = $this->policymaker->get('title')->value;
     $agendaItems = NULL;
     $publishDate = NULL;
@@ -565,7 +566,7 @@ class PolicymakerService {
         $publishDate = date('d.m.Y', $document_timestamp);
       }
       else {
-        $publishDate = FALSE;
+        $publishDate = NULL;
       }
 
       $fileUrl = $meetingService->getUrlFromAhjoDocument($document);
@@ -575,6 +576,7 @@ class PolicymakerService {
     foreach ($meeting->get('field_meeting_agenda') as $item) {
 
       $data = json_decode($item->value, TRUE);
+
       if (!$data) {
         continue;
       }
@@ -592,9 +594,16 @@ class PolicymakerService {
         $agenda_link = NULL;
       }
 
+      if (!empty($data['Section'])) {
+        $index = $data['AgendaPoint'] . '. ' . $data['Section'];
+      }
+      else {
+        $index = $data['AgendaPoint'];
+      }
+
       $agendaItems[] = [
         'subject' => $data['AgendaItem'],
-        'index' => $data['AgendaPoint'],
+        'index' => $index,
         'link' => $agenda_link,
       ];
     }
@@ -603,7 +612,7 @@ class PolicymakerService {
       'meeting' => [
         'page_title' => $pageTitle,
         'date_long' => $dateLong,
-        'title' => "$policymaker_title $dateShort",
+        'title' => $policymaker_title . ' ' . $meetingNumber . '/' . $meetingYear,
       ],
       'list' => $agendaItems,
       'file' => [


### PR DESCRIPTION
**To test**
* Checkout branch
* SSH into the container, then run `drush cim -y; drush cr; drush ap:fs -v; drush mim ahjo_trustees:all --update`
* If you don't have policymakers and meetings imported, run: `drush mim ahjo_policymakers:all; drush mim ahjo_meetings:all`
* Edit some kaupuningvaltuusto meetings with minutes and agendas published: https://helsinki-paatokset.docker.so/fi/admin/content/meetings?title=kaupunginvaltuusto&field_meeting_id_value=
  * Change the meeting date so they are in 2022. Edit one of them to be tomorrow
* Go to the Kaupunginvaltuusto page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
  *  The calendar should show the meetings you just edited. The motions and minutes links should take you to the minutes page of that meeting, not a pdf file
  * The page should have about 160 to 170 members listed. Easier to count from the raw JSON data: http://helsinki-paatokset.docker.so/fi/ahjo_api/org_composition/02900
  * Searching and filtering the list should work
* Go to the documents page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat
  * The "download pdf" link should be gone
  * Open a minutes page. It should have the sections listed next to the agenda item index numbers
* Create and set a frontpage for the site. Also create a landing page with the URL "/kokouskalenteri"
* Go to the frontpage. The calendar should have the meeting you edited visible, and the motions or minutes link should take you to the minutes page under kaupunginvaltuusto
* Go to the kokouskalenteri-page: https://helsinki-paatokset.docker.so/fi/kokouskalenteri
  *  The motion and minutes link (if they exist on specific meetings) should take you to the minutes page