### PR TITLE
PP-302: Add new processor + modify sector processor to enable decisio…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drush/drush": "^10.4",
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
-        "paatokset/paatokset_search": "0.2.3"
+        "paatokset/paatokset_search": "0.2.5"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -113,9 +113,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "0.2.3",
+                "version": "0.2.5",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.3/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.5/paatokset_search.zip",
                     "type": "zip"
                 }
             }
@@ -124,11 +124,11 @@
     "scripts": {
         "copy-commit-message-script": "make copy-commit-message-script",
         "post-install-cmd": [
-            "rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
+            "rm -rf public/modules/custom/paatokset_search/assets && rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
             "@copy-commit-message-script"
         ],
         "post-update-cmd": [
-            "rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
+            "rm -rf public/modules/custom/paatokset_search/assets && rsync -a vendor/paatokset/paatokset_search/ public/modules/custom/paatokset_search/assets || true",
             "@copy-commit-message-script"
         ]
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "518ea316838481b443032741b63fcdb3",
+    "content-hash": "aed5efcc1b23c49902395cb3b21bae52",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7993,10 +7993,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "0.2.3",
+            "version": "0.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.3/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.5/paatokset_search.zip"
             },
             "type": "library"
         },

--- a/conf/cmi/paatokset_helsinki_kanava.settings.yml
+++ b/conf/cmi/paatokset_helsinki_kanava.settings.yml
@@ -1,3 +1,5 @@
 all_recordings_link: 'https://www.helsinkikanava.fi/fi_FI/web/helsinkikanava/player/folder/serie?seriesId=39419540&groupItemId=39419540'
 debug_mode: 0
 city_council_id: '02900'
+city_hall_id: '00400'
+trustee_organization_type_id: '19'

--- a/conf/cmi/search_api.index.decisions.yml
+++ b/conf/cmi/search_api.index.decisions.yml
@@ -11,13 +11,9 @@ dependencies:
     - field.storage.node.field_diary_number
     - field.storage.node.field_full_title
     - field.storage.node.field_decision_native_id
-    - field.storage.node.field_diary_number
-    - field.storage.node.field_decision_case_title
-    - field.storage.node.field_decision_date
     - field.storage.node.field_dm_org_above_name
     - field.storage.node.field_dm_org_name
     - field.storage.node.field_organization_type
-    - field.storage.node.field_full_title
     - field.storage.node.field_top_category_name
     - search_api.server.elasticsearch
   module:
@@ -60,11 +56,6 @@ field_settings:
       config:
         - field.storage.node.field_decision_motion_parsed
   decision_url:
-    label: 'Decision URL'
-    datasource_id: 'entity:node'
-    property_path: decision_url
-    type: string
-  decision_url_1:
     label: 'Decision URL'
     datasource_id: 'entity:node'
     property_path: decision_url
@@ -126,6 +117,16 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_organization_type
+  sector:
+    label: Sector
+    datasource_id: 'entity:node'
+    property_path: sector
+    type: string
+  special_status:
+    label: 'Special status'
+    datasource_id: 'entity:node'
+    property_path: special_status
+    type: string
   subject:
     label: 'Full title'
     datasource_id: 'entity:node'
@@ -161,6 +162,9 @@ processor_settings:
   language_with_fallback: {  }
   rendered_item: {  }
   sector_json: {  }
+  special_status: {  }
+  trustee_name: {  }
+  trustee_title: {  }
 tracker_settings:
   default:
     indexing_order: fifo

--- a/public/modules/custom/paatokset_helsinki_kanava/src/Form/HelsinkiKanavaForm.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/src/Form/HelsinkiKanavaForm.php
@@ -39,6 +39,20 @@ class HelsinkiKanavaForm extends ConfigFormBase {
       '#description' => 'Id for the city council policymaker.',
     ];
 
