### PR TITLE
PP-0: Misc decisionmaker fixes

### DIFF
--- a/conf/cmi/block.block.helfi_paatokset_page_title.yml
+++ b/conf/cmi/block.block.helfi_paatokset_page_title.yml
@@ -15,10 +15,10 @@ plugin: page_title_block
 settings:
   id: page_title_block
   label: 'Sivun otsikko'
-  provider: core
   label_display: '0'
+  provider: core
 visibility:
   request_path:
     id: request_path
-    pages: "/paattajat/*/asiakirjat/*\r\n/paatokset-issue/*\r\n/paatokset"
     negate: true
+    pages: "/paattajat/*/asiakirjat/*\r\n/paatokset-issue/*\r\n/paatokset"

--- a/conf/cmi/block.block.paatoksetpolicymakermembers.yml
+++ b/conf/cmi/block.block.paatoksetpolicymakermembers.yml
@@ -1,10 +1,10 @@
 uuid: 313f4a33-acae-4b17-9701-81e4f5948326
 langcode: fi
-status: true
+status: false
 dependencies:
   module:
-    - ctools
-    - paatokset_ahjo
+    - node
+    - paatokset_policymakers
   theme:
     - helfi_paatokset
 id: paatoksetpolicymakermembers

--- a/conf/cmi/core.entity_form_display.node.policymaker.default.yml
+++ b/conf/cmi/core.entity_form_display.node.policymaker.default.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.node.policymaker.field_policymaker_summary
     - field.field.node.policymaker.field_recording_description
     - field.field.node.policymaker.field_resource_uri
+    - field.field.node.policymaker.field_sector_name
     - node.type.policymaker
   module:
     - datetime
@@ -49,6 +50,7 @@ third_party_settings:
         - field_organization_type
         - field_organization_type_id
         - field_dm_org_name
+        - field_sector_name
         - field_policymaker_formed
         - field_policymaker_dissolved
         - field_policymaker_existing
@@ -184,7 +186,7 @@ content:
     third_party_settings: {  }
   field_dm_org_above:
     type: json_textarea
-    weight: 15
+    weight: 16
     region: content
     settings:
       rows: 5
@@ -192,7 +194,7 @@ content:
     third_party_settings: {  }
   field_dm_org_below:
     type: json_textarea
-    weight: 16
+    weight: 17
     region: content
     settings:
       rows: 5
@@ -208,7 +210,7 @@ content:
     third_party_settings: {  }
   field_dm_sector:
     type: json_textarea
-    weight: 14
+    weight: 15
     region: content
     settings:
       rows: 5
@@ -232,7 +234,7 @@ content:
     third_party_settings: {  }
   field_is_decisionmaker:
     type: boolean_checkbox
-    weight: 13
+    weight: 14
     region: content
     settings:
       display_label: true
@@ -271,20 +273,20 @@ content:
     third_party_settings: {  }
   field_policymaker_dissolved:
     type: datetime_default
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   field_policymaker_existing:
     type: boolean_checkbox
-    weight: 12
+    weight: 13
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_policymaker_formed:
     type: datetime_default
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -319,6 +321,14 @@ content:
     region: content
     settings:
       rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_sector_name:
+    type: string_textfield
+    weight: 10
+    region: content
+    settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   langcode:

--- a/conf/cmi/core.entity_form_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_form_display.node.trustee.default.yml
@@ -79,13 +79,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_trustee_email:
-    weight: 10
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
     type: email_default
+    weight: 10
     region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
   field_trustee_home_district:
     type: string_textfield
     weight: 8
@@ -95,13 +95,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_trustee_homepage:
+    type: link_default
     weight: 9
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_trustee_id:
     type: string_textfield
     weight: 3

--- a/conf/cmi/core.entity_view_display.node.policymaker.default.yml
+++ b/conf/cmi/core.entity_view_display.node.policymaker.default.yml
@@ -27,6 +27,7 @@ dependencies:
     - field.field.node.policymaker.field_policymaker_summary
     - field.field.node.policymaker.field_recording_description
     - field.field.node.policymaker.field_resource_uri
+    - field.field.node.policymaker.field_sector_name
     - node.type.policymaker
   module:
     - text
@@ -110,6 +111,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 9
+    region: content
+  field_sector_name:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 10
     region: content
 hidden:
   field_contacts: true

--- a/conf/cmi/core.entity_view_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_view_display.node.trustee.default.yml
@@ -69,11 +69,11 @@ content:
     weight: 11
     region: content
   field_trustee_email:
-    weight: 15
+    type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    weight: 15
     region: content
   field_trustee_home_district:
     type: string
