### PR TITLE
PP-280: Add cache tags to custom content lists

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -456,6 +456,10 @@ function paatokset_ahjo_api_preprocess_node__case__full(&$variables): void {
   $variables['all_decisions_link'] = $caseService->getDecisionMeetingLink();
   $variables['other_decisions_link'] = $caseService->getPolicymakerDecisionsLink();
   $variables['vote_results'] = $caseService->getVotingResults();
+
+  $variables['#cache'] = [
+    'tags' => ['node_list:decision'],
+  ];
 }
 
 /**
@@ -488,6 +492,13 @@ function paatokset_ahjo_api_preprocess_node__decision__full(&$variables): void {
   $variables['all_decisions_link'] = $caseService->getDecisionMeetingLink();
   $variables['other_decisions_link'] = $caseService->getPolicymakerDecisionsLink();
   $variables['vote_results'] = $caseService->getVotingResults();
+
+  $variables['#cache'] = [
+    'tags' => [
+      'node_list:decision',
+      'node_list:case',
+    ],
+  ];
 }
 
 /**

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/AllInitiativesBlock.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/AllInitiativesBlock.php
@@ -29,6 +29,13 @@ class AllInitiativesBlock extends BlockBase {
   }
 
   /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return ['node_list:trustee'];
+  }
+
+  /**
    * Get cache contexts.
    */
   public function getCacheContexts() {

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/DecisionTreeBlock.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/DecisionTreeBlock.php
@@ -20,12 +20,18 @@ class DecisionTreeBlock extends BlockBase {
    */
   public function build() {
     return [
-      '#cache' => ['contexts' => ['url.path', 'url.query_args']],
       'label' => t('Decision tree'),
       '#attributes' => [
         'class' => ['decision-tree'],
       ],
     ];
+  }
+
+  /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return ['node_list:meeting'];
   }
 
   /**

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/FrontpageCalendarBlock.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/FrontpageCalendarBlock.php
@@ -29,6 +29,13 @@ class FrontpageCalendarBlock extends BlockBase {
   }
 
   /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return ['node_list:meeting'];
+  }
+
+  /**
    * Get cache contexts.
    */
   public function getCacheContexts() {

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/MeetingsCalendarBlock.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/MeetingsCalendarBlock.php
@@ -29,6 +29,13 @@ class MeetingsCalendarBlock extends BlockBase {
   }
 
   /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return ['node_list:meeting'];
+  }
+
+  /**
    * Get cache contexts.
    */
   public function getCacheContexts() {

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/PolicymakerListingBlock.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/Block/PolicymakerListingBlock.php
@@ -20,11 +20,20 @@ class PolicymakerListingBlock extends BlockBase {
    */
   public function build() {
     return [
-      '#cache' => ['contexts' => ['url.path', 'url.query_args']],
       'label' => t('Browse policymakers'),
       '#attributes' => [
         'class' => ['policymaker-listing'],
       ],
+    ];
+  }
+
+  /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return [
+      'node_list:policymaker',
+      'node_list:trustee',
     ];
   }
 

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -89,6 +89,7 @@ function paatokset_policymakers_preprocess_node__policymaker(&$variables) {
   $councilId = \Drupal::config('paatokset_helsinki_kanava.settings')->get('city_council_id');
 
   $policymaker = $variables['node'];
+
   $policymakerService->setPolicyMakerNode($policymaker);
   $variables['organization_type'] = $policymakerService->getPolicymakerTypeFromNode($policymaker);
   $variables['organization_type_color'] = $policymakerService->getPolicymakerClass($policymaker);
@@ -99,12 +100,15 @@ function paatokset_policymakers_preprocess_node__policymaker(&$variables) {
     'Viranhaltija',
   ];
 
+  $cache_tags = [];
+
   $orgType = $policymaker->get('field_organization_type')->value;
+  $variables['is_organization'] = FALSE;
 
   if ($orgType) {
     if (!in_array($orgType, $not_organization_types)) {
       $variables['is_organization'] = TRUE;
-      
+
       $members = $policymakerService->getComposition();
       if($members) {
         $variables['has_members'] = TRUE;
@@ -143,6 +147,23 @@ function paatokset_policymakers_preprocess_node__policymaker(&$variables) {
   if ($councilId && ($policymaker->get('field_policymaker_id')->value === $councilId)) {
     $variables['render_announcement_block'] = TRUE;
     $no_content = FALSE;
+
+    // Add cache tag for Helsinki Kanava videos.
+    $cache_tags[] = 'meeting_video_list';
+  }
+
+  // Add cache tags for meetings or decisions based on org type.
+  if ($variables['is_organization']) {
+    $cache_tags[] = 'node_list:meeting';
+  }
+  else {
+    $cache_tags[] = 'node_list:decisions';
+  }
+
+  if (!empty($cache_tags)) {
+    $variables['#cache'] = [
+      'tags' => $cache_tags,
+    ];
   }
 
   $variables['no_content'] = $no_content;
@@ -184,11 +205,11 @@ function paatokset_policymakers_preprocess_field__node__title(&$variables) {
     if($node->hasField('field_first_name') && !$node->get('field_first_name')->isEmpty()) {
       $first_name = $node->get('field_first_name')->value;
     }
-  
+
     if($node->hasField('field_last_name') && !$node->get('field_last_name')->isEmpty()) {
       $last_name = $node->get('field_last_name')->value;
     }
-  
+
     if(!empty($first_name) || !empty($last_name)) {
       $variables['items'][0]['content']['#context']['value'] = $title . ': ' . $first_name . ' ' . $last_name;
     }
@@ -309,7 +330,8 @@ function paatokset_policymakers_preprocess_html(&$variables) {
   if(_paatokset_policymakers_page_is_pm_subpage($variables)) {
     $variables['attributes']['class'][] = 'has-policymaker-nav';
   }
-  // Remmove title block on minutes page.
+
+  // Remove title block on minutes page.
   if(preg_match('/policymaker\.minutes\./', \Drupal::routeMatch()->getRouteName()) && isset($variables['page']['before_content']['helfi_paatokset_page_title'])) {
     unset($variables['page']['before_content']['helfi_paatokset_page_title']);
   }
@@ -317,10 +339,10 @@ function paatokset_policymakers_preprocess_html(&$variables) {
 
 /**
  * Helper function to decipher if page is policymaker subpage
- * 
+ *
  * @param array $variables
  *    Drupal-provided variables arary
- * 
+ *
  * @return bool
  *    Return result of conditional check
  */

--- a/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerController.php
+++ b/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerController.php
@@ -135,7 +135,13 @@ class PolicymakerController extends ControllerBase {
       $build['list'] = $meetingData['list'];
       $build['file'] = $meetingData['file'];
       $build['#documents_description'] = '<div>' . (!empty($documentsDescription) ? $documentsDescription : \Drupal::config('paatokset_ahjo_api.default_texts')->get('documents_description.value')) . '</div>';
+
+      // Add cache context for current node.
+      $build['#cache']['tags'][] = 'node:' . $meetingData['meeting']['nid'];
     }
+
+    // Add cache context for minutes of the discussion for the link to show up.
+    $build['#cache']['tags'][] = 'media_list:minutes_of_the_discussion';
 
     if ($meetingData['decision_announcement']) {
       $build['decision_announcement'] = $meetingData['decision_announcement'];

--- a/public/modules/custom/paatokset_policymakers/src/Plugin/Block/CalendarBlock.php
+++ b/public/modules/custom/paatokset_policymakers/src/Plugin/Block/CalendarBlock.php
@@ -29,6 +29,13 @@ class CalendarBlock extends BlockBase {
   }
 
   /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return ['node_list:meeting'];
+  }
+
+  /**
    * Get cache contexts.
    */
   public function getCacheContexts() {

--- a/public/modules/custom/paatokset_policymakers/src/Plugin/Block/ContactsBlock.php
+++ b/public/modules/custom/paatokset_policymakers/src/Plugin/Block/ContactsBlock.php
@@ -78,6 +78,13 @@ class ContactsBlock extends BlockBase {
   }
 
   /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return ['tpr_unit_list'];
+  }
+
+  /**
    * Get cache contexts.
    */
   public function getCacheContexts() {

--- a/public/modules/custom/paatokset_policymakers/src/Plugin/Block/MembersBlock.php
+++ b/public/modules/custom/paatokset_policymakers/src/Plugin/Block/MembersBlock.php
@@ -29,6 +29,13 @@ class MembersBlock extends BlockBase {
   }
 
   /**
+   * Get cache tags.
+   */
+  public function getCacheTags() {
+    return ['node_list:trustee'];
+  }
+
+  /**
    * Get cache contexts.
    */
   public function getCacheContexts() {

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -880,6 +880,7 @@ class PolicymakerService {
 
     return [
       'meeting' => [
+        'nid' => $meeting->id(),
         'page_title' => $pageTitle,
         'date_long' => $dateLong,
         'title' => $policymaker_title . ' ' . $meetingNumber . '/' . $meetingYear,

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/AgendasSubmenuBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/AgendasSubmenuBlock.php
@@ -38,7 +38,6 @@ class AgendasSubmenuBlock extends BlockBase {
     $years = array_keys($list);
 
     return [
-      '#cache' => ['contexts' => ['url.path', 'url.query_args']],
       '#title' => 'Viranhaltijapäätökset',
       '#years' => $years,
       '#list' => $list,
@@ -46,11 +45,10 @@ class AgendasSubmenuBlock extends BlockBase {
   }
 
   /**
-   * Set cache age to zero.
+   * Get cache tags.
    */
-  public function getCacheMaxAge() {
-    // If you need to redefine the Max Age for that block.
-    return 0;
+  public function getCacheTags() {
+    return ['node_list:decision'];
   }
 
   /**

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/DocumentsBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/DocumentsBlock.php
@@ -37,7 +37,6 @@ class DocumentsBlock extends BlockBase {
     $list = $this->policymakerService->getApiMinutes(NULL, TRUE);
 
     return [
-      '#cache' => ['contexts' => ['url.path', 'url.query_args']],
       '#title' => 'Viranhaltijapäätökset',
       '#years' => array_keys($list),
       '#list' => $list,
@@ -45,11 +44,10 @@ class DocumentsBlock extends BlockBase {
   }
 
   /**
-   * Set cache age to zero.
+   * Get cache tags.
    */
-  public function getCacheMaxAge() {
-    // If you need to redefine the Max Age for that block.
-    return 0;
+  public function getCacheTags() {
+    return ['node_list:meeting'];
   }
 
   /**

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/MinutesOfDiscussionBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/MinutesOfDiscussionBlock.php
@@ -37,18 +37,19 @@ class MinutesOfDiscussionBlock extends BlockBase {
     $minutes = $this->policymakerService->getMinutesOfDiscussion(NULL, TRUE);
 
     return [
-      '#cache' => ['contexts' => ['url.path', 'url.query_args']],
       '#years' => array_keys($minutes),
       '#list' => $minutes,
     ];
   }
 
   /**
-   * Set cache age to zero.
+   * Get cache tags.
    */
-  public function getCacheMaxAge() {
-    // If you need to redefine the Max Age for that block.
-    return 0;
+  public function getCacheTags() {
+    return [
+      'media_list:minutes_of_the_discussion',
+      'node_list:meeting',
+    ];
   }
 
   /**

--- a/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
+++ b/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
@@ -217,6 +217,10 @@ function helfi_paatokset_preprocess_node__trustee(&$variables) {
     return;
   }
 
+  $variables['#cache'] = [
+    'tags' => ['media_list:declaration_of_affiliation'],
+  ];
+
   if($node->get('field_trustee_initiatives')) {
     $content_initiatives = [];
     foreach($node->get('field_trustee_initiatives') as $json) {


### PR DESCRIPTION
## What was done
This PR adds missing cache tags to multiple blocks and node preprocesses to content list caches can be invalidated properly.

##  How to set up
- Checkout branch and run `make drush-cr`
- If you don't have any integration data, run `make ahjo-migrations`
- Comment out everything related to caches in `public/sites/default/local.settings.php`, then run `make drush-cr` again
- Login as admin to the site in one window and open another window in incognito mode. Whenever you need to test a specific page, test it in both

## Frontpage calendar and news
- Open the frontpage: https://helsinki-paatokset.docker.so/fi/etusivu
- Find one of the meetings listed in the frontpage calendar and edit it: https://helsinki-paatokset.docker.so/fi/admin/content/meetings
  - Edit the date, toggle the "agenda published / minutes published" and change the "Decision maker" field
  - Reload the page The changes made should be visible
- Fine one of the news articles listed on the front page and delete it: https://helsinki-paatokset.docker.so/fi/admin/content?title=&type=imported_article&status=All&langcode=All
  - When you reload the frontpage, the news list should be updated 

## Meeting calendar
- Visit the meeting calendar page: https://helsinki-paatokset.docker.so/fi/kokouskalenteri
- Find one of the meetings listed in the current month and edit it (edit the same fields you did on the front page)
- Once you reload the calendar page, the changes you made should be visible

## Decisionmakers list
- Open the Päättäjät-page: https://helsinki-paatokset.docker.so/fi/paattajat/
  - Edit one decisionmaker: https://helsinki-paatokset.docker.so/fi/admin/content/decisionmakers
    - Add an image and change the "Organization label" color from the dropdown (the other content comes from integration fields that can't be changed)
    - Reload the page. The changes should be visible
  - Edit a trustee: https://helsinki-paatokset.docker.so/fi/admin/content/trustees
    - Reload the page again. The changes should be visible

## Declarations of affiliation
- Open the declarations of affiliation page: https://helsinki-paatokset.docker.so/fi/tietoa-paatoksenteosta/sidonnaisuusilmoitukset
- Open a trustee page: https://helsinki-paatokset.docker.so/fi/admin/content/trustees
  - Edit it to add some personal info fields, because the affiliation document links won't show up otherwise
- Add a declaration of affiliation document and attach it to the trustee you have open: https://helsinki-paatokset.docker.so/fi/media/add/declaration_of_affiliation
- Reload both pages. The document should be listed on both

## Decision page
- Find and open decision where the case node also exists, and one other unrelated decision node.
  - Decision: https://helsinki-paatokset.docker.so/fi/admin/content/decisions
  - Case: https://helsinki-paatokset.docker.so/fi/admin/content/cases
  - Make sure you have the decision selected from the dropdown in the case. Open the decision using it's own URL alias without the query parameter
- Edit the case and decisions node title (and full title) values to something distinctive
- Reload both the case and the decision page. The titles should be updated to the edited values
- Edit the unrelated decision and replace the diary number to match the case you have open
- Reload all pages. The decision you edited should be selectable in the dropdown

## Policymaker pages
- Open the kaupunginvaltuusto page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
- Helsinki kanava migration:
  - Run the helsinki kanava migration with `drush migrate-import paatokset_meeting_videos`
  - Reload the page. The video should now be visible.
  - Rollback the migration with `drush migrate-rollback paatokset_meeting_videos` 
  - Reload the page. The video should be missing now.
- Members list:
  - Edit some of the trustees listed on the page (first- and lastname are easy to see).
  - Reload again. The changes should be visible.
- Meeting calendar:
  - Find the meetings that are listed in the upcoming meetings section and edit the dates and the "agenda / minutes published" toggles (if there are none, edit the dates of some existing Kaupunginvaltuusto meetings).
  - Reload the page. The changes to the meetings should be visible
- Recent documents, and all documents list:
  - Find the recent documents listed on the page
  - Open the documents page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat
  - Edit the dates on the documents (all the other content comes from hard to edit fields).
  - Reload both pages. The changes to the dates should be visible
- Meeting minutes and minutes of discussion list:
  - Open meeting minutes page for one of the documents you edited
  - Edit the meeting again and change the date. The update should be visible when you reload the meeting minutes page
  - Open the minutes of the discussion list: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/keskustelup%C3%B6yt%C3%A4kirjat
  - Add a minutes of the discussion file and attach it to the meeting you just edited: https://helsinki-paatokset.docker.so/fi/media/add/minutes_of_the_discussion
  - Reload both pages. The file should be visible in the list and on the meeting minutes page
 - Decisions list:
   - Open an official's page, for example: https://helsinki-paatokset.docker.so/fi/paattajat/pormestari
   - And the decisions list: https://helsinki-paatokset.docker.so/fi/paattajat/pormestari/paatokset
   - Find some of the decisions listed and edit the dates and titles: https://helsinki-paatokset.docker.so/fi/admin/content/decisions
   - Reload both pages. The changes you made should be visible 