### PR TITLE
PP-0: Add method to caseService for getting full decision URLs

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -250,7 +250,7 @@ class CaseService {
   /**
    * Get decision URL by ID.
    *
-   * @param NodeInterface $decision
+   * @param Drupal\node\NodeInterface $decision
    *   Decision node.
    *
    * @return Drupal\Core\Url
@@ -280,7 +280,6 @@ class CaseService {
 
     return $decision->toUrl();
   }
-
 
   /**
    * Get label for decision (organization name + date).


### PR DESCRIPTION
This PR adds a new method for getting case node URLs with query parameters for decision nodes, or just decision node URLs if the case is missing.

**To test**
- Checkout branch and run `make drush-cr`
- If you don't have Ahjo data imported, run: `drush ap:fs;drush mim ahjo_decisionmakers:all;drush mim ahjo_meetings:latest;drush mim ahjo_cases:latest;drush mim ahjo_decisions:latest`
- This meeting should have decisions to test with: https://helsinki-paatokset.docker.so/fi/paattajat/tarkastuslautakunta/asiakirjat/U003110202118
- Check that each link actually links to the case node, not the decision node, and that the correct decision is loaded via the query parameter
- Delete one of the cases and reload the list. The link should now point to the decision node
- Find one of the decisions (with an existing case node) and remove their diary number. The link should now point to the decision node