### PR TITLE
PP-305: Add missing cron jobs

### DIFF
--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -17,6 +17,7 @@ echo "Starting cron: $(date)"
 # @endcode
 
 exec "/crons/update-translations.sh" &
+exec "/crons/run-helsinki-integrations.sh" &
 exec "/crons/run-immediate-ahjo-integrations.sh" &
 exec "/crons/run-aggregated-ahjo-integrations.sh" &
 

--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -17,7 +17,8 @@ echo "Starting cron: $(date)"
 # @endcode
 
 exec "/crons/update-translations.sh" &
-exec "/crons/run-callback-queue.sh" &
+exec "/crons/run-immediate-ahjo-integrations.sh" &
+exec "/crons/run-aggregated-ahjo-integrations.sh" &
 
 while true
 do

--- a/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+while true
+do
+  echo "Aggregating data for meetings: $(date)"
+  drush ahjo-proxy:aggregate meetings --dataset=latest
+  echo "Aggregating data for cases: $(date)"
+  drush ahjo-proxy:aggregate cases --dataset=latest
+  echo "Migrating data for cases: $(date)"
+  echo "Aggregating data for decisions: $(date)"
+  drush ahjo-proxy:aggregate decisions --dataset=latest
+  echo "Aggregating data for council members: $(date)"
+  drush ahjo-proxy:get-council-positionsoftrust
+  echo "Migrating data for meetings: $(date)"
+  drush migrate-import ahjo_meetings:latest --update
+  echo "Migrating data for cases: $(date)"
+  drush migrate-import ahjo_cases:latest --update
+  echo "Migrating data for decisions: $(date)"
+  drush migrate-import ahjo_decisions:latest --update
+  echo "Migrating data for council members: $(date)"
+  drush migrate-import ahjo_trustees:council --update
+  echo "Generating motions from meeting data: $(date)"
+  drush ahjo-proxy:get-motions
+  echo "Updating decision and motion data: $(date)"
+  drush ahjo-proxy:update-decisions
+  # Sleep for 24 hours.
+  sleep 86400
+done

--- a/docker/openshift/crons/run-callback-queue.sh
+++ b/docker/openshift/crons/run-callback-queue.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-while true
-do
-  echo "Running Ahjo API callback queue: $(date)"
-  drush queue:run ahjo_api_subscriber_queue
-  # Sleep for 30 minutes.
-  sleep 1800
-done

--- a/docker/openshift/crons/run-helsinki-integrations.sh
+++ b/docker/openshift/crons/run-helsinki-integrations.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+while true
+do
+  echo "Running Helsinki kanava migration: $(date)"
+  drush migrate-import paatokset_helsinki_kanava --update
+  echo "Running news migration: $(date)"
+  drush migrate-import paatokset_news --update
+  # Sleep for 1 hour.
+  sleep 3600
+done

--- a/docker/openshift/crons/run-immediate-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-immediate-ahjo-integrations.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+while true
+do
+  echo "Running Ahjo API callback queue: $(date)"
+  drush queue:run ahjo_api_subscriber_queue
+  echo "Generating motions from meeting data: $(date)"
+  drush ahjo-proxy:get-motions
+  echo "Updating decision and motion data: $(date)"
+  drush ahjo-proxy:update-decisions
+  # Sleep for 30 minutes.
+  sleep 1800
+done

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -693,7 +693,7 @@ class AhjoAggregatorCommands extends DrushCommands {
    * @option limit
    *   Limit processing to certain amount of nodes.
    *
-   * @usage ahjo-proxy:set-decicion-flag --limit=50
+   * @usage ahjo-proxy:set-decision-flag --limit=50
    *   Sets decision flag for the first 50 decisions where it wasn't before.
    *
    * @aliases ap:sdf

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorJSON.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorJSON.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\paatokset_search\Plugin\search_api\processor;
 
+use Drupal\node\NodeInterface;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
@@ -50,7 +51,7 @@ class SectorJSON extends ProcessorPluginBase {
     if ($datasourceId == 'entity:node') {
       $node = $item->getOriginalObject()->getValue();
 
-      $policymaker;
+      $policymaker = NULL;
       if ($node->getType() === 'policymaker') {
         $policymaker = $node;
       }
@@ -60,7 +61,7 @@ class SectorJSON extends ProcessorPluginBase {
         $policymaker = $policymakerService->getPolicymaker($node->get('field_policymaker_id')->value);
       }
 
-      if ($policymaker) {
+      if ($policymaker instanceof NodeInterface) {
         $sectorData = $policymaker->get('field_dm_sector')->value;
 
         if ($sectorData && $sectorData !== 'null') {

--- a/tools/make/project/ahjo.mk
+++ b/tools/make/project/ahjo.mk
@@ -1,0 +1,10 @@
+PHONY += ahjo-migrations
+ahjo-migrations: # Run Ahjo migrations from local data.
+	$(call drush_on_${RUN_ON},ahjo-proxy:store-static-files)
+	$(call drush_on_${RUN_ON},migrate-import ahjo_cases:latest)
+	$(call drush_on_${RUN_ON},migrate-import ahjo_meetings:latest)
+	$(call drush_on_${RUN_ON},migrate-import ahjo_decisions:latest)
+	$(call drush_on_${RUN_ON},migrate-import ahjo_decisionmakers:all)
+	$(call drush_on_${RUN_ON},migrate-import ahjo_trustees:council)
+	$(call drush_on_${RUN_ON},ahjo-proxy:get-motions --localdata)
+	$(call drush_on_${RUN_ON},ahjo-proxy:update-decisions --update)


### PR DESCRIPTION
This PR adds the remaining migrations to the cron job scripts. Also adds a fallback mechanism for missing cases and meetings, where they are added to the subscriber callback queue.

**To test**
* Checkout branch
* Read the shell scripts and check that they make sense. Any migrations missing?
* Run `drush cr;drush cim -y`
* If you have any migrated decision entities, roll them back with: `drush migrate-rollback ahjo_decisions:latest`
  * Note: if this breaks because of URL redirects, delete the redirect and the node manually, then run `drush migrate-reset-status ahjo_decisions:latest` and continue the rollback.
* If you don't have migration data yet, run: `drush ap:fs;drush mim ahjo_decisions:latest`
* Run `drush ac:l`. The output should be mostly empty.
* Run `drush ap:ud --localdata -v`
  * This should complain about a lot of missing cases and meetings
* Run `drush ac:l`. The missing cases and meetings should now appear in this list
* You'll need a functioning VPN connection for the next steps:
  * Connect to the VPN and get an access token for Ahjo Open ID: https://nginx-paatokset-test.agw.arodevtest.hel.fi/en/admin/ahjo-open-id
* Run `drush queue:run ahjo_api_subscriber_queue`
  * This should (hopefully) create nodes for the missing cases and meetings. Confirm this by looking  at the content overview page: https://helsinki-paatokset.docker.so/fi/admin/content