### PR TITLE
PP-263: Change urls and titles

### DIFF
--- a/conf/cmi/metatag.metatag_defaults.node.yml
+++ b/conf/cmi/metatag.metatag_defaults.node.yml
@@ -9,7 +9,7 @@ label: Content
 tags:
   canonical_url: '[node:url]'
   content_language: '[node:langcode]'
-  title: '[node:title] | [site:name]'
+  title: "[node:title] | [site:name] |\_Helsingin Kaupunki"
   article_modified_time: '[node:created:html_datetime]'
   article_published_time: '[node:created:html_datetime]'
   og_image_url: '[node:field_liftup_image:entity:field_media_image:og_image:url],[site:base-url]/themes/custom/hdbt/src/images/og-global.png'

--- a/conf/cmi/metatag.metatag_defaults.node__decision.yml
+++ b/conf/cmi/metatag.metatag_defaults.node__decision.yml
@@ -1,0 +1,8 @@
+uuid: 046d61ce-2a9c-4936-967b-3a24d4d96594
+langcode: fi
+status: true
+dependencies: {  }
+id: node__decision
+label: 'Sisältö: Decision'
+tags:
+  title: '[node:title] – [node:field_dm_org_name:value] | [site:name] | Helsingin Kaupunki'

--- a/public/modules/custom/paatokset_search/paatokset_search.routing.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.routing.yml
@@ -1,5 +1,5 @@
 paatokset_search.decisions:
-  path: 'paatokset'
+  path: 'asia'
   defaults:
     _controller: '\Drupal\paatokset_search\Controller\SearchController::decisions'
     _title: 'Search decisions'


### PR DESCRIPTION
Note: This PR doesn't handle translating URLs or the title suffix yet, there's a separate ticket for translations etc.

**To test**
* Checkout branch
* Run `drush cr;drush cim -y`
* The decisions search should now be available at: https://helsinki-paatokset.docker.so/fi/asia
* Create a new node: https://helsinki-paatokset.docker.so/fi/node/add/landing_page
  * After saving, the page title tag should be in this format: [node:title] | Päätökset | Helsingin Kaupunki
* Check an existing decision or create a new one (make sure to add a title and a organization name). The title should be in this format: [node:title] - [organization name] | Päätökset | Helsingin Kaupunki 