### PR TITLE
PP-315: Added other decisions link if there is no all decisions link,…

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -468,6 +468,15 @@ function paatokset_ahjo_api_preprocess_node__decision__full(&$variables): void {
   $caseService = \Drupal::service('paatokset_ahjo_cases');
   $caseService->setEntitiesById($case_id, $decision_id);
 
+  /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
+  $policymakerService = \Drupal::service('paatokset_policymakers');
+  $policymakerService->setPolicyMaker($node->get('field_policymaker_id')->value);
+  $decisions_url = $policymakerService->getDecisionsRoute();
+
+  if ($decisions_url instanceof Url) {
+    $decisions_url = $decisions_url->toString();
+  }
+
   $variables['main_heading'] = $caseService->getDecisionHeading();
   $variables['decision_pdf'] = $caseService->getDecisionPdf();
   $variables['selectedDecision'] = $caseService->getSelectedDecision();
@@ -480,6 +489,7 @@ function paatokset_ahjo_api_preprocess_node__decision__full(&$variables): void {
   $variables['previous_decision'] = $caseService->getPrevDecision();
   $variables['decision_content'] = $caseService->parseContent();
   $variables['all_decisions_link'] = $caseService->getDecisionMeetingLink();
+  $variables['other_decisions_link'] = $decisions_url;
 
   $vote_results_accordion = [];
   $vote_results_by_party = [];

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -150,16 +150,18 @@ function paatokset_policymakers_preprocess_field__node__title(&$variables) {
   $first_name = '';
   $last_name = '';
 
-  if($node->hasField('field_first_name') && !$node->get('field_first_name')->isEmpty()) {
-    $first_name = $node->get('field_first_name')->value;
-  }
-
-  if($node->hasField('field_last_name') && !$node->get('field_last_name')->isEmpty()) {
-    $last_name = $node->get('field_last_name')->value;
-  }
-
-  if(!empty($first_name) || !empty($last_name)) {
-    $variables['items'][0]['content']['#context']['value'] = $title . ': ' . $first_name . ' ' . $last_name;
+  if($node->getType() === 'policymaker') {
+    if($node->hasField('field_first_name') && !$node->get('field_first_name')->isEmpty()) {
+      $first_name = $node->get('field_first_name')->value;
+    }
+  
+    if($node->hasField('field_last_name') && !$node->get('field_last_name')->isEmpty()) {
+      $last_name = $node->get('field_last_name')->value;
+    }
+  
+    if(!empty($first_name) || !empty($last_name)) {
+      $variables['items'][0]['content']['#context']['value'] = $title . ': ' . $first_name . ' ' . $last_name;
+    }
   }
 }
 

--- a/public/themes/custom/helfi_paatokset/templates/components/case-navigation.html.twig
+++ b/public/themes/custom/helfi_paatokset/templates/components/case-navigation.html.twig
@@ -13,15 +13,18 @@
   </div>
 
   {% include '@helfi_paatokset/components/decisions-dropdown.html.twig' with { selected: selectedDecision, options: all_decisions, show_warning: next_decision, warning_label: 'More recent handlings'|trans } %}
-
+  
+  <div class="issue-dropdown__show-more"}>
   {% if all_decisions_link is empty %}
-    {% set all_decisions_link = '#' %}
-    {% set hide_all_decisions_link = TRUE %}
-  {% endif %}
-  <div class="issue-dropdown__show-more" {% if hide_all_decisions_link %}style="display:none;"{% endif %}>
+    <a href="{{ other_decisions_link }}" class="paatokset-button-link">
+      <span>{{ 'Other decisions for the policymaker'|t }}</span>
+      <i class="hel-icon hel-icon hel-icon--arrow-right"></i>
+    </a>
+  {% else %}
     <a href="{{ all_decisions_link }}" class="paatokset-button-link">
       <span>{{ 'Other decisions for the meeting'|t }}</span>
       <i class="hel-icon hel-icon hel-icon--arrow-right"></i>
     </a>
+  {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Ticket: https://helsinkisolutionoffice.atlassian.net/browse/PP-315

Added other decisions link if all decisions link doesn't exist. Fixed bug where node title change also affected trustees.

**How to test**

Checkout branch and run `drush cr` go to https://helsinki-paatokset.docker.so/fi/asia/hel-2021-011445/3a1f12b2-6d94-4ba7-b4a4-e35b1eb654cc
There should now be a link to the policymakers decision page. Check also that the other decisions for the meeting link works on pages where it's supposed to work i.ex.https://helsinki-paatokset.docker.so/fi/asia/hel-2016-012511/8cb6b9ed-98d5-4456-8ed4-f2b47b04852b

Check some trustee pages that their titles are normal. Edit some viranhaltija decision maker and add first and last names to it. They should still work as intended