### PR TITLE
PP-0: Editor settings

### DIFF
--- a/conf/cmi/editor.editor.full_html.yml
+++ b/conf/cmi/editor.editor.full_html.yml
@@ -34,7 +34,7 @@ settings:
         -
           name: Media
           items:
-            1: quote
+            - quote
         -
           name: Links
           items:
@@ -51,14 +51,15 @@ settings:
             - PasteFromWord
             - SpecialChar
             - Source
+            - Table
   plugins:
     drupallink:
       linkit_enabled: true
       linkit_profile: helfi
-    language:
-      language_list: un
     stylescombo:
       styles: ''
+    language:
+      language_list: un
     tokenbrowser:
       token_types: {  }
 image_upload:

--- a/conf/cmi/filter.format.full_html.yml
+++ b/conf/cmi/filter.format.full_html.yml
@@ -25,7 +25,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class><footer class><br> <div class><span class aria-hidden> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title class> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr>'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div class=""> <span aria-hidden class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title class=""> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:


### PR DESCRIPTION
Add quote + table tool buttons to editor

Testing:
- Run `drush cim -y; drush cr`
- Create new content (or edit existing) with text type paragrapgs (ie. basic page). Add a new paragraph of type text and check that you can add quotes and tables from the toolbar at the top of the editor