### PR TITLE
PP-163: PP-163: added more fields for trustee

### DIFF
--- a/conf/cmi/core.entity_form_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_form_display.node.trustee.default.yml
@@ -3,15 +3,25 @@ langcode: fi
 status: true
 dependencies:
   config:
+    - field.field.node.trustee.field_first_name
+    - field.field.node.trustee.field_last_name
     - field.field.node.trustee.field_trustee_chairmanships
     - field.field.node.trustee.field_trustee_council_group
+    - field.field.node.trustee.field_trustee_datapumppu_id
+    - field.field.node.trustee.field_trustee_email
+    - field.field.node.trustee.field_trustee_home_district
     - field.field.node.trustee.field_trustee_id
+    - field.field.node.trustee.field_trustee_image
     - field.field.node.trustee.field_trustee_initiatives
+    - field.field.node.trustee.field_trustee_phone
+    - field.field.node.trustee.field_trustee_profession
     - field.field.node.trustee.field_trustee_resolutions
     - field.field.node.trustee.field_trustee_title
+    - image.style.thumbnail
     - node.type.trustee
   module:
     - hdbt_admin_editorial
+    - image
     - json_field
     - path
     - scheduler
@@ -22,12 +32,28 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 9
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_first_name:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_last_name:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_trustee_chairmanships:
-    weight: 6
+    weight: 11
     settings:
       rows: 5
       placeholder: ''
@@ -42,6 +68,30 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_trustee_datapumppu_id:
+    weight: 22
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_trustee_email:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_trustee_home_district:
+    weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_trustee_id:
     weight: 1
     settings:
@@ -50,16 +100,40 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_trustee_image:
+    weight: 8
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
   field_trustee_initiatives:
-    weight: 4
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: json_textarea
     region: content
-  field_trustee_resolutions:
+  field_trustee_phone:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_trustee_profession:
     weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_trustee_resolutions:
+    weight: 10
     settings:
       rows: 5
       placeholder: ''
@@ -76,14 +150,14 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 7
+    weight: 12
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 12
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -91,12 +165,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 15
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 13
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -104,14 +178,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 21
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 16
     region: content
     third_party_settings: {  }
   title:
@@ -124,7 +198,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 13
     settings:
       match_operator: CONTAINS
       size: 60
@@ -134,12 +208,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 14
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 15
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_form_display.node.trustee.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.trustee.field_trustee_datapumppu_id
     - field.field.node.trustee.field_trustee_email
     - field.field.node.trustee.field_trustee_home_district
+    - field.field.node.trustee.field_trustee_homepage
     - field.field.node.trustee.field_trustee_id
     - field.field.node.trustee.field_trustee_image
     - field.field.node.trustee.field_trustee_initiatives
@@ -86,6 +87,14 @@ content:
     region: content
   field_trustee_home_district:
     weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_trustee_homepage:
+    weight: 28
     settings:
       size: 60
       placeholder: ''

--- a/conf/cmi/core.entity_view_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_view_display.node.trustee.default.yml
@@ -3,14 +3,23 @@ langcode: fi
 status: true
 dependencies:
   config:
+    - field.field.node.trustee.field_first_name
+    - field.field.node.trustee.field_last_name
     - field.field.node.trustee.field_trustee_chairmanships
     - field.field.node.trustee.field_trustee_council_group
+    - field.field.node.trustee.field_trustee_datapumppu_id
+    - field.field.node.trustee.field_trustee_email
+    - field.field.node.trustee.field_trustee_home_district
     - field.field.node.trustee.field_trustee_id
+    - field.field.node.trustee.field_trustee_image
     - field.field.node.trustee.field_trustee_initiatives
+    - field.field.node.trustee.field_trustee_phone
+    - field.field.node.trustee.field_trustee_profession
     - field.field.node.trustee.field_trustee_resolutions
     - field.field.node.trustee.field_trustee_title
     - node.type.trustee
   module:
+    - image
     - json_field
     - user
 id: node.trustee.default
@@ -18,30 +27,95 @@ targetEntityType: node
 bundle: trustee
 mode: default
 content:
+  field_first_name:
+    weight: 12
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_last_name:
+    weight: 13
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_trustee_chairmanships:
-    weight: 4
+    weight: 5
     label: above
     settings: {  }
     third_party_settings: {  }
     type: json
     region: content
   field_trustee_council_group:
-    weight: 1
+    weight: 2
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
     region: content
+  field_trustee_datapumppu_id:
+    weight: 11
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_trustee_email:
+    weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_trustee_home_district:
+    weight: 10
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_trustee_image:
+    weight: 1
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
   field_trustee_initiatives:
-    weight: 2
+    weight: 3
     label: above
     settings: {  }
     third_party_settings: {  }
     type: json
     region: content
+  field_trustee_phone:
+    weight: 9
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_trustee_profession:
+    weight: 8
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_trustee_resolutions:
-    weight: 3
+    weight: 4
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -56,7 +130,7 @@ content:
     type: string
     region: content
   links:
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_view_display.node.trustee.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.trustee.field_trustee_datapumppu_id
     - field.field.node.trustee.field_trustee_email
     - field.field.node.trustee.field_trustee_home_district
