### PR TITLE
PP-270: Install Editoria11y module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "druidfi/omen": "^0.2.0",
         "drupal/core-composer-scaffold": "^9.1",
         "drupal/core-recommended": "^9.1",
+        "drupal/editoria11y": "^1.0",
         "drupal/elasticsearch_connector": "^7.0@alpha",
         "drupal/hdbt": "^2.0",
         "drupal/hdbt_admin": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -2967,6 +2967,54 @@
             }
         },
         {
+            "name": "drupal/editoria11y",
+            "version": "1.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/editoria11y.git",
+                "reference": "1.0.10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/editoria11y-1.0.10.zip",
+                "reference": "1.0.10",
+                "shasum": "0ab4ddf2746c627afb9539bbe7f90047c3b19e7d"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.10",
+                    "datestamp": "1643919343",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bkosborne",
+                    "homepage": "https://www.drupal.org/user/788032"
+                },
+                {
+                    "name": "itmaybejj",
+                    "homepage": "https://www.drupal.org/user/1177504"
+                }
+            ],
+            "description": "Checks for accessibility in page content.",
+            "homepage": "https://www.drupal.org/project/editoria11y",
+            "support": {
+                "source": "https://git.drupalcode.org/project/editoria11y"
+            }
+        },
+        {
             "name": "drupal/elasticsearch_connector",
             "version": "7.0.0-alpha3",
             "source": {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -26,6 +26,7 @@ module:
   dynamic_page_cache: 0
   easy_breadcrumb: 0
   editor: 0
+  editoria11y: 0
   elasticsearch_connector: 0
   entity: 0
   entity_reference_revisions: 0

--- a/conf/cmi/editoria11y.settings.yml
+++ b/conf/cmi/editoria11y.settings.yml
@@ -1,0 +1,11 @@
+_core:
+  default_config_hash: NGxFi-xycxrzrGVZtCUl7MACi0jVRk130tNabvIN6ng
+content_root: ''
+no_load: ''
+ignore_containers: ''
+embedded_content_warning: ''
+allow_overflow: ''
+assertiveness: smart
+download_links: ''
+ignore_link_strings: ''
+hidden_handlers: ''

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -3,9 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.full_html
     - media.type.ahjo_document
     - media.type.declaration_of_affiliation
     - media.type.file
+    - media.type.hel_map
+    - media.type.helfi_chart
     - media.type.image
     - media.type.minutes_of_the_discussion
     - media.type.policymaker_images
@@ -16,19 +19,26 @@ dependencies:
     - node.type.imported_article
     - node.type.landing_page
     - node.type.meeting
+    - node.type.news_item
     - node.type.page
     - node.type.policymaker
     - taxonomy.vocabulary.keywords
+    - taxonomy.vocabulary.news_tags
     - taxonomy.vocabulary.pdf_categories
   module:
     - block
+    - config_translation
+    - content_lock
     - content_translation
+    - editoria11y
     - eu_cookie_compliance
     - file
+    - filter
     - helfi_api_base
     - helfi_tpr
     - locale
     - media
+    - menu_link_attributes
     - menu_link_content
     - node
     - paatokset_ahjo_proxy
@@ -36,23 +46,25 @@ dependencies:
     - paragraphs_library
     - path
     - pathauto
+    - publication_date
     - redirect
+    - role_delegation
     - scheduler
     - simple_sitemap
     - system
     - taxonomy
     - toolbar
     - view_unpublished
-    - content_lock
 _core:
   default_config_hash: wJWcExCcstsjfohW4IUVRm742x2vKz6nOlZpa3OG7yQ
 id: admin
-label: Administrator
+label: Pääkäyttäjä
 weight: 5
 is_admin: null
 permissions:
   - 'access administration pages'
   - 'access ahjo documents'
+  - 'access content'
   - 'access content overview'
   - 'access files overview'
   - 'access media overview'
@@ -65,8 +77,10 @@ permissions:
   - 'access tpr_unit overview'
   - 'access user profiles'
   - 'administer blocks'
+  - 'administer editoria11y checker'
   - 'administer eu cookie compliance categories'
   - 'administer eu cookie compliance popup'
+  - 'administer hotjar settings'
   - 'administer media'
   - 'administer media types'
   - 'administer menu'
@@ -78,6 +92,11 @@ permissions:
   - 'administer taxonomy'
   - 'administer url aliases'
   - 'administer users'
+  - 'assign admin role'
+  - 'assign content_producer role'
+  - 'assign editor role'
+  - 'assign read_only role'
+  - 'break content lock'
   - 'bypass node access'
   - 'cancel account'
   - 'change own username'
@@ -85,11 +104,14 @@ permissions:
   - 'create content translations'
   - 'create declaration_of_affiliation media'
   - 'create file media'
+  - 'create hel_map media'
+  - 'create helfi_chart media'
   - 'create image media'
   - 'create imported_article content'
   - 'create landing_page content'
   - 'create media'
   - 'create minutes_of_the_discussion media'
+  - 'create news_item content'
   - 'create page content'
   - 'create paragraph library item'
   - 'create policymaker content'
@@ -98,6 +120,7 @@ permissions:
   - 'create remote_video media'
   - 'create soundcloud media'
   - 'create terms in keywords'
+  - 'create terms in news_tags'
   - 'create terms in pdf_categories'
   - 'create tpr_service'
   - 'create tpr_unit'
@@ -106,11 +129,14 @@ permissions:
   - 'delete any article content'
   - 'delete any declaration_of_affiliation media'
   - 'delete any file media'
+  - 'delete any hel_map media'
+  - 'delete any helfi_chart media'
   - 'delete any image media'
   - 'delete any imported_article content'
   - 'delete any landing_page content'
   - 'delete any media'
   - 'delete any minutes_of_the_discussion media'
+  - 'delete any news_item content'
   - 'delete any page content'
   - 'delete any policymaker content'
   - 'delete any policymaker_images media'
@@ -127,10 +153,13 @@ permissions:
   - 'delete own article content'
   - 'delete own declaration_of_affiliation media'
   - 'delete own file media'
+  - 'delete own hel_map media'
+  - 'delete own helfi_chart media'
   - 'delete own image media'
   - 'delete own imported_article content'
   - 'delete own landing_page content'
   - 'delete own minutes_of_the_discussion media'
+  - 'delete own news_item content'
   - 'delete own page content'
   - 'delete own policymaker content'
   - 'delete own policymaker_images media'
@@ -142,16 +171,20 @@ permissions:
   - 'delete policymaker revisions'
   - 'delete remote entities'
   - 'delete terms in keywords'
+  - 'delete terms in news_tags'
   - 'delete terms in pdf_categories'
   - 'edit any article content'
   - 'edit any case content'
   - 'edit any declaration_of_affiliation media'
   - 'edit any file media'
+  - 'edit any hel_map media'
+  - 'edit any helfi_chart media'
   - 'edit any image media'
   - 'edit any imported_article content'
   - 'edit any landing_page content'
   - 'edit any meeting content'
   - 'edit any minutes_of_the_discussion media'
+  - 'edit any news_item content'
   - 'edit any page content'
   - 'edit any policymaker content'
   - 'edit any policymaker_images media'
@@ -161,11 +194,14 @@ permissions:
   - 'edit own case content'
   - 'edit own declaration_of_affiliation media'
   - 'edit own file media'
+  - 'edit own hel_map media'
+  - 'edit own helfi_chart media'
   - 'edit own image media'
   - 'edit own imported_article content'
   - 'edit own landing_page content'
   - 'edit own meeting content'
   - 'edit own minutes_of_the_discussion media'
+  - 'edit own news_item content'
   - 'edit own page content'
   - 'edit own policymaker content'
   - 'edit own policymaker_images media'
@@ -174,6 +210,7 @@ permissions:
   - 'edit paragraph library item'
   - 'edit remote entities'
   - 'edit terms in keywords'
+  - 'edit terms in news_tags'
   - 'edit terms in pdf_categories'
   - 'revert all revisions'
   - 'revert article revisions'
@@ -183,8 +220,11 @@ permissions:
   - 'revert page revisions'
   - 'revert policymaker revisions'
   - 'schedule publishing of nodes'
+  - 'set landing_page published on date'
+  - 'set page published on date'
   - 'translate any entity'
   - 'translate article node'
+  - 'translate configuration'
   - 'translate editable entities'
   - 'translate file media'
   - 'translate image media'
@@ -192,6 +232,8 @@ permissions:
   - 'translate keywords taxonomy_term'
   - 'translate landing_page node'
   - 'translate menu_link_content'
+  - 'translate news_item node'
+  - 'translate news_tags taxonomy_term'
   - 'translate page node'
   - 'translate pdf_categories taxonomy_term'
   - 'translate remote_video media'
@@ -207,6 +249,9 @@ permissions:
   - 'update media'
   - 'update own tpr_service'
   - 'update own tpr_unit'
+  - 'use menu link attributes'
+  - 'use text format full_html'
+  - 'use text format minimal'
   - 'view all media revisions'
   - 'view all revisions'
   - 'view all tpr_service revisions'
@@ -214,8 +259,10 @@ permissions:
   - 'view any unpublished content'
   - 'view article revisions'
   - 'view case revisions'
+  - 'view editoria11y checker'
   - 'view imported_article revisions'
   - 'view landing_page revisions'
+  - 'view media'
   - 'view meeting revisions'
   - 'view own unpublished content'
   - 'view own unpublished media'
@@ -229,37 +276,3 @@ permissions:
   - 'view tpr_service'
   - 'view tpr_unit'
   - 'view unpublished paragraphs'
-  - 'assign admin role'
-  - 'assign content_producer role'
-  - 'assign read_only role'
-  - 'create helfi_chart media'
-  - 'delete any helfi_chart media'
-  - 'delete own helfi_chart media'
-  - 'edit any helfi_chart media'
-  - 'edit own helfi_chart media'
-  - 'create news_item content'
-  - 'create terms in news_tags'
-  - 'delete any news_item content'
-  - 'delete own news_item content'
-  - 'delete terms in news_tags'
-  - 'edit any news_item content'
-  - 'edit own news_item content'
-  - 'edit terms in news_tags'
-  - 'translate news_item node'
-  - 'translate news_tags taxonomy_term'
-  - 'create hel_map media'
-  - 'delete any hel_map media'
-  - 'delete own hel_map media'
-  - 'edit any hel_map media'
-  - 'edit own hel_map media'
-  - 'access content'
-  - 'administer hotjar settings'
-  - 'assign editor role'
-  - 'set landing_page published on date'
-  - 'set page published on date'
-  - 'translate configuration'
-  - 'use menu link attributes'
-  - 'use text format full_html'
-  - 'use text format minimal'
-  - 'view media'
-  - 'break content lock'

--- a/conf/cmi/user.role.anonymous.yml
+++ b/conf/cmi/user.role.anonymous.yml
@@ -11,7 +11,7 @@ dependencies:
 _core:
   default_config_hash: EDyVdaROG6pYzyEct43c01Wq4gpATszrk-qR6gqnQ84
 id: anonymous
-label: 'Anonymous user'
+label: 'Anonyymi käyttäjä'
 weight: 0
 is_admin: false
 permissions:

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -2,26 +2,24 @@ uuid: 81cd258a-8e4e-4a01-869a-c329952a4773
 langcode: en
 status: true
 dependencies:
-  config:
-    - filter.format.full_html
   module:
     - eu_cookie_compliance
-    - filter
     - helfi_api_base
     - helfi_tpr
     - media
     - system
+    - toolbar
 _core:
   default_config_hash: 83Nuup-6oYkkdAsvg3nrR2pBOgtTXEV1JrzpCCLkYLM
 id: authenticated
-label: 'Authenticated user'
+label: 'Sisäänkirjautunut käyttäjä'
 weight: 1
 is_admin: false
 permissions:
   - 'access content'
+  - 'access toolbar'
   - 'display eu cookie compliance popup'
   - 'view media'
   - 'view remote entities'
   - 'view tpr_service'
   - 'view tpr_unit'
-  - 'access toolbar'

--- a/conf/cmi/user.role.content_producer.yml
+++ b/conf/cmi/user.role.content_producer.yml
@@ -3,9 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.full_html
     - media.type.ahjo_document
     - media.type.declaration_of_affiliation
     - media.type.file
+    - media.type.hel_map
+    - media.type.helfi_chart
     - media.type.image
     - media.type.minutes_of_the_discussion
     - media.type.policymaker_images
@@ -14,19 +17,23 @@ dependencies:
     - node.type.article
     - node.type.imported_article
     - node.type.landing_page
+    - node.type.news_item
     - node.type.page
     - node.type.policymaker
     - taxonomy.vocabulary.keywords
     - taxonomy.vocabulary.pdf_categories
   module:
     - content_translation
+    - editoria11y
     - file
+    - filter
     - helfi_api_base
     - media
     - node
     - paragraphs
     - paragraphs_library
     - path
+    - publication_date
     - scheduler
     - system
     - taxonomy
@@ -35,7 +42,7 @@ dependencies:
 _core:
   default_config_hash: XhNzDGDspXeMyW4TAki8MB6z-vzBwmtP_efemgX6-HI
 id: content_producer
-label: 'Content producer'
+label: 'Sisällöntuottaja suppea'
 weight: 3
 is_admin: null
 permissions:
@@ -50,17 +57,21 @@ permissions:
   - 'administer media'
   - 'administer media types'
   - 'administer nodes'
+  - 'administer paragraphs library'
   - 'administer taxonomy'
   - 'cancel account'
   - 'change own username'
   - 'create article content'
   - 'create declaration_of_affiliation media'
   - 'create file media'
+  - 'create hel_map media'
+  - 'create helfi_chart media'
   - 'create image media'
   - 'create imported_article content'
   - 'create landing_page content'
   - 'create media'
   - 'create minutes_of_the_discussion media'
+  - 'create news_item content'
   - 'create page content'
   - 'create paragraph library item'
   - 'create policymaker content'
@@ -91,10 +102,13 @@ permissions:
   - 'delete own article content'
   - 'delete own declaration_of_affiliation media'
   - 'delete own file media'
+  - 'delete own hel_map media'
+  - 'delete own helfi_chart media'
   - 'delete own image media'
   - 'delete own imported_article content'
   - 'delete own landing_page content'
   - 'delete own minutes_of_the_discussion media'
+  - 'delete own news_item content'
   - 'delete own page content'
   - 'delete own policymaker content'
   - 'delete own policymaker_images media'
@@ -107,10 +121,12 @@ permissions:
   - 'edit any article content'
   - 'edit any declaration_of_affiliation media'
   - 'edit any file media'
+  - 'edit any helfi_chart media'
   - 'edit any image media'
   - 'edit any imported_article content'
   - 'edit any landing_page content'
   - 'edit any minutes_of_the_discussion media'
+  - 'edit any news_item content'
   - 'edit any page content'
   - 'edit any policymaker content'
   - 'edit any policymaker_images media'
@@ -119,10 +135,13 @@ permissions:
   - 'edit own article content'
   - 'edit own declaration_of_affiliation media'
   - 'edit own file media'
+  - 'edit own hel_map media'
+  - 'edit own helfi_chart media'
   - 'edit own image media'
   - 'edit own imported_article content'
   - 'edit own landing_page content'
   - 'edit own minutes_of_the_discussion media'
+  - 'edit own news_item content'
   - 'edit own page content'
   - 'edit own policymaker content'
   - 'edit own policymaker_images media'
@@ -137,14 +156,20 @@ permissions:
   - 'revert page revisions'
   - 'revert policymaker revisions'
   - 'schedule publishing of nodes'
+  - 'set landing_page published on date'
+  - 'set page published on date'
   - 'translate editable entities'
   - 'update any media'
   - 'update media'
+  - 'use text format full_html'
+  - 'use text format minimal'
   - 'view all media revisions'
   - 'view all revisions'
+  - 'view any unpublished content'
   - 'view any unpublished landing_page content'
   - 'view any unpublished page content'
   - 'view article revisions'
+  - 'view editoria11y checker'
   - 'view imported_article revisions'
   - 'view landing_page revisions'
   - 'view own unpublished content'
@@ -155,20 +180,3 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
-  - 'create helfi_chart media'
-  - 'delete own helfi_chart media'
-  - 'edit own helfi_chart media'
-  - 'create news_item content'
-  - 'delete own news_item content'
-  - 'edit any news_item content'
-  - 'edit own news_item content'
-  - 'create hel_map media'
-  - 'delete own hel_map media'
-  - 'edit own hel_map media'
-  - 'administer paragraphs library'
-  - 'set landing_page published on date'
-  - 'set page published on date'
-  - 'use text format full_html'
-  - 'use text format minimal'
-  - 'view any unpublished content'
-  - 'edit any helfi_chart media'

--- a/conf/cmi/user.role.editor.yml
+++ b/conf/cmi/user.role.editor.yml
@@ -1,9 +1,40 @@
 uuid: 1c0c28c3-45e1-40b2-a342-f3c27da44120
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.full_html
+    - media.type.file
+    - media.type.helfi_chart
+    - media.type.image
+    - media.type.remote_video
+    - media.type.soundcloud
+    - node.type.landing_page
+    - node.type.page
+    - taxonomy.vocabulary.keywords
+  module:
+    - content_translation
+    - editoria11y
+    - file
+    - filter
+    - helfi_api_base
+    - locale
+    - media
+    - menu_link_attributes
+    - menu_link_content
+    - node
+    - paragraphs
+    - paragraphs_library
+    - path
+    - publication_date
+    - redirect
+    - scheduler
+    - system
+    - taxonomy
+    - toolbar
+    - view_unpublished
 id: editor
-label: Editor
+label: 'Sisällöntuottaja laaja'
 weight: 4
 is_admin: null
 permissions:
@@ -25,6 +56,7 @@ permissions:
   - 'change own username'
   - 'create content translations'
   - 'create file media'
+  - 'create helfi_chart media'
   - 'create image media'
   - 'create landing_page content'
   - 'create media'
@@ -36,6 +68,7 @@ permissions:
   - 'create terms in keywords'
   - 'create url aliases'
   - 'delete any file media'
+  - 'delete any helfi_chart media'
   - 'delete any image media'
   - 'delete any landing_page content'
   - 'delete any media'
@@ -46,6 +79,7 @@ permissions:
   - 'delete landing_page revisions'
   - 'delete media'
   - 'delete own file media'
+  - 'delete own helfi_chart media'
   - 'delete own image media'
   - 'delete own landing_page content'
   - 'delete own page content'
@@ -55,12 +89,14 @@ permissions:
   - 'delete remote entities'
   - 'delete terms in keywords'
   - 'edit any file media'
+  - 'edit any helfi_chart media'
   - 'edit any image media'
   - 'edit any landing_page content'
   - 'edit any page content'
   - 'edit any remote_video media'
   - 'edit any soundcloud media'
   - 'edit own file media'
+  - 'edit own helfi_chart media'
   - 'edit own image media'
   - 'edit own landing_page content'
   - 'edit own page content'
@@ -94,6 +130,7 @@ permissions:
   - 'view all media revisions'
   - 'view all revisions'
   - 'view any unpublished content'
+  - 'view editoria11y checker'
   - 'view landing_page revisions'
   - 'view own unpublished content'
   - 'view own unpublished media'
@@ -101,8 +138,3 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
-  - 'create helfi_chart media'
-  - 'delete any helfi_chart media'
-  - 'delete own helfi_chart media'
-  - 'edit any helfi_chart media'
-  - 'edit own helfi_chart media'

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -7,7 +7,7 @@ dependencies:
     - toolbar
     - view_unpublished
 id: read_only
-label: 'Read only'
+label: Lukija
 weight: 2
 is_admin: null
 permissions:


### PR DESCRIPTION
**To test**
- Checkout branch, run `make composer-install drush-cr drush-cim`
- Login as admin or content creator
- Navigate around the site. You should see the new icon in the bottom right corner
- Open a decision / case node. There should be some errors
- The example content pages should have some manual checks visible: https://helsinki-paatokset.docker.so/fi/esimerkkisivu
- Edit the example page and add a H6 heading somewhere in the content. Save the node. The module should notify you that the heading level jumped from H2 / H3 to H6.