### PR TITLE
PP-288: Indexing for decision content and motion fields

### DIFF
--- a/conf/cmi/core.entity_form_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_form_display.node.decision.default.yml
@@ -9,9 +9,11 @@ dependencies:
     - field.field.node.decision.field_decision_attachments
     - field.field.node.decision.field_decision_case_title
     - field.field.node.decision.field_decision_content
+    - field.field.node.decision.field_decision_content_parsed
     - field.field.node.decision.field_decision_date
     - field.field.node.decision.field_decision_meeting
     - field.field.node.decision.field_decision_motion
+    - field.field.node.decision.field_decision_motion_parsed
     - field.field.node.decision.field_decision_native_id
     - field.field.node.decision.field_decision_organization
     - field.field.node.decision.field_decision_previous
@@ -31,11 +33,79 @@ dependencies:
     - node.type.decision
   module:
     - datetime
+    - field_group
     - hdbt_admin_editorial
     - json_field
     - path
     - scheduler
     - text
+third_party_settings:
+  field_group:
+    group_decision_data:
+      children:
+        - field_full_title
+        - field_decision_native_id
+        - field_decision_date
+        - field_decision_section
+        - field_decision_case_title
+        - field_diary_number
+        - field_diary_number_label
+        - field_classification_code
+        - field_classification_title
+        - field_top_category_name
+        - field_decision_record
+        - field_decision_content
+        - field_decision_motion
+        - field_decision_attachments
+      label: 'Decision data'
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_organization_data:
+      children:
+        - field_policymaker_id
+        - field_dm_org_name
+        - field_organization_type
+        - field_dm_org_above_name
+        - field_decision_organization
+      label: 'Organization data'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
+    group_meeting_data:
+      children:
+        - field_meeting_id
+        - field_meeting_sequence_number
+        - field_decision_meeting
+        - field_voting_results
+      label: 'Meeting data'
+      region: content
+      parent_name: ''
+      weight: 3
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: false
+        description: ''
+        required_fields: false
 id: node.decision.default
 targetEntityType: node
 bundle: decision
@@ -43,137 +113,11 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 27
+    weight: 32
     region: content
     settings: {  }
     third_party_settings: {  }
   field_classification_code:
-    type: string_textfield
-    weight: 8
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_classification_title:
-    type: string_textfield
-    weight: 9
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_attachments:
-    type: json_textarea
-    weight: 23
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_case_title:
-    type: string_textfield
-    weight: 5
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_content:
-    type: text_textarea
-    weight: 17
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_date:
-    type: datetime_default
-    weight: 3
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_decision_meeting:
-    type: json_textarea
-    weight: 21
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_motion:
-    type: text_textarea
-    weight: 18
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_native_id:
-    type: string_textfield
-    weight: 2
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_organization:
-    type: json_textarea
-    weight: 11
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_previous:
-    type: json_textarea
-    weight: 24
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_record:
-    type: json_textarea
-    weight: 16
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_section:
-    type: string_textfield
-    weight: 4
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_diary_number:
-    type: string_textfield
-    weight: 6
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_diary_number_label:
-    type: string_textfield
-    weight: 7
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dm_org_above_name:
-    type: string_textfield
-    weight: 15
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_dm_org_name:
     type: string_textfield
     weight: 13
     region: content
@@ -181,38 +125,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_full_title:
-    type: string_textfield
-    weight: 1
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_meeting_id:
-    type: string_textfield
-    weight: 19
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_meeting_sequence_number:
-    type: number
-    weight: 20
-    region: content
-    settings:
-      placeholder: ''
-    third_party_settings: {  }
-  field_organization_type:
-    type: string_textfield
-    weight: 12
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_policymaker_id:
+  field_classification_title:
     type: string_textfield
     weight: 14
     region: content
@@ -220,7 +133,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_top_category_name:
+  field_decision_attachments:
+    type: json_textarea
+    weight: 28
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_case_title:
     type: string_textfield
     weight: 10
     region: content
