### PR TITLE
Pp 274 finnish analyzator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drush/drush": "^10.4",
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
-        "paatokset/paatokset_search": "^0.2.0"
+        "paatokset/paatokset_search": "0.2.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -113,9 +113,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "0.2.0",
+                "version": "0.2.1",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.0/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.1/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -7809,10 +7809,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.0/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.1/paatokset_search.zip"
             },
             "type": "library"
         },

--- a/public/modules/custom/paatokset_search/paatokset_search.info.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.info.yml
@@ -2,3 +2,6 @@ name: Päätökset search
 type: module
 package: Custom
 core_version_requirement: ^9
+dependecies:
+  - elasticsearch_connector
+  - search_api

--- a/public/modules/custom/paatokset_search/paatokset_search.info.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.info.yml
@@ -2,6 +2,6 @@ name: Päätökset search
 type: module
 package: Custom
 core_version_requirement: ^9
-dependecies:
+dependencies:
   - elasticsearch_connector
   - search_api

--- a/public/modules/custom/paatokset_search/paatokset_search.services.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.services.yml
@@ -1,0 +1,4 @@
+services:
+  Drupal\paatokset_search\EventSubscriber\PrepareIndex:
+    tags:
+      - { name: 'event_subscriber' }

--- a/public/modules/custom/paatokset_search/src/EventSubscriber/PrepareIndex.php
+++ b/public/modules/custom/paatokset_search/src/EventSubscriber/PrepareIndex.php
@@ -34,6 +34,7 @@ class PrepareIndex implements EventSubscriberInterface {
     if (in_array($indexName, $finnishIndices)) {
       $indexConfig = $event->getIndexConfig();
       $indexConfig['body']['settings']['analysis']['analyzer']['default']['type'] = 'finnish';
+      $event->setIndexConfig($indexConfig);
     }
   }
 

--- a/public/modules/custom/paatokset_search/src/EventSubscriber/PrepareIndex.php
+++ b/public/modules/custom/paatokset_search/src/EventSubscriber/PrepareIndex.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\paatokset_search\EventSubscriber;
+
+use Drupal\elasticsearch_connector\Event\PrepareIndexEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * {@inheritdoc}
+ */
+class PrepareIndex implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PrepareIndexEvent::PREPARE_INDEX => 'prepareIndices',
+    ];
+  }
+
+  /**
+   * Method to prepare index.
+   *
+   * @param Drupal\elasticsearch_connector\Event\PrepareIndexEvent $event
+   *   The PrepareIndex event.
+   */
+  public function prepareIndices(PrepareIndexEvent $event) {
+    $indexName = $event->getIndexName();
+    $finnishIndices = [
+      'paatokset_decisions',
+      'paatokset_policymakers',
+    ];
+    if (in_array($indexName, $finnishIndices)) {
+      $indexConfig = $event->getIndexConfig();
+      $indexConfig['body']['settings']['analysis']['analyzer']['default']['type'] = 'finnish';
+    }
+  }
+
+}


### PR DESCRIPTION
Set up event subscriber that sets the default analyzer as 'finnish' in finnish indices.

To test:
- Delete your existing indices. This can be done by sending DELETE request to [elastic-url]/[index-name] - without any modifications to your local environment the url should look like http://localhost:9200/paatokset_decisions. You should get a response with message: `acknowledged: true`
- Run `make new`. Remember to take a backup with `make drush-create-dump` beforehand!
- Check that the index has been created. You can verify this by sending a GET request to http://localhost:9200/_cat/indices. The list should include `paatokset_decisions` -index.
- Send GET request to http://localhost:9200/paatokset_decisions/_settings. In the response under 'analysis' you should see that the default analyzer is set as finnish. 
- Navigate to `https://helsinki-paatokset.docker.so/fi/paatokset`. The search app should work. Try making a few searches and see if the results are wonky / any problems occur.