+    - field.field.node.trustee.field_trustee_homepage
     - field.field.node.trustee.field_trustee_id
     - field.field.node.trustee.field_trustee_image
     - field.field.node.trustee.field_trustee_initiatives
@@ -76,6 +77,14 @@ content:
     region: content
   field_trustee_home_district:
     weight: 10
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_trustee_homepage:
+    weight: 14
     label: above
     settings:
       link_to_entity: false

--- a/conf/cmi/core.entity_view_display.node.trustee.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.trustee.teaser.yml
@@ -4,10 +4,18 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.trustee.field_first_name
+    - field.field.node.trustee.field_last_name
     - field.field.node.trustee.field_trustee_chairmanships
     - field.field.node.trustee.field_trustee_council_group
+    - field.field.node.trustee.field_trustee_datapumppu_id
+    - field.field.node.trustee.field_trustee_email
+    - field.field.node.trustee.field_trustee_home_district
     - field.field.node.trustee.field_trustee_id
+    - field.field.node.trustee.field_trustee_image
     - field.field.node.trustee.field_trustee_initiatives
+    - field.field.node.trustee.field_trustee_phone
+    - field.field.node.trustee.field_trustee_profession
     - field.field.node.trustee.field_trustee_resolutions
     - field.field.node.trustee.field_trustee_title
     - node.type.trustee
@@ -24,10 +32,18 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_first_name: true
+  field_last_name: true
   field_trustee_chairmanships: true
   field_trustee_council_group: true
+  field_trustee_datapumppu_id: true
+  field_trustee_email: true
+  field_trustee_home_district: true
   field_trustee_id: true
+  field_trustee_image: true
   field_trustee_initiatives: true
+  field_trustee_phone: true
+  field_trustee_profession: true
   field_trustee_resolutions: true
   field_trustee_title: true
   langcode: true

--- a/conf/cmi/core.entity_view_display.node.trustee.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.trustee.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.trustee.field_trustee_datapumppu_id
     - field.field.node.trustee.field_trustee_email
     - field.field.node.trustee.field_trustee_home_district
+    - field.field.node.trustee.field_trustee_homepage
     - field.field.node.trustee.field_trustee_id
     - field.field.node.trustee.field_trustee_image
     - field.field.node.trustee.field_trustee_initiatives
@@ -39,6 +40,7 @@ hidden:
   field_trustee_datapumppu_id: true
   field_trustee_email: true
   field_trustee_home_district: true
+  field_trustee_homepage: true
   field_trustee_id: true
   field_trustee_image: true
   field_trustee_initiatives: true

--- a/conf/cmi/field.field.media.declaration_of_affiliation.field__policymaker_reference.yml
+++ b/conf/cmi/field.field.media.declaration_of_affiliation.field__policymaker_reference.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.media.field__policymaker_reference
     - media.type.declaration_of_affiliation
     - node.type.policymaker
+    - node.type.trustee
 id: media.declaration_of_affiliation.field__policymaker_reference
 field_name: field__policymaker_reference
 entity_type: media
@@ -21,9 +22,10 @@ settings:
   handler_settings:
     target_bundles:
       policymaker: policymaker
+      trustee: trustee
     sort:
       field: _none
       direction: ASC
     auto_create: false
-    auto_create_bundle: ''
+    auto_create_bundle: policymaker
 field_type: entity_reference