@@ -84,6 +84,7 @@ content:
     weight: 10
     region: content
   field_trustee_homepage:
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -92,9 +93,8 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
-    region: content
     weight: null
+    region: content
   field_trustee_image:
     type: image
     label: hidden
@@ -143,10 +143,10 @@ content:
     weight: 0
     region: content
   links:
-    weight: 6
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 6
+    region: content
 hidden:
   field_trustee_id: true
   langcode: true

--- a/conf/cmi/field.field.node.policymaker.field_sector_name.yml
+++ b/conf/cmi/field.field.node.policymaker.field_sector_name.yml
@@ -1,0 +1,19 @@
+uuid: cf3ef782-cbd2-4b3e-8652-12963385f471
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sector_name
+    - node.type.policymaker
+id: node.policymaker.field_sector_name
+field_name: field_sector_name
+entity_type: node
+bundle: policymaker
+label: 'Sector name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_sector_name.yml
+++ b/conf/cmi/field.storage.node.field_sector_name.yml
@@ -1,0 +1,21 @@
+uuid: 70c906ab-8dcb-4f38-a6d8-e44465930365
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_sector_name
+field_name: field_sector_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/search_api.index.decisions.yml
+++ b/conf/cmi/search_api.index.decisions.yml
@@ -7,6 +7,7 @@ dependencies:
   module:
     - paatokset_ahjo
     - search_api
+    - paatokset_search
 id: decisions
 name: Decisions
 description: ''
@@ -112,11 +113,12 @@ processor_settings:
   aggregated_field: {  }
   language_with_fallback: {  }
   rendered_item: {  }
+  sector_json: {  }
 tracker_settings:
   default:
     indexing_order: fifo
 options:
   cron_limit: 50
-  index_directly: true
+  index_directly: false
   track_changes_in_references: true
 server: elasticsearch

--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -3,8 +3,10 @@ langcode: fi
 status: true
 dependencies:
   config:
-    - field.storage.node.field_ahjo_title
+    - field.storage.node.field_dm_org_name
     - field.storage.node.field_organization_type
+    - field.storage.node.field_ahjo_title
+    - field.storage.node.field_sector_name
     - search_api.server.elasticsearch
   module:
     - search_api
@@ -15,6 +17,14 @@ name: Policymakers
 description: ''
 read_only: false
 field_settings:
+  field_dm_org_name:
+    label: 'Organization name'
+    datasource_id: 'entity:node'
+    property_path: field_dm_org_name
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_dm_org_name
   field_organization_type:
     label: 'Organization type'
     datasource_id: 'entity:node'
@@ -23,6 +33,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_organization_type
+  field_sector_name:
+    label: 'Sector name'
+    datasource_id: 'entity:node'
+    property_path: field_sector_name
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_sector_name
   sector:
     label: Sector
     datasource_id: 'entity:node'
@@ -62,6 +80,6 @@ tracker_settings:
     indexing_order: fifo
 options:
   cron_limit: 50
-  index_directly: true
+  index_directly: false
   track_changes_in_references: true
 server: elasticsearch

--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -61,7 +61,7 @@ tracker_settings:
   default:
     indexing_order: fifo
 options:
+  cron_limit: 50
   index_directly: true
   track_changes_in_references: true
-  cron_limit: 50
 server: elasticsearch

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisionmakers.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisionmakers.yml
@@ -114,6 +114,7 @@ process:
     to_timezone: UTC
     source: dissolved
   field_is_decisionmaker: is_decisionmaker
+  field_sector_name: sector/Sector
   field_dm_sector:
     -
       plugin: single_value

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -114,7 +114,7 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     ];
   }
 