@@ -228,9 +149,174 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_decision_content:
+    type: text_textarea
+    weight: 22
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_content_parsed:
+    type: text_textarea
+    weight: 0
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_date:
+    type: datetime_default
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_decision_meeting:
+    type: json_textarea
+    weight: 26
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_motion:
+    type: text_textarea
+    weight: 23
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_motion_parsed:
+    type: text_textarea
+    weight: 0
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_native_id:
+    type: string_textfield
+    weight: 5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_organization:
+    type: json_textarea
+    weight: 24
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_previous:
+    type: json_textarea
+    weight: 29
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_record:
+    type: json_textarea
+    weight: 21
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_section:
+    type: string_textfield
+    weight: 9
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_diary_number:
+    type: string_textfield
+    weight: 11
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_diary_number_label:
+    type: string_textfield
+    weight: 12
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_dm_org_above_name:
+    type: string_textfield
+    weight: 23
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_dm_org_name:
+    type: string_textfield
+    weight: 21
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_full_title:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_meeting_id:
+    type: string_textfield
+    weight: 24
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_meeting_sequence_number:
+    type: number
+    weight: 25
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_organization_type:
+    type: string_textfield
+    weight: 22
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_policymaker_id:
+    type: string_textfield
+    weight: 20
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_top_category_name:
+    type: string_textfield
+    weight: 15
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_voting_results:
     type: json_textarea
-    weight: 22
+    weight: 27
     region: content
     settings:
       rows: 5
@@ -238,40 +324,40 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 25
+    weight: 30
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 35
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 28
+    weight: 33
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 31
+    weight: 36
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 34
+    weight: 39
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 29
+    weight: 34
     region: content
     settings:
       display_label: true
@@ -286,7 +372,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 26
+    weight: 31
     region: content
     settings:
       match_operator: CONTAINS
@@ -296,12 +382,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 32
+    weight: 37
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 33
+    weight: 38
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_form_display.node.decision.default.yml
@@ -60,7 +60,7 @@ third_party_settings:
       label: 'Decision data'
       region: content
       parent_name: ''
-      weight: 1
+      weight: 3
       format_type: details
       format_settings:
         classes: ''
@@ -79,7 +79,7 @@ third_party_settings:
       label: 'Organization data'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 4
       format_type: details
       format_settings:
         classes: ''
@@ -97,7 +97,7 @@ third_party_settings:
       label: 'Meeting data'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 5
       format_type: details
       format_settings:
         classes: ''
@@ -113,35 +113,11 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 32
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_classification_code:
-    type: string_textfield
-    weight: 13
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_classification_title:
-    type: string_textfield
-    weight: 14
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_attachments:
-    type: json_textarea
-    weight: 28
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_decision_case_title:
     type: string_textfield
     weight: 10
     region: content
@@ -149,9 +125,33 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_classification_title:
+    type: string_textfield
+    weight: 11
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_attachments:
+    type: json_textarea
+    weight: 16
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_case_title:
+    type: string_textfield
+    weight: 7
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_decision_content:
     type: text_textarea
-    weight: 22
+    weight: 14
     region: content
     settings:
       rows: 5
@@ -159,7 +159,7 @@ content:
     third_party_settings: {  }
   field_decision_content_parsed:
     type: text_textarea
-    weight: 0
+    weight: 1
     region: content
     settings:
       rows: 5
@@ -167,7 +167,7 @@ content:
     third_party_settings: {  }
   field_decision_date:
     type: datetime_default
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -181,7 +181,7 @@ content:
     third_party_settings: {  }
   field_decision_motion:
     type: text_textarea
-    weight: 23
+    weight: 15
     region: content
     settings:
       rows: 5
@@ -189,7 +189,7 @@ content:
     third_party_settings: {  }
   field_decision_motion_parsed:
     type: text_textarea