+    $form['city_hall_id'] = [
+      '#type' => 'textfield',
+      '#default_value' => $config->get('city_hall_id'),
+      '#title' => t('City Hall ID'),
+      '#description' => 'Id for the city hall policymaker',
+    ];
+
+    $form['trustee_organization_type_id'] = [
+      '#type' => 'textfield',
+      '#default_value' => $config->get('trustee_organization_type_id'),
+      '#title' => t('Trustee organization type id'),
+      '#description' => 'Id for the trustee type for policymakers',
+    ];
+
     $form['all_recordings_link'] = [
       '#type' => 'url',
       '#default_value' => $config->get('all_recordings_link'),
@@ -64,6 +78,8 @@ class HelsinkiKanavaForm extends ConfigFormBase {
 
     $this->config('paatokset_helsinki_kanava.settings')
       ->set('city_council_id', $form_state->getValue('city_council_id'))
+      ->set('city_hall_id', $form_state->getValue('city_hall_id'))
+      ->set('trustee_organization_type_id', $form_state->getValue('trustee_organization_type_id'))
       ->set('all_recordings_link', $form_state->getValue('all_recordings_link'))
       ->set('debug_mode', $form_state->getValue('debug_mode'))
       ->save();

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorJSON.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorJSON.php
@@ -50,18 +50,26 @@ class SectorJSON extends ProcessorPluginBase {
     if ($datasourceId == 'entity:node') {
       $node = $item->getOriginalObject()->getValue();
 
-      if ($node->getType() !== 'policymaker') {
-        return;
+      $policymaker;
+      if ($node->getType() === 'policymaker') {
+        $policymaker = $node;
+      }
+      if ($node->getType() === 'decision') {
+        /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService */
+        $policymakerService = \Drupal::service('paatokset_policymakers');
+        $policymaker = $policymakerService->getPolicymaker($node->get('field_policymaker_id')->value);
       }
 
-      $sectorData = $node->get('field_dm_sector')->value;
+      if ($policymaker) {
+        $sectorData = $policymaker->get('field_dm_sector')->value;
 
-      if ($sectorData && $sectorData !== 'null') {
-        $parsed = json_decode($sectorData);
-        if (isset($parsed->Sector)) {
-          $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), 'entity:node', 'sector');
-          foreach ($fields as $field) {
-            $field->addValue($parsed->Sector);
+        if ($sectorData && $sectorData !== 'null') {
+          $parsed = json_decode($sectorData);
+          if (isset($parsed->Sector)) {
+            $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), 'entity:node', 'sector');
+            foreach ($fields as $field) {
+              $field->addValue($parsed->Sector);
+            }
           }
         }
       }

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SpecialStatus.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SpecialStatus.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\paatokset_search\Plugin\search_api\processor;
+
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+
+/**
+ * Computes CSS class for the given entity.
+ *
+ * @SearchApiProcessor(
+ *    id = "special_status",
+ *    label = @Translation("Special status"),
+ *    description = @Translation("Marks the entity with pre-defined special statuses"),
+ *    stages = {
+ *      "add_properties" = 0
+ *    },
+ *    locked = true,
+ *    hidden = true
+ * )
+ */
+class SpecialStatus extends ProcessorPluginBase {
+  const CITY_COUNCIL = '_city_council';
+  const CITY_HALL = '_city_hall';
+  const TRUSTEE = '_trustee';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DataSourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if ($datasource) {
+      $definition = [
+        'label' => $this->t('Special status'),
+        'description' => $this->t('Marks the entity with pre-defined special statuses'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['special_status'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $datasourceId = $item->getDataSourceId();
+    if ($datasourceId === 'entity:node' && $node = $item->getOriginalObject()->getValue()) {
+      if ($node->getType() === 'decision') {
+        $status = NULL;
+        $id = $node->get('field_policymaker_id')->value;
+        if ((string) \Drupal::config('paatokset_helsinki_kanava.settings')->get('city_council_id') === $id) {
+          $status = self::CITY_COUNCIL;
+        }
+        elseif ((string) \Drupal::config('paatokset_helsinki_kanava.settings')->get('city_hall_id') === $id) {
+          $status = self::CITY_HALL;
+        }
+        else {
+          /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService */
+          $policymakerService = \Drupal::service('paatokset_policymakers');
+          $policymaker = $policymakerService->getPolicymaker($id);
+          if ($policymaker && (string) $policymaker->get('field_organization_type_id')->value === \Drupal::config('paatokset_helsinki_kanava.settings')->get('trustee_organization_type_id')) {
+            $status = self::TRUSTEE;
+          }
+        }
+
+        if ($status) {
+          $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), 'entity:node', 'special_status');
+          if (isset($fields['special_status'])) {
+            $fields['special_status']->addValue($status);
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Added supporting features for filtering the decision search by policymakers.

To test:

- `make shell` into the container. Run `composer install`.
- Run `drush cim -y && drush cr`
- Navigate to [decisions index management page](https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/decisions). If you have old index data indexed, it might be a good idea to run `Clear all indexed data` and then running the indexing process. If not, just run the indexing process.
- Navigate to [decisions search page](https://helsinki-paatokset.docker.so/fi/asia). It's advisable to press ctrl/cmd + R a couple times to make sure your browser isn't doing any caching shenanigans