### PR TITLE
PP-304: Bump paatokset_search to 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drush/drush": "^10.4",
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
-        "paatokset/paatokset_search": "0.2.5"
+        "paatokset/paatokset_search": "1.0.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -113,9 +113,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "0.2.5",
+                "version": "1.0.0",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.5/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.0/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aed5efcc1b23c49902395cb3b21bae52",
+    "content-hash": "e7751d275d490a26b841472b2ba355f7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7993,10 +7993,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "0.2.5",
+            "version": "1.0.0",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/0.2.5/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.0/paatokset_search.zip"
             },
             "type": "library"
         },

--- a/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
@@ -1,6 +1,6 @@
 paatokset-search:
   remote: https://github.com/City-of-Helsinki/paatokset-search
-  version: 0.2.3
+  version: 1.0.0
   license:
     name: MIT
     url: https://github.com/City-of-Helsinki/asuntomyynti-search/blob/develop/README.md


### PR DESCRIPTION
Bump paatokset_search to 1.0.0.

Jira: https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/PP/boards/172?modal=detail&selectedIssue=PP-304

(Make sure your index settings are up-to-date).

To test:
- `make shell` into the container. Run `composer update paatokset/paatokset_search  --no-cache`. This should update the application to version 1.0.0.
- Navigate to [policymakers page](https://helsinki-paatokset.docker.so/fi/paattajat). Try making a search that gets wildcard matches, eg. 'lääkäri'. You might want to ctrl / cmd + R to make sure browser cache does not produce weird stuff.
- Try clicking the latest item in the pagination. This should work as expected (takes you to the last page of results)
- Pagination shold be reflected in the URL (via 'results' -parameter). Try refreshing the page - you should get the same results and you should be on the same page you were before.