--- a/conf/cmi/field.field.node.trustee.field_first_name.yml
+++ b/conf/cmi/field.field.node.trustee.field_first_name.yml
@@ -1,0 +1,19 @@
+uuid: d50e5e9f-212b-448c-a2ab-3a0c9baa197d
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_first_name
+    - node.type.trustee
+id: node.trustee.field_first_name
+field_name: field_first_name
+entity_type: node
+bundle: trustee
+label: 'First name'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.trustee.field_last_name.yml
+++ b/conf/cmi/field.field.node.trustee.field_last_name.yml
@@ -1,0 +1,19 @@
+uuid: cebc9c2b-c4ef-4fdc-b969-9a4121a3da93
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_last_name
+    - node.type.trustee
+id: node.trustee.field_last_name
+field_name: field_last_name
+entity_type: node
+bundle: trustee
+label: 'Last name'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.trustee.field_trustee_datapumppu_id.yml
+++ b/conf/cmi/field.field.node.trustee.field_trustee_datapumppu_id.yml
@@ -1,0 +1,19 @@
+uuid: 13cd519d-0f2c-487a-a6fc-279328a929d6
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_trustee_datapumppu_id
+    - node.type.trustee
+id: node.trustee.field_trustee_datapumppu_id
+field_name: field_trustee_datapumppu_id
+entity_type: node
+bundle: trustee
+label: 'Datapumppu ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.trustee.field_trustee_email.yml
+++ b/conf/cmi/field.field.node.trustee.field_trustee_email.yml
@@ -1,0 +1,19 @@
+uuid: df869ac2-8c04-4dc2-a12c-f7e12a15600d
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_trustee_email
+    - node.type.trustee
+id: node.trustee.field_trustee_email
+field_name: field_trustee_email
+entity_type: node
+bundle: trustee
+label: Email
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.trustee.field_trustee_home_district.yml
+++ b/conf/cmi/field.field.node.trustee.field_trustee_home_district.yml
@@ -1,0 +1,19 @@
+uuid: 14654594-a163-49e3-953c-e8e476f10437
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_trustee_home_district
+    - node.type.trustee
+id: node.trustee.field_trustee_home_district
+field_name: field_trustee_home_district
+entity_type: node
+bundle: trustee
+label: 'Home district'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.trustee.field_trustee_homepage.yml
+++ b/conf/cmi/field.field.node.trustee.field_trustee_homepage.yml
@@ -1,0 +1,19 @@
+uuid: 4cfa257a-15de-4fca-ae35-2a95196f5d3f
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_trustee_homepage
+    - node.type.trustee
+id: node.trustee.field_trustee_homepage
+field_name: field_trustee_homepage
+entity_type: node
+bundle: trustee
+label: Homepage
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.trustee.field_trustee_image.yml
+++ b/conf/cmi/field.field.node.trustee.field_trustee_image.yml
@@ -1,0 +1,38 @@
+uuid: d774b289-49ed-44fa-a314-6b32a4931593
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_trustee_image
+    - node.type.trustee
+  module:
+    - image
+id: node.trustee.field_trustee_image
+field_name: field_trustee_image
+entity_type: node
+bundle: trustee
+label: Image
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/conf/cmi/field.field.node.trustee.field_trustee_phone.yml
+++ b/conf/cmi/field.field.node.trustee.field_trustee_phone.yml
@@ -1,0 +1,19 @@
+uuid: 03f9b63d-1a22-4337-abf5-0ea3bae1062f
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_trustee_phone
+    - node.type.trustee
+id: node.trustee.field_trustee_phone
+field_name: field_trustee_phone
+entity_type: node
+bundle: trustee
+label: Phone
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.field.node.trustee.field_trustee_profession.yml
+++ b/conf/cmi/field.field.node.trustee.field_trustee_profession.yml
@@ -1,0 +1,19 @@
+uuid: 0aacb2c5-bdbe-4e1e-9c60-9b24c6fbbaa9
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_trustee_profession
+    - node.type.trustee
+id: node.trustee.field_trustee_profession
+field_name: field_trustee_profession
+entity_type: node
+bundle: trustee
+label: Profession
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_trustee_datapumppu_id.yml
+++ b/conf/cmi/field.storage.node.field_trustee_datapumppu_id.yml
@@ -1,0 +1,21 @@
+uuid: 81bd87e3-1f03-4910-892f-1f788f5e7a39
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_trustee_datapumppu_id
+field_name: field_trustee_datapumppu_id
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_trustee_email.yml
+++ b/conf/cmi/field.storage.node.field_trustee_email.yml
@@ -1,0 +1,21 @@
+uuid: 7b64ab97-fbff-46f3-aa1b-1dd99ef19a30
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_trustee_email
+field_name: field_trustee_email
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_trustee_home_district.yml
+++ b/conf/cmi/field.storage.node.field_trustee_home_district.yml
@@ -1,0 +1,21 @@
+uuid: bce7ceda-bf52-4ec4-abd3-a3bfe5270d91
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_trustee_home_district
+field_name: field_trustee_home_district
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_trustee_homepage.yml
+++ b/conf/cmi/field.storage.node.field_trustee_homepage.yml
@@ -1,0 +1,21 @@
+uuid: bf448955-3e85-410d-a121-b5cde611b618
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_trustee_homepage
+field_name: field_trustee_homepage
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_trustee_image.yml
+++ b/conf/cmi/field.storage.node.field_trustee_image.yml
@@ -1,0 +1,30 @@
+uuid: 62057453-42f3-4705-9786-378f95e7764d
+langcode: fi
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_trustee_image
+field_name: field_trustee_image
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_trustee_phone.yml
+++ b/conf/cmi/field.storage.node.field_trustee_phone.yml
@@ -1,0 +1,21 @@
+uuid: f22f3272-4f50-49fe-a7a4-683944dc1ebd
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_trustee_phone
+field_name: field_trustee_phone
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_trustee_profession.yml
+++ b/conf/cmi/field.storage.node.field_trustee_profession.yml
@@ -1,0 +1,21 @@
+uuid: 16b2d080-f926-40b8-8e9c-32e72c0c22fe
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_trustee_profession
+field_name: field_trustee_profession
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Ticket: https://helsinkisolutionoffice.atlassian.net/browse/PP-163

Added new fields for trustee that were specified in the ticket. As extra: separate first and last name fields were added.

**How to test**

Checkout branch and run `drush cim -y; drush cr`. Go to https://helsinki-paatokset.docker.so/fi/admin/structure/types/manage/trustee/fields and check the the new fields are visible as well as when creating a trustee https://helsinki-paatokset.docker.so/fi/node/add/trustee

Check code changes that there are no extra configs added