-    weight: 0
+    weight: 2
     region: content
     settings:
       rows: 5
@@ -197,7 +197,7 @@ content:
     third_party_settings: {  }
   field_decision_native_id:
     type: string_textfield
-    weight: 5
+    weight: 4
     region: content
     settings:
       size: 60
@@ -213,7 +213,7 @@ content:
     third_party_settings: {  }
   field_decision_previous:
     type: json_textarea
-    weight: 29
+    weight: 6
     region: content
     settings:
       rows: 5
@@ -221,7 +221,7 @@ content:
     third_party_settings: {  }
   field_decision_record:
     type: json_textarea
-    weight: 21
+    weight: 13
     region: content
     settings:
       rows: 5
@@ -229,7 +229,7 @@ content:
     third_party_settings: {  }
   field_decision_section:
     type: string_textfield
-    weight: 9
+    weight: 6
     region: content
     settings:
       size: 60
@@ -237,7 +237,7 @@ content:
     third_party_settings: {  }
   field_diary_number:
     type: string_textfield
-    weight: 11
+    weight: 8
     region: content
     settings:
       size: 60
@@ -245,7 +245,7 @@ content:
     third_party_settings: {  }
   field_diary_number_label:
     type: string_textfield
-    weight: 12
+    weight: 9
     region: content
     settings:
       size: 60
@@ -269,7 +269,7 @@ content:
     third_party_settings: {  }
   field_full_title:
     type: string_textfield
-    weight: 4
+    weight: 3
     region: content
     settings:
       size: 60
@@ -308,7 +308,7 @@ content:
     third_party_settings: {  }
   field_top_category_name:
     type: string_textfield
-    weight: 15
+    weight: 12
     region: content
     settings:
       size: 60
@@ -324,40 +324,40 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 30
+    weight: 7
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 35
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 33
+    weight: 10
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 36
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 39
+    weight: 16
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 34
+    weight: 11
     region: content
     settings:
       display_label: true
@@ -372,7 +372,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 31
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS
@@ -382,12 +382,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 37
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 38
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.default.yml
@@ -9,9 +9,11 @@ dependencies:
     - field.field.node.decision.field_decision_attachments
     - field.field.node.decision.field_decision_case_title
     - field.field.node.decision.field_decision_content
+    - field.field.node.decision.field_decision_content_parsed
     - field.field.node.decision.field_decision_date
     - field.field.node.decision.field_decision_meeting
     - field.field.node.decision.field_decision_motion
+    - field.field.node.decision.field_decision_motion_parsed
     - field.field.node.decision.field_decision_native_id
     - field.field.node.decision.field_decision_organization
     - field.field.node.decision.field_decision_previous
@@ -86,6 +88,13 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
+  field_decision_content_parsed:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 26
+    region: content
   field_decision_date:
     type: datetime_default
     label: above
@@ -108,6 +117,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_decision_motion_parsed:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 27
     region: content
   field_decision_native_id:
     type: string

--- a/conf/cmi/core.entity_view_display.node.decision.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.teaser.yml
@@ -10,9 +10,11 @@ dependencies:
     - field.field.node.decision.field_decision_attachments
     - field.field.node.decision.field_decision_case_title
     - field.field.node.decision.field_decision_content
+    - field.field.node.decision.field_decision_content_parsed
     - field.field.node.decision.field_decision_date
     - field.field.node.decision.field_decision_meeting
     - field.field.node.decision.field_decision_motion
+    - field.field.node.decision.field_decision_motion_parsed
     - field.field.node.decision.field_decision_native_id
     - field.field.node.decision.field_decision_organization
     - field.field.node.decision.field_decision_previous
@@ -49,9 +51,11 @@ hidden:
   field_decision_attachments: true
   field_decision_case_title: true
   field_decision_content: true
+  field_decision_content_parsed: true
   field_decision_date: true
   field_decision_meeting: true
   field_decision_motion: true