-  $accorion_contents = [
+  $accordion_contents = [
     'valtuusto' => ['Valtuusto', []],
     'hallitus' => ['Hallitus', []],
     'viranhaltija' => ['Viranhaltija', []],
@@ -123,21 +123,21 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     'jaosto' => ['Jaosto', []]
   ];
 
-  foreach ($accorion_contents as $key => $value) {
+  foreach ($accordion_contents as $key => $value) {
     $filter = $value[0];
 
-    $accorion_contents[$key][1] = array_filter($filtered, function ($var) use ($filter) {
+    $accordion_contents[$key][1] = array_filter($filtered, function ($var) use ($filter) {
       return ($var['organization_type'] == $filter);
     });
   };
 
   $hallituksen_jaosto_filter = 'hallitu';
-  $hallituksen_jaosto = array_filter($accorion_contents['lautakunta'][1], function ($var) use ($hallituksen_jaosto_filter) {
+  $hallituksen_jaosto = array_filter($accordion_contents['lautakunta'][1], function ($var) use ($hallituksen_jaosto_filter) {
       return (str_contains($var['title'], $hallituksen_jaosto_filter));
   });
 
   //Removes kaupunginhallituksen jaostot from array
-  $lautakunta = array_filter($accorion_contents['lautakunta'][1], function ($var) use ($hallituksen_jaosto_filter) {
+  $lautakunta = array_filter($accordion_contents['lautakunta'][1], function ($var) use ($hallituksen_jaosto_filter) {
     return (!str_contains($var['title'], $hallituksen_jaosto_filter));
   });
 
@@ -156,13 +156,13 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
     ];
   };
 
-  $variables['cards'] = [$accorion_contents['valtuusto'][1], $accorion_contents['hallitus'][1]];
+  $variables['cards'] = [$accordion_contents['valtuusto'][1], $accordion_contents['hallitus'][1]];
 
   $variables['accordions'][] = [
     'Kaupinginhallituksen jaostot' => $hallituksen_jaosto,
-    'Lautakunnat ja jaostot' => array_merge($lautakunta, $accorion_contents['jaosto'][1]),
-    'Viranhaltijat' => $accorion_contents['viranhaltija'][1],
-    'Luottamushenkilöpäättäjät' => $accorion_contents['trustee'][1],
+    'Lautakunnat ja jaostot' => array_merge($lautakunta, $accordion_contents['jaosto'][1]),
+    'Viranhaltijat' => $accordion_contents['viranhaltija'][1],
+    'Luottamushenkilöpäättäjät' => $accordion_contents['trustee'][1],
     'Luottamushenkilöt' => $trustees,
   ];
 

--- a/public/modules/custom/paatokset_ahjo_api/templates/block/block--policymaker-listing.html.twig
+++ b/public/modules/custom/paatokset_ahjo_api/templates/block/block--policymaker-listing.html.twig
@@ -43,7 +43,7 @@
             <div class="policymaker-row__color {{ row.organization_type|lower|replace({'ö':'o'}) }}"></div>
             <div class="policymaker-row__title">
               {{ row.title|t }}
-              {% if row.organization_type == 'Viranhaltija' %}
+              {% if row.organization_type == 'Viranhaltija' or row.organization_type == 'Luottamushenkilö' %}
                 <div class="policymaker-row__sub-title" >{{ row.organization_name }}</div>
               {% endif %}
             </div>

--- a/public/modules/custom/paatokset_policymakers/js/policymaker_members.js
+++ b/public/modules/custom/paatokset_policymakers/js/policymaker_members.js
@@ -10,7 +10,7 @@
   Drupal.behaviors.paatoksetPolicymakersPolicymakerMembers = {
     attach() {
       const markup = `
-      <div class="policymaker-members">
+      <div class="policymaker-members__container">
         <div class="policymaker-members__filters">
           <div class="search-wrapper">
             <label>{{ searchLabel }}</label>
@@ -56,11 +56,10 @@
         </div>
       </div>
       `
-      const policymakerID = document.querySelector('#block-paatoksetpolicymakermembers').dataset.policymaker;
-      const policymakerType = document.querySelector('#block-paatoksetpolicymakermembers').dataset.type;
+      const container = document.querySelector('.policymaker-members__block');
+      const policymakerID = container.dataset.policymaker;
+      const policymakerType = container.dataset.type;
       const dataURL = window.location.origin + '/fi/ahjo_api/org_composition/' + policymakerID;
-
-      console.log(policymakerType !== 'Valtuusto')
 
       new Vue({
         el: '#policymaker-members-vue',

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -189,8 +189,18 @@ function paatokset_policymakers_pathauto_pattern_alter(&$pattern, array $context
     return;
   }
 
+  $allowed_types = [
+    'Viranhaltija',
+    'Luottamushenkilö',
+  ];
+
   // Only act on Viranhaltija decisionmakers.
-  if ($node->get('field_organization_type')->value !== 'Viranhaltija') {
+  if (!in_array($node->get('field_organization_type')->value, $allowed_types)) {
+    return;
+  }
+
+  // Special case: Dont' add org name to Pormestari URL.
+  if ($node->get('field_ahjo_title')->value === 'Pormestari') {
     return;
   }
 

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -170,3 +170,33 @@ function template_preprocess_block__policymaker_members(array &$variables) {
     $variables['entity'] = $variables['elements']['#block__policymaker_members'];
   }
 }
+
+/**
+ * Implements hook_pathauto_pattern_alter().
+ *
+ * Custom node path for Viranhaltija decisionmakers, add org name to URL.
+ */
+function paatokset_policymakers_pathauto_pattern_alter(&$pattern, array $context) {
+  // Only act on node context.
+  if (!isset($context['module'], $context['data']['node']) || $context['module'] !== 'node') {
+    return;
+  }
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $context['data']['node'];
+
+  // Only act on policymaker nodes and make sure fields exist.
+  if (!$node->bundle() === 'policymaker' || !$node->hasField('field_dm_org_name') || !$node->hasField('field_organization_type')) {
+    return;
+  }
+
+  // Only act on Viranhaltija decisionmakers.
+  if ($node->get('field_organization_type')->value !== 'Viranhaltija') {
+    return;
+  }
+
+  // If org name exists, add it to the path.
+  if (!$node->get('field_dm_org_name')->isEmpty()) {
+    $pattern->setPattern('paattajat/[node:field_ahjo_title]-[node:field_dm_org_name:value]');
+    return;
+  }
+}

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -250,13 +250,23 @@ class PolicymakerService {
       return NULL;
     }
 
+    $policymaker = $this->getPolicymaker();
+
+    if (!$policymaker instanceof NodeInterface || $policymaker->getType() !== 'policymaker') {
+      return NULL;
+    }
+
+    $policymaker_url = $policymaker->toUrl()->toString();
+    $policymaker_url_bits = explode('/', $policymaker_url);
+    $policymaker_org = array_pop($policymaker_url_bits);
+
     $route = PolicymakerRoutes::getSubroutes()['minutes'];
     $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
     $localizedRoute = "$route.$currentLanguage";
 
     if ($this->routeExists($localizedRoute)) {
       return Url::fromRoute($localizedRoute, [
-        'organization' => strtolower($this->policymaker->get('field_ahjo_title')->value),
+        'organization' => strtolower($policymaker_org),
         'id' => $id,
       ]);
     }

--- a/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-members.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-members.html.twig
@@ -1,6 +1,6 @@
 {%
   set classes = [
-  'policymaker-members',
+  'policymaker-members__block',
   'container',
   view_mode ? 'policymaker-members--view-mode-' ~ view_mode|clean_class,
 ]

--- a/public/modules/custom/paatokset_policymakers/templates/content/node--policymaker.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/content/node--policymaker.html.twig
@@ -143,8 +143,8 @@
             {% if meeting_calendar %}
               <li><a href="#meeting-calendar">{{ 'Meeting calendar'|trans }}</a></li>
             {% endif %}
-            {% if members %}
-              <li><a href="#members">{{ 'Members of the board'|trans }}</a></li>
+            {% if is_organization %}
+              <li><a href="#members-list">{{ 'Members list'|trans }}</a></li>
             {% endif %}
           </ul>
           <i class="hds-icon hds-icon--arrow-down hds-icon--size-xxl" aria-hidden="true"></i>
@@ -237,6 +237,12 @@
   {% if meeting_calendar %}
     <section class="container policymaker-calendar" id="meeting-calendar">
       {{ drupal_block('policymaker_calendar') }}
+    </section>
+  {% endif %}
+
+  {% if is_organization %}
+    <section class="container" id="members-list">
+      {{ drupal_block('policymaker_members') }}
     </section>
   {% endif %}
 


### PR DESCRIPTION
**To test**
* Checkout branch, SSH into the container and run: `drush cr; drush cim -y;drush mim ahjo_decisionmakers:all --update`
* Go to https://helsinki-paatokset.docker.so/kokouskalenteri and find some agenda or motion links for organizations that have spaces and dashes in the title. They should now take you to the correct page instead of a 404 error
* Go to https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
  * There should be a link to the members list in the links block
  * The members list should work normally
* Go to: https://helsinki-paatokset.docker.so/fi/admin/content/decisionmakers
  * Sort the list by organization type
  * Open some "Luottamushenkilö"  or "Viranhaltija" decisionmakers. The members list should not be visible
  * The "Viranhaltija" nodes should have the "Organization name" value added to their URL aliases, so there should no longer be any with URLs such as "/paattajat/yksikon-paallikko-4"
  * "Luottamushenkilö" nodes should also have the "Organization name" value added to their URL aliases, except for "Pormestari", which should have this URL: https://helsinki-paatokset.docker.so/fi/paattajat/pormestari
 * Check the fields on the Policymaker index: https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/policymakers/fields
   * The Sector name and Organization name fields should now be added 
   * The immediate indexing has been disabled because it caused capacity and flooding issues locally. The nodes will be indexed through cron or manually