### PR TITLE
PP-252: Minor decisionmaker fixes

### DIFF
--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -713,7 +713,7 @@ class PolicymakerService {
       }
 
       if (!empty($data['Section'])) {
-        $index = $data['AgendaPoint'] . '. &ndash; ' . $data['Section'];
+        $index = $data['AgendaPoint'] . '. – ' . $data['Section'];
       }
       else {
         $index = $data['AgendaPoint'];

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -560,17 +560,9 @@ class PolicymakerService {
         continue;
       }
 
-      // If document doesn't have issued date, use meeting date (e.g agendas).
-      if ($document->hasField('field_document_issued') && !$document->get('field_document_issued')->isEmpty()) {
-        $document_timestamp = strtotime($document->get('field_document_issued')->value);
-      }
-      else {
-        $document_timestamp = $meeting_timestamp;
-      }
-
       $result = [
-        'publish_date' => date('d.m.Y', $document_timestamp),
-        'publish_date_short' => date('m - Y', $document_timestamp),
+        'publish_date' => date('d.m.Y', $meeting_timestamp),
+        'publish_date_short' => date('m - Y', $meeting_timestamp),
         'title' => $document_title,
         'meeting_number' => $node->get('field_meeting_sequence_number')->value . ' - ' . $meeting_year,
         'origin_url' => $meetingService->getUrlFromAhjoDocument($document),
@@ -721,7 +713,7 @@ class PolicymakerService {
       }
 
       if (!empty($data['Section'])) {
-        $index = $data['AgendaPoint'] . '. ' . $data['Section'];
+        $index = $data['AgendaPoint'] . '. &ndash; ' . $data['Section'];
       }
       else {
         $index = $data['AgendaPoint'];

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
@@ -106,14 +106,19 @@ class PolicymakerSideNav extends BlockBase {
       'Viranhaltija',
       'Luottamushenkilö',
     ];
-    if (in_array($policymaker->get('field_organization_type')->value, $trustee_types)) {
+    $org_type = $policymaker->get('field_organization_type')->value;
+    if (in_array($org_type, $trustee_types)) {
       $routes = PolicymakerRoutes::getTrusteeRoutes();
     }
     else {
       $routes = PolicymakerRoutes::getOrganizationRoutes();
     }
 
-    foreach ($routes as $route) {
+    foreach ($routes as $key => $route) {
+      if ($key === 'discussion_minutes' && $org_type !== 'Valtuusto') {
+        continue;
+      }
+
       $localizedRoute = "$route.$currentLanguage";
       if ($this->policymakerService->routeExists($localizedRoute)) {
         $route = $routeProvider->getRouteByName($localizedRoute);


### PR DESCRIPTION
**To test**
* Checkout branch, run `make drush-cr` (assuming you have decisionmaker and meeting data imported)
* Go to the kaupunginvaltuusto page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
  * The 'minutes of discussion' / 'keskustelupöytäkirjat' link should be visible in the subnavigation
  * Open the documents page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat
  * The dates listed should be the meeting date, not the minutes publication date (confirm this by opening on of the minute pages)
  * On the minute page, the index and sections should now have an ndash separating them
* Go to the kaupunkiympäristölautakunta page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunkiymparistolautakunta
  * The minutes of discussion link should not be visible   