### PR TITLE
PP-165-260: Backend work for frontend tickets

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -95,7 +95,7 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     ->execute();
   $nodes_policymakers =  \Drupal\node\Entity\Node::loadMultiple($nids_policymakers);
 
-  foreach($nodes_policymakers as $node) {
+  foreach ($nodes_policymakers as $node) {
     if (!$node instanceof NodeInterface) {
       continue;
     }
@@ -123,7 +123,7 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     'jaosto' => ['Jaosto', []]
   ];
 
-  foreach($accorion_contents as $key => $value) {
+  foreach ($accorion_contents as $key => $value) {
     $filter = $value[0];
 
     $accorion_contents[$key][1] = array_filter($filtered, function ($var) use ($filter) {
@@ -147,7 +147,7 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     ->execute();
   $nodes_trustees = \Drupal\node\Entity\Node::loadMultiple($nids_trustees);
 
-  foreach($nodes_trustees as $node) {
+  foreach ($nodes_trustees as $node) {
     $options = ['absolute' => TRUE];
     $trustees[] = [
       'title' => $node->getTitle(),

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -141,8 +141,11 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     return (!str_contains($var['title'], $hallituksen_jaosto_filter));
   });
 
-  $nids_trustees = \Drupal::entityQuery('node')->condition('type','trustee')->execute();
-  $nodes_trustees =  \Drupal\node\Entity\Node::loadMultiple($nids_trustees);
+  $nids_trustees = \Drupal::entityQuery('node')
+    ->condition('type','trustee')
+    ->condition('status', 1)
+    ->execute();
+  $nodes_trustees = \Drupal\node\Entity\Node::loadMultiple($nids_trustees);
 
   foreach($nodes_trustees as $node) {
     $options = ['absolute' => TRUE];

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -89,15 +89,27 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     $variables['entity'] = $variables['elements']['#block__policymaker_listing'];
   }
 
-  $nids_policymakers = \Drupal::entityQuery('node')->condition('type','policymaker')->execute();
+  $nids_policymakers = \Drupal::entityQuery('node')
+    ->condition('type','policymaker')
+    ->condition('status', 1)
+    ->execute();
   $nodes_policymakers =  \Drupal\node\Entity\Node::loadMultiple($nids_policymakers);
 
   foreach($nodes_policymakers as $node) {
+    if (!$node instanceof NodeInterface) {
+      continue;
+    }
+
+    if (!$node->hasField('field_ahjo_title') || !$node->hasField('field_dm_org_name') || $node->get('field_ahjo_title')->isEmpty()) {
+      continue;
+    }
+
     $options = ['absolute' => TRUE];
     $filtered[] = [
-      'title' => $node->getTitle(),
+      'title' => $node->get('field_ahjo_title')->value,
       'link' => \Drupal\Core\Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options),
       'organization_type' => $node->get('field_organization_type')->value,
+      'organization_name' => $node->get('field_dm_org_name')->value,
       'image' => $node->get('field_policymaker_image')->view('default'),
     ];
   }

--- a/public/modules/custom/paatokset_ahjo_api/templates/block/block--policymaker-listing.html.twig
+++ b/public/modules/custom/paatokset_ahjo_api/templates/block/block--policymaker-listing.html.twig
@@ -41,7 +41,12 @@
           {% for row in values %}
           <a href="{{ row.link }}" class="policymaker-row__link">
             <div class="policymaker-row__color {{ row.organization_type|lower|replace({'ö':'o'}) }}"></div>
-            <span class="policymaker-row__title" >{{ row.title|t }}</span>
+            <div class="policymaker-row__title">
+              {{ row.title|t }}
+              {% if row.organization_type == 'Viranhaltija' %}
+                <div class="policymaker-row__sub-title" >{{ row.organization_name }}</div>
+              {% endif %}
+            </div>
             <i class="hds-icon hds-icon--arrow-right"></i>
           </a>
         {% endfor %}

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -74,7 +74,10 @@ function paatokset_policymakers_preprocess_block__policymaker_calendar(array &$v
  * Implements preprocess_node hook.
  */
 function paatokset_policymakers_preprocess_node__policymaker(&$variables) {
+  /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
   $policymakerService = \Drupal::service('paatokset_policymakers');
+
+  /** @var \Drupal\paatokset_ahjo_api\Service\MeetingService $meetingService */
   $meetingService = \Drupal::service('paatokset_ahjo_meetings');
   $councilId = \Drupal::config('paatokset_helsinki_kanava.settings')->get('city_council_id');
 

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -728,7 +728,7 @@ class PolicymakerService {
         $index = $data['AgendaPoint'] . '. – ' . $data['Section'];
       }
       else {
-        $index = $data['AgendaPoint'];
+        $index = $data['AgendaPoint'] . '.';
       }
 
       $agendaItems[] = [

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -904,4 +904,35 @@ class PolicymakerService {
     return $result;
   }
 
+  /**
+   * Gets all initiatives from trustee nodes.
+   *
+   * @return array
+   *   List of initiatives.
+   */
+  public function getAllInitiatives(): array {
+    $nids = \Drupal::entityQuery('node')
+    ->condition('type','trustee')
+    ->condition('status', 1)
+    ->condition('field_trustee_initiatives', '', '<>')
+    ->execute();
+
+    $nodes = Node::loadMultiple($nids);
+    $initiatives = [];
+    foreach($nodes as $node) {
+      if (!$node instanceof NodeInterface || !$node->hasField('field_trustee_initiatives')) {
+        continue;
+      }
+
+      $id = $node->get('field_trustee_id')->value;
+
+      foreach ($node->get('field_trustee_initiatives') as $field) {
+        $initiative = json_decode($field->value, TRUE);
+        $inititive['Trustee'] = $id;
+        $initiatives[] = $initiative;
+      }
+    }
+
+    return $initiatives;
+  }
 }

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -912,14 +912,14 @@ class PolicymakerService {
    */
   public function getAllInitiatives(): array {
     $nids = \Drupal::entityQuery('node')
-    ->condition('type','trustee')
-    ->condition('status', 1)
-    ->condition('field_trustee_initiatives', '', '<>')
-    ->execute();
+      ->condition('type', 'trustee')
+      ->condition('status', 1)
+      ->condition('field_trustee_initiatives', '', '<>')
+      ->execute();
 
     $nodes = Node::loadMultiple($nids);
     $initiatives = [];
-    foreach($nodes as $node) {
+    foreach ($nodes as $node) {
       if (!$node instanceof NodeInterface || !$node->hasField('field_trustee_initiatives')) {
         continue;
       }
@@ -928,11 +928,12 @@ class PolicymakerService {
 
       foreach ($node->get('field_trustee_initiatives') as $field) {
         $initiative = json_decode($field->value, TRUE);
-        $inititive['Trustee'] = $id;
+        $initiative['TrusteeID'] = $id;
         $initiatives[] = $initiative;
       }
     }
 
     return $initiatives;
   }
+
 }


### PR DESCRIPTION
**To test**
- Checkout branch, run `make drush-cr`
- If you don't have up-to-date policymaker and trustee data, ssh into the container and run `drush ap:fs -v;drush mim ahjo_decisionmakers:all;drush mim ahjo_trustees:all;drush mim ahjo_meetings:latest`
- Edit the kaupunginvaltuusto title: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
  - Open the Päättäjät listing page: https://helsinki-paatokset.docker.so/fi/paattajat (if this doesn't exist, create a landing page with the /paattajat URL alias).
  - The kaupunginvaltuusto item should use the value from field_ahjo_title and no the edited title
  - Scroll down to the "Viranhaltijat"-list. These should have the organization name field printed after the title. (This looks a bit ugly right now, but will be handled in the actual frontend ticket).
- Check the individual agenda listing for Kaupunginhallitus: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus/asiakirjat
  - This should have some Agenda-documents. Open one of them and check that the index numbers end with a "."-character
- Read the PolicymakerService.php changes
  - This can be tested by adding a `$initiatives = $policymakerService->getAllInitiatives();dd($initiatives);` code snippet to line 79 of `paatokset_policymakers/paatokset_policymakers.module` and opening any policymaker node: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus