### PR TITLE
PP-300: Added name to policymaker title if it is set

### DIFF
--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -137,10 +137,15 @@ function paatokset_policymakers_preprocess_field__node__title(&$variables) {
   $first_name = '';
   $last_name = '';
 
-  if($node->hasField('field_first_name') && !empty($node->get('field_first_name')->value) && $node->hasField('field_last_name') && !empty($node->get('field_last_name')->value)) {
+  if($node->hasField('field_first_name') && !$node->get('field_first_name')->isEmpty()) {
     $first_name = $node->get('field_first_name')->value;
-    $last_name = $node->get('field_last_name')->value;
+  }
 
+  if($node->hasField('field_last_name') && !$node->get('field_last_name')->isEmpty()) {
+    $last_name = $node->get('field_last_name')->value;
+  }
+
+  if(!empty($first_name) || !empty($last_name)) {
     $variables['items'][0]['content']['#context']['value'] = $title . ': ' . $first_name . ' ' . $last_name;
   }
 }

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -129,6 +129,23 @@ function paatokset_policymakers_preprocess_node__policymaker(&$variables) {
 }
 
 /**
+ * Implements preprocess_field hook.
+ */
+function paatokset_policymakers_preprocess_field__node__title(&$variables) {
+  $title = $variables['items'][0]['content']['#context']['value'];
+  $node = $variables['element']['#object'];
+  $first_name = '';
+  $last_name = '';
+
+  if($node->hasField('field_first_name') && !empty($node->get('field_first_name')->value) && $node->hasField('field_last_name') && !empty($node->get('field_last_name')->value)) {
+    $first_name = $node->get('field_first_name')->value;
+    $last_name = $node->get('field_last_name')->value;
+
+    $variables['items'][0]['content']['#context']['value'] = $title . ': ' . $first_name . ' ' . $last_name;
+  }
+}
+
+/**
  * Implements preprocess hook.
  */
 function paatokset_policymakers_preprocess_policymaker_minutes(&$variables) {


### PR DESCRIPTION
Ticket: https://helsinkisolutionoffice.atlassian.net/browse/PP-300

**How to test**

Checkout branch and run `drush cr`

Edit some policymaker page (i.ex. https://helsinki-paatokset.docker.so/fi/paattajat/yksikon-johtaja-henkilosto-ja-liiketoiminnan-tuki-yksikko) and add first and last names to it. The names should now appear after the initial title i.ex. "Yksikön johtaja: Etunimi Sukunimi"