+  field_decision_motion_parsed: true
   field_decision_native_id: true
   field_decision_organization: true
   field_decision_previous: true

--- a/conf/cmi/field.field.node.decision.field_decision_content_parsed.yml
+++ b/conf/cmi/field.field.node.decision.field_decision_content_parsed.yml
@@ -1,0 +1,25 @@
+uuid: e0109af9-d92f-4cf9-9e45-be280d823902
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_decision_content_parsed
+    - node.type.decision
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.decision.field_decision_content_parsed
+field_name: field_decision_content_parsed
+entity_type: node
+bundle: decision
+label: 'Decision content'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/conf/cmi/field.field.node.decision.field_decision_motion_parsed.yml
+++ b/conf/cmi/field.field.node.decision.field_decision_motion_parsed.yml
@@ -1,0 +1,25 @@
+uuid: 5e31c33c-b527-42dc-bab8-a813e798daff
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_decision_motion_parsed
+    - node.type.decision
+  module:
+    - allowed_formats
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+id: node.decision.field_decision_motion_parsed
+field_name: field_decision_motion_parsed
+entity_type: node
+bundle: decision
+label: 'Decision motion'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/conf/cmi/field.storage.node.field_decision_content_parsed.yml
+++ b/conf/cmi/field.storage.node.field_decision_content_parsed.yml
@@ -1,0 +1,19 @@
+uuid: 4e5a6df5-6a14-4009-b6bd-a91c6a2d9e44
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_decision_content_parsed
+field_name: field_decision_content_parsed
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_decision_motion_parsed.yml
+++ b/conf/cmi/field.storage.node.field_decision_motion_parsed.yml
@@ -1,0 +1,19 @@
+uuid: aa148495-a4f6-4023-aa8c-e1ccadd89a54
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_decision_motion_parsed
+field_name: field_decision_motion_parsed
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/search_api.index.decisions.yml
+++ b/conf/cmi/search_api.index.decisions.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - field.storage.node.field_decision_case_title
     - field.storage.node.field_classification_title
+    - field.storage.node.field_decision_content_parsed
     - field.storage.node.field_decision_date
+    - field.storage.node.field_decision_motion_parsed
     - field.storage.node.field_diary_number
     - field.storage.node.field_full_title
     - field.storage.node.field_decision_native_id
@@ -31,6 +33,23 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_classification_title
+  decision_content:
+    label: 'Decision content'
+    datasource_id: 'entity:node'
+    property_path: field_decision_content_parsed
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_decision_content_parsed
+  decision_motion:
+    label: 'Decision motion'
+    datasource_id: 'entity:node'
+    property_path: field_decision_motion_parsed
+    type: text
+    boost: 0.5
+    dependencies:
+      config:
+        - field.storage.node.field_decision_motion_parsed
   id:
     label: 'Native ID'
     datasource_id: 'entity:node'
@@ -117,6 +136,7 @@ datasource_settings:
 processor_settings:
   add_url: {  }
   aggregated_field: {  }
+  entity_type: {  }
   language_with_fallback: {  }
   rendered_item: {  }
   sector_json: {  }

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
@@ -126,10 +126,24 @@ process:
     plugin: default_value
     default_value: plain_text
   field_decision_content/value: content
+  field_decision_content_parsed/value:
+    callable: _paatokset_ahjo_api_parse_decision_content
+    plugin: callback
+    source: content
+  field_decision_content_parsed/format:
+    plugin: default_value
+    default_value: full_html
   field_decision_motion/format:
     plugin: default_value
     default_value: plain_text
   field_decision_motion/value: motion
