### PR TITLE
PP-303: Bump paatokset_search version to 0.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drush/drush": "^10.4",
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
-        "paatokset/paatokset_search": "0.2.3"
+        "paatokset/paatokset_search": "0.2.4"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -112,9 +112,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "0.2.3",
+                "version": "0.2.4",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.3/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.4/paatokset_search.zip",
                     "type": "zip"
                 }
             }
@@ -123,11 +123,11 @@
     "scripts": {
         "copy-commit-message-script": "make copy-commit-message-script",
         "post-install-cmd": [
-            "rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
+            "rm -rf public/modules/custom/paatokset_search/assets && rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
             "@copy-commit-message-script"
         ],
         "post-update-cmd": [
-            "rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
+            "rm -rf public/modules/custom/paatokset_search/assets && rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
             "@copy-commit-message-script"
         ]
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7be9105cbb1b7dbccaf92408fe953e4c",
+    "content-hash": "7894acada2d68f9f7f3c1aab301fbc5c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7945,10 +7945,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.3/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.4/paatokset_search.zip"
             },
             "type": "library"
         },

--- a/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
@@ -1,6 +1,6 @@
 paatokset-search:
   remote: https://github.com/City-of-Helsinki/paatokset-search
-  version: 0.2.3
+  version: 0.2.4
   license:
     name: MIT
     url: https://github.com/City-of-Helsinki/asuntomyynti-search/blob/develop/README.md


### PR DESCRIPTION
(Hold off on reviewing this until https://github.com/City-of-Helsinki/helsinki-paatokset/pull/150 has been merged) 

Fix search apps styles after HDBT updates.

To test:

- Checkout branch. Run `composer install`. This should load the `0.2.4` version of paatokset_search.
- Make sure you have a landing page with url `paattajat`. Check out the [decisions](https://helsinki-paatokset.docker.so/fi/asia) and [decision makers](https://helsinki-paatokset.docker.so/fi/paattajat) pages. Make sure that the search apps are aligned in the same way that rest of the content is.