### PR TITLE
Pp 330 search filter changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drush/drush": "^10.4",
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
-        "paatokset/paatokset_search": "1.0.0"
+        "paatokset/paatokset_search": "1.0.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -113,9 +113,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "1.0.0",
+                "version": "1.0.1",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.0/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.1/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7751d275d490a26b841472b2ba355f7",
+    "content-hash": "67e50e26f645852a15618866117e37b1",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7993,10 +7993,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.0/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.1/paatokset_search.zip"
             },
             "type": "library"
         },

--- a/conf/cmi/paatokset_helsinki_kanava.settings.yml
+++ b/conf/cmi/paatokset_helsinki_kanava.settings.yml
@@ -2,4 +2,4 @@ all_recordings_link: 'https://www.helsinkikanava.fi/fi_FI/web/helsinkikanava/pla
 debug_mode: 0
 city_council_id: '02900'
 city_hall_id: '00400'
-trustee_organization_type_id: '19'
+trustee_organization_type_id: '12'

--- a/conf/cmi/paatokset_search.settings.yml
+++ b/conf/cmi/paatokset_search.settings.yml
@@ -1,0 +1,2 @@
+city_hall_id: '00400'
+trustee_organization_type_id: '12'

--- a/conf/cmi/search_api.index.decisions.yml
+++ b/conf/cmi/search_api.index.decisions.yml
@@ -6,10 +6,10 @@ dependencies:
     - field.storage.node.field_decision_case_title
     - field.storage.node.field_classification_title
     - field.storage.node.field_decision_content_parsed
-    - field.storage.node.field_decision_date
     - field.storage.node.field_decision_motion_parsed
     - field.storage.node.field_diary_number
     - field.storage.node.field_full_title
+    - field.storage.node.field_meeting_date
     - field.storage.node.field_decision_native_id
     - field.storage.node.field_dm_org_above_name
     - field.storage.node.field_dm_org_name
@@ -86,13 +86,13 @@ field_settings:
       config:
         - field.storage.node.field_decision_case_title
   meeting_date:
-    label: 'Decision issued date'
+    label: 'Meeting / creation date'
     datasource_id: 'entity:node'
-    property_path: field_decision_date
+    property_path: field_meeting_date
     type: date
     dependencies:
       config:
-        - field.storage.node.field_decision_date
+        - field.storage.node.field_meeting_date
   organization_above_name:
     label: 'Organization level above name'
     datasource_id: 'entity:node'

--- a/public/modules/custom/paatokset_helsinki_kanava/src/Form/HelsinkiKanavaForm.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/src/Form/HelsinkiKanavaForm.php
@@ -39,20 +39,6 @@ class HelsinkiKanavaForm extends ConfigFormBase {
       '#description' => 'Id for the city council policymaker.',
     ];
 
-    $form['city_hall_id'] = [
-      '#type' => 'textfield',
-      '#default_value' => $config->get('city_hall_id'),
-      '#title' => t('City Hall ID'),
-      '#description' => 'Id for the city hall policymaker',
-    ];
-
-    $form['trustee_organization_type_id'] = [
-      '#type' => 'textfield',
-      '#default_value' => $config->get('trustee_organization_type_id'),
-      '#title' => t('Trustee organization type id'),
-      '#description' => 'Id for the trustee type for policymakers',
-    ];
-
     $form['all_recordings_link'] = [
       '#type' => 'url',
       '#default_value' => $config->get('all_recordings_link'),

--- a/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
@@ -1,6 +1,6 @@
 paatokset-search:
   remote: https://github.com/City-of-Helsinki/paatokset-search
-  version: 1.0.0
+  version: 1.0.1
   license:
     name: MIT
     url: https://github.com/City-of-Helsinki/asuntomyynti-search/blob/develop/README.md

--- a/public/modules/custom/paatokset_search/paatokset_search.links.menu.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.links.menu.yml
@@ -1,0 +1,5 @@
+paatokset_search.settings_form:
+  title: 'Paatokset Search'
+  route_name: 'paatokset_search.settings_form'
+  description: 'Paatokset Search settings'
+  parent: system.admin_config_search

--- a/public/modules/custom/paatokset_search/paatokset_search.routing.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.routing.yml
@@ -5,3 +5,13 @@ paatokset_search.decisions:
     _title: 'Search decisions'
   requirements:
     _access: 'TRUE'
+
+paatokset_search.settings_form:
+  path: '/admin/config/paatokset_search/settings'
+  defaults:
+    _form: '\Drupal\paatokset_search\Form\PaatoksetSearchForm'
+    _title: 'Paatokset Search settings'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admins_route: TRUE

--- a/public/modules/custom/paatokset_search/src/Form/PaatoksetSearchForm.php
+++ b/public/modules/custom/paatokset_search/src/Form/PaatoksetSearchForm.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\paatokset_search\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form for Paatokset Search settings.
+ */
+class PaatoksetSearchForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'paatokset_search.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'paatokset_search_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('paatokset_search.settings');
+
+    $form['city_hall_id'] = [
+      '#type' => 'textfield',
+      '#default_value' => $config->get('city_hall_id'),
+      '#title' => t('City Hall ID'),
+      '#description' => 'Id for the city hall policymaker',
+    ];
+
+    $form['trustee_organization_type_id'] = [
+      '#type' => 'textfield',
+      '#default_value' => $config->get('trustee_organization_type_id'),
+      '#title' => t('Trustee organization type id'),
+      '#description' => 'Id for the trustee type for policymakers',
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('paatokset_search.settings')
+      ->set('city_hall_id', $form_state->getValue('city_hall_id'))
+      ->set('trustee_organization_type_id', $form_state->getValue('trustee_organization_type_id'))
+      ->save();
+  }
+
+}


### PR DESCRIPTION
Search filter changes:
- 'Viranhaltijat' -filter now shows decisions where organization_type is correct value
-  Decisionmaker-filter accepts single value only
- Date displayed on the decision card is now the meeting date

To test:
- `make shell` into the container. Run `composer update paatokset/paatokset_search; drush cim -y; drush cr`
- Navigate to your (decisions index page)[https://helsinki-paatokset.docker.so/fi/admin/config/search/search-api/index/decisions]. Reindex all the content (Queue all items for reindexing -> run indexing process). It _might_ be good to clear all indexed data before reindex, if your local data has changed noticeably since last indexing.
-  Once indexing is complete, navigate to (search page)[https://helsinki-paatokset.docker.so/fi/asia].

Check following on the search page: 
- 'Päättäjä'-filter ony allows one selection
- Selecting 'Viranhaltijat' form the 'Päättäjä'-filter shows you decisions by decisionmakers of type 'Viranhaltija', not 'Luottamushenkilö.
- When you follow the result card by clicking it, the date shown on the card matches the one shown in the meeting dropdown on the case page.