### PR TITLE
PP-276: Caseless decisions, agenda items without sequence numbers, document listing page titles

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -585,6 +585,13 @@ class CaseService {
       return [];
     }
 
+    if ($this->selectedDecision->hasField('field_diary_number') && !$this->selectedDecision->get('field_diary_number')->isEmpty()) {
+      $has_case_id = TRUE;
+    }
+    else {
+      $has_case_id = FALSE;
+    }
+
     $content = $this->selectedDecision->get('field_decision_content')->value;
     $motion = $this->selectedDecision->get('field_decision_motion')->value;
 
@@ -663,7 +670,7 @@ class CaseService {
     // Add decision date to appeal process accordion.
     // Do not display for motions, only for decisions.
     $appeal_content = NULL;
-    if ($content && $this->selectedDecision->hasField('field_decision_date') && !$this->selectedDecision->get('field_decision_date')->isEmpty()) {
+    if ($has_case_id && $content && $this->selectedDecision->hasField('field_decision_date') && !$this->selectedDecision->get('field_decision_date')->isEmpty()) {
       $decision_timestamp = strtotime($this->selectedDecision->get('field_decision_date')->value);
       $decision_date = date('d.m.Y', $decision_timestamp);
       $appeal_content = '<p class="issue__decision-date">' . t('This decision was published on <strong>@date</strong>', ['@date' => $decision_date]) . '</p>';
@@ -671,7 +678,7 @@ class CaseService {
 
     // Appeal information. Only display for decisions (if content is available).
     $appeal_info = $content_xpath->query("//*[contains(@class, 'MuutoksenhakuOtsikko')]");
-    if ($content && $appeal_info) {
+    if ($has_case_id && $content && $appeal_info) {
       $appeal_content .= $this->getHtmlContentUntilBreakingElement($appeal_info);
     }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
@@ -84,11 +84,14 @@ class TrusteeService {
       return NULL;
     }
 
-    return [[
+    // Placeholder content for layout before API integration is implemented.
+    $content = [
       'meeting' => 'Kaupunginvaltuuston kokous 2021/26',
       'speaking_turn' => '13. Kansanäänestysaloite Malmin lentokentän säilyttämisestä ilmailukäytössä (2:13)',
-      'link' => '/'
-    ]];
+      'link' => '/',
+    ];
+
+    return [$content];
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
@@ -20,7 +20,7 @@ class TrusteeService {
    * @return string
    *   The title transformed into name string
    */
-  public static function getTrusteeName(NodeInterface $trustee) {
+  public static function getTrusteeName(NodeInterface $trustee): string {
     return self::transformTrusteeName($trustee->getTitle());
   }
 
@@ -35,7 +35,7 @@ class TrusteeService {
    * @return string
    *   The title transformed into name string
    */
-  public static function transformTrusteeName(string $title) {
+  public static function transformTrusteeName(string $title): string {
     $nameParts = explode(',', $title);
     return $nameParts[1] . ' ' . $nameParts[0];
   }
@@ -46,21 +46,49 @@ class TrusteeService {
    * @param Drupal\node\NodeInterface $trustee
    *   The trustee node.
    *
-   * @return string|void
-   *   The trustee title to display or void
+   * @return string|null
+   *   The trustee title to display or NULL
    */
-  public static function getTrusteeTitle(NodeInterface $trustee) {
+  public static function getTrusteeTitle(NodeInterface $trustee): ?string {
+    if (!$trustee->hasField('field_trustee_title') || $trustee->get('field_trustee_title')->isEmpty()) {
+      return NULL;
+    }
+
     if ($title = $trustee->get('field_trustee_title')->value) {
-      if ($title == 'Jäsen') {
+
+      if ($title === 'Jäsen') {
         return t('Valtuutettu');
       }
 
-      if ($title == 'Varajäsen') {
+      if ($title === 'Varajäsen') {
         return t('Varavaltuutettu');
       }
 
       return $title;
     }
+  }
+
+  /**
+   * Get trustee speaking turns from Datapumppu integration.
+   *
+   * Note: Not implemented yet!
+   *
+   * @param Drupal\node\NodeInterface $trustee
+   *   Trustee node.
+   *
+   * @return array|null
+   *   Trustee's speaking turns from the API, if found.
+   */
+  public static function getSpeakingTurns(NodeInterface $trustee): ?array {
+    if (!$trustee->hasField('field_trustee_datapumppu_id') || $trustee->get('field_trustee_datapumppu_id')->isEmpty()) {
+      return NULL;
+    }
+
+    return [[
+      'meeting' => 'Kaupunginvaltuuston kokous 2021/26',
+      'speaking_turn' => '13. Kansanäänestysaloite Malmin lentokentän säilyttämisestä ilmailukäytössä (2:13)',
+      'link' => '/'
+    ]];
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo_api/templates/component/agenda-item--list-item.html.twig
+++ b/public/modules/custom/paatokset_ahjo_api/templates/component/agenda-item--list-item.html.twig
@@ -10,7 +10,9 @@
   {% if agenda_item.link %}
     <a href="{{ agenda_item.link }}">
   {% endif %}
-    <span class="agenda-item__index-number">{{ agenda_item.index }}</span>
+    {% if agenda_item.index %}
+      <span class="agenda-item__index-number">{{ agenda_item.index }}</span>
+    {% endif %}
     <span class="agenda-item__subject">{{ agenda_item.subject }}</span>
   {% if agenda_item.link %}
     {% include '@hdbt/misc/icon.twig' with {icon: 'arrow-right'} %}

--- a/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerController.php
+++ b/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerController.php
@@ -51,7 +51,15 @@ class PolicymakerController extends ControllerBase {
    *   Documents title.
    */
   public static function getDocumentsTitle(): TranslatableMarkup {
-    return t('Documents');
+    $policymakerService = \Drupal::service('paatokset_policymakers');
+    $policymakerService->setPolicyMakerByPath();
+    $policymaker = $policymakerService->getPolicymaker();
+
+    if (!$policymaker instanceof NodeInterface) {
+      return t('Documents');
+    }
+
+    return t('Documents: @name', ['@name' => $policymaker->get('title')->value]);
   }
 
   /**
@@ -87,7 +95,15 @@ class PolicymakerController extends ControllerBase {
    *   Decisions title.
    */
   public static function getDecisionsTitle(): TranslatableMarkup {
-    return t('Decisions');
+    $policymakerService = \Drupal::service('paatokset_policymakers');
+    $policymakerService->setPolicyMakerByPath();
+    $policymaker = $policymakerService->getPolicymaker();
+
+    if (!$policymaker instanceof NodeInterface) {
+      return t('Decisions');
+    }
+
+    return t('Decisions: @name', ['@name' => $policymaker->get('title')->value]);
   }
 
   /**
@@ -138,7 +154,15 @@ class PolicymakerController extends ControllerBase {
    *   Discussions title.
    */
   public static function getDiscussionMinutesTitle(): TranslatableMarkup {
-    return t('Discussion minutes');
+    $policymakerService = \Drupal::service('paatokset_policymakers');
+    $policymakerService->setPolicyMakerByPath();
+    $policymaker = $policymakerService->getPolicymaker();
+
+    if (!$policymaker instanceof NodeInterface) {
+      return t('Discussion minutes');
+    }
+
+    return t('Discussion minutes: @name', ['@name' => $policymaker->get('title')->value]);
   }
 
   /**

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -789,7 +789,8 @@ class PolicymakerService {
           'index' => $index,
           'link' => $agenda_link,
         ];
-      } else {
+      }
+      else {
         $agendaItems[] = [
           'subject' => $data['AgendaItem'],
           'index' => $index,
@@ -864,7 +865,7 @@ class PolicymakerService {
 
         if ($entity->get('field_document')->target_id) {
           $file_id = $entity->get('field_document')->target_id;
-          $download_link = file_create_url(File::load($file_id)->getFileUri());
+          $download_link = \Drupal::service('file_url_generator')->generateAbsoluteString(File::load($file_id)->getFileUri());
           $result['origin_url'] = $download_link;
         }
 
@@ -878,49 +879,6 @@ class PolicymakerService {
     }
 
     return $transformedResults;
-  }
-
-  /**
-   * Get all policymaker documents.
-   *
-   * @return array
-   *   Array of resulting documents
-   */
-  public function getDocumentData() : array {
-    $documents = $this->getMinutesOfDiscussion();
-    $declarationsOfAffiliation = $this->getDeclarationsOfAffilition();
-
-    foreach ($declarationsOfAffiliation as $declaration) {
-      $date = $declaration->get('created')->value;
-      $title = $declaration->name->value;
-      $year = date('Y', $date);
-      if (!isset($documents['years'])) {
-        $documents['years'][$year] = [
-          '#type' => 'link',
-          '#title' => $year,
-        ];
-      }
-
-      $file_id = $declaration->get('field_document')->target_id;
-      if ($declaration->get('field_document')->target_id) {
-        $download_link = Url::fromUri(file_create_url(File::load($file_id)->getFileUri()));
-      }
-
-      $documents['list'][$year][] = [
-        '#type' => 'link',
-        '#responsiveDate' => date("m-Y", $date),
-        '#responsiveTitle' => $title,
-        '#date' => date("d.m.Y", $date),
-        '#timestamp' => $date,
-        '#year' => $year,
-        '#title' => $title,
-        '#url' => '',
-        '#download_link' => $download_link ?? NULL,
-        '#download_label' => str_replace(' ', '_', $title),
-      ];
-    }
-
-    return $documents;
   }
 
   /**

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
@@ -116,7 +116,19 @@ class PolicymakerSideNav extends BlockBase {
       $localizedRoute = "$route.$currentLanguage";
       if ($this->policymakerService->routeExists($localizedRoute)) {
         $route = $routeProvider->getRouteByName($localizedRoute);
-        $title = call_user_func($route->getDefault('_title_callback'))->render();
+        if ($key === 'documents') {
+          $title = t('Documents');
+        }
+        elseif ($key === 'decisions') {
+          $title = t('Decisions');
+        }
+        elseif ($key === 'discussion_minutes') {
+          $title = t('Discussion minutes');
+        }
+        else {
+          $title = call_user_func($route->getDefault('_title_callback'))->render();
+        }
+
         $items[] = [
           'title' => $title,
           'url' => Url::fromRoute($localizedRoute, ['organization' => $policymaker_org]),

--- a/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
+++ b/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
@@ -283,24 +283,17 @@ function helfi_paatokset_preprocess_node__trustee(&$variables) {
     ];
   };
 
-  //TO-DO: change to use actual data from datapumppu
-  $content_speaking_turns[] = [
-    'meeting' => 'Kaupunginvaltuuston kokous 2021/26',
-    'speaking_turn' => '13. Kansanäänestysaloite Malmin lentokentän säilyttämisestä ilmailukäytössä (2:13)',
-    'link' => '/'
-  ];
+  if ($speaking_turns = TrusteeService::getSpeakingTurns($node)) {
+    $variables['speaking_turns'] = [
+      'title' => t('Valtuutetun puheenvuorot'),
+      'content' => $speaking_turns,
+    ];
+  }
 
-  $variables['speaking_turns'] = [
-    'title' => t('Valtuutetun puheenvuorot'),
-    'content' => $content_speaking_turns
-  ];
-
-  if(
-    $trustee_title = $node->get('field_trustee_title')->value &&
-    ($trustee_title === 'Jäsen' || $trustee_title === 'Varajäsen')
-  ) {
-    $variables['content']['field_trustee_title'] = TrusteeService::getTrusteeTitle($node);
-  };
+  $trustee_title = TrusteeService::getTrusteeTitle($node);
+  if ($trustee_title) {
+    $variables['content']['field_trustee_title'] = $trustee_title;
+  }
 
   if(isset($node->field_policymaker_reference->entity)) {
     $policymaker = $node->field_policymaker_reference->entity;
@@ -317,13 +310,13 @@ function helfi_paatokset_preprocess_node__trustee(&$variables) {
       ]
     );
   };
-  
+
   // Check if there are any DOAs for the trustee
   $doaQuery = \Drupal::entityQuery('media')
     ->condition('bundle', 'declaration_of_affiliation')
     ->condition('field__policymaker_reference', $node->id())
     ->execute();
-  
+
   if(!empty($doaQuery)) {
     // Display only one DOA for the page - there should be only one of these per trustee.
     $doa = Media::load(reset($doaQuery));

--- a/public/themes/custom/helfi_paatokset/templates/content/node--trustee.html.twig
+++ b/public/themes/custom/helfi_paatokset/templates/content/node--trustee.html.twig
@@ -101,7 +101,7 @@
   <div class="trustee-image">
       {{ content.field_trustee_image }}
     </div>
-  {% if 
+  {% if
     content.field_trustee_profession|render or
     content.field_trustee_home_district|render or
     content.field_trustee_email|render or
@@ -137,6 +137,7 @@
     </div>
   {% endif %}
 
+  {% if speaking_turns.content is not empty %}
   <div class="accordion__wrapper handorgel accordion_speaking-turn">
     <h4 class="accordion-item__header handorgel__header">
       <button class="accordion-item__button accordion-item__button--toggle handorgel__header__button">
@@ -152,7 +153,6 @@
         <div>
           <div class="speaking-turn__meeting">{{ row.meeting }}</div>
           <div class="speaking-turn__link-container">
-            {% include '@hdbt/misc/icon.twig' with {icon: 'videocamera'} %}
             <a class="speaking-turn__link" href="{{row.link}}">{{ row.speaking_turn }}</a>
           </div>
         </div>
@@ -164,8 +164,9 @@
       </div>
     </div>
   </div>
+  {% endif %}
 
-  {% if initiatives.content|length > 0 %}
+  {% if initiatives.content is not empty %}
   <div class="accordion__wrapper handorgel accordion_initiatives">
     <h4 class="accordion-item__header handorgel__header">
       <button class="accordion-item__button accordion-item__button--toggle handorgel__header__button">
@@ -192,7 +193,7 @@
   </div>
   {% endif %}
 
-  {% if resolutions.content|length > 0 %}
+  {% if resolutions.content is not empty %}
   <div class="accordion__wrapper handorgel accordion_resolutions">
     <h4 class="accordion-item__header handorgel__header">
       <button class="accordion-item__button accordion-item__button--toggle handorgel__header__button">


### PR DESCRIPTION
**To test**
- Checkout branch
- Run `make drush-cim;make drush-cr`
- If you don't have data from Ahjo imported yet, SSH into the container and run: `drush ap:fs;drush ahjo_meetings:latest;drush ahjo_cases:latest;drush ahjo_decisions:latest;drush ahjo_decisionmakers:all;drush ahjo_trustees:council;drush ap:ud --localdata`
- Find some decisions without a diary number: https://helsinki-paatokset.docker.so/fi/admin/content/decisions?title=&field_diary_number_value=&field_decision_native_id_value=&field_decision_motion_value=All&field_decision_content_value=All&order=field_diary_number&sort=asc
  - The "Appeal process" accordion should not be visible and the layout shouldn't break
- Edit a meeting: https://helsinki-paatokset.docker.so/fi/node/689/edit
  - In meeting data -> agenda, edit some of the agenda items. Don't edit the swedish ones, since they won't be visible anyway
  - For one or two, change the "AgendaPoint" value to "null", with the quotes (that's how we get it from the API).
  - For one, change it to null without the quotes
  - For another, remove the "AgendaPoint" property completely
  - Save the node and open the related meeting minutes page (link to this can be found if you view the meeting node).
  - The agenda items you changed should appear without index numbers at the end of the list. (If the updated values aren't visible, run `make drush-cr`)
- Open some decision maker pages: https://helsinki-paatokset.docker.so/fi/admin/content/decisionmakers
  - Open the "Documents", "Minutes of discussion" and "Decision" subpages.
  - The title HTML element should be in this format: "[subpage]: [decisionmaker title] | Helsingin Kaupunki"
  - The values in the subnavi shouldn't have the decisionmaker title included
- Open some trustee pages: https://helsinki-paatokset.docker.so/fi/admin/content/trustees
  - The trustee titles should now be transformed from "Jäsen" and "Varajäsen" to "Valtuutettu" and "Varavaltuutettu"
  - The "Valtuutetun puheenvuorot" section should now be missing
  - Edit the trustee page and add some value to the "Datapumppu ID" field, then save
  - The puheenvuorot section should now appear with placeholder data