+  field_decision_motion_parsed/value:
+    callable: _paatokset_ahjo_api_parse_decision_motion
+    plugin: callback
+    source: motion
+  field_decision_motion_parsed/format:
+    plugin: default_value
+    default_value: full_html
   field_decision_attachments:
     plugin: callback
     callable: json_encode

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -659,6 +659,31 @@ function _paatokset_ahjo_api_get_top_category($value): ?string {
 }
 
 /**
+ * Parse decision content from raw HTML.
+ *
+ * @param mixed $value
+ * @return string|null
+ */
+function _paatokset_ahjo_api_parse_decision_content($value): string|null {
+  /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
+  $caseService = \Drupal::service('paatokset_ahjo_cases');
+  return $caseService->parseContentSectionsFromHtml((string) $value);
+}
+
+/**
+ * Parse decision motion from raw HTML.
+ *
+ * @param mixed $value
+ *
+ * @return string|null
+ */
+function _paatokset_ahjo_api_parse_decision_motion($value): string|null {
+  /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
+  $caseService = \Drupal::service('paatokset_ahjo_cases');
+  return $caseService->parseContentSectionsFromHtml((string) $value);
+}
+
+/**
  * Implements hook_entity_extra_field_info().
  */
 function paatokset_ahjo_api_entity_extra_field_info(): array {

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -693,6 +693,19 @@ class CaseService {
     }
 
     $html = $node->get($field_name)->value;
+    return $this->parseContentSectionsFromHtml($html);
+  }
+
+  /**
+   * Parse content sections from raw HTML.
+   *
+   * @param string $html
+   *   Input HTML.
+   *
+   * @return string|null
+   *   Content sections, if found.
+   */
+  public function parseContentSectionsFromHtml(string $html): ?string {
     $dom = new \DOMDocument();
     if (!empty($html)) {
       @$dom->loadHTML($html);

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -677,6 +677,40 @@ class CaseService {
   }
 
   /**
+   * Parse Ahjo API HTML main content from motion or content raw data.
+   *
+   * @param Drupal\node\NodeInterface $node
+   *   Decision node.
+   * @param string $field_name
+   *   Which field to get raw data from.
+   *
+   * @return string|null
+   *   Parsed content HTML as string, if found.
+   */
+  public function getDecisionContentFromHtml(NodeInterface $node, string $field_name): ?string {
+    if (!$node instanceof NodeInterface || !$node->hasField($field_name) || $node->get($field_name)->isEmpty()) {
+      return NULL;
+    }
+
+    $html = $node->get($field_name)->value;
+    $dom = new \DOMDocument();
+    if (!empty($html)) {
+      @$dom->loadHTML($html);
+    }
+    $xpath = new \DOMXPath($dom);
+
+    $content = NULL;
+    // Main decision content sections.
+    $sections = $xpath->query("//*[contains(@class, 'SisaltoSektio')]");
+
+    foreach ($sections as $section) {
+      $content .= $section->ownerDocument->saveHTML($section);
+    }
+
+    return $content;
+  }
+
+  /**
    * Split motions into sections.
    *
    * @param \DOMNodeList $list


### PR DESCRIPTION
**To test**
* Checkout branch
* SSH into the container and run `drush cr;drush cim -y`
* If you have decision data already, try running: `drush ap:dc -v`
  * This should update the decision content and motion fields.
  * Edit a few decisions from:  https://helsinki-paatokset.docker.so/fi/admin/content/decisions
  * They should have HTML content in the decision and motion fields. The content should also be cleaned up a bit compared to the field_decision_content and field_decision_motion fields found in the decision data group (removed HTML and HEAD tags, and only including the main content for example).
* Run `drush migrate-rollback ahjo_decisions:latest;drush migrate-import ahjo_decisions:latest`
* OR if you didn't have decision data migrated, just run: `drush ap:fs -v;drush mim ahjo_meetings:latest;drush mim ahjo_cases:latest;drush mim ahjo_decisions:latest;drush ap:ud --localdata`
* After the migration has been run, check the decisions list again. They should have the motion and content fields filled through the migration process
* Check the decisions search index fields: https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/decisions/fields
  * The decision_content and decision_motion fields should be configured
  * Index the content and check that the fields are actually indexed 