### PR TITLE
PP-0: Retrieve color class by dm id

### DIFF
--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/ColorClass.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/ColorClass.php
@@ -57,7 +57,7 @@ class ColorClass extends ProcessorPluginBase {
       $policymakerService = \Drupal::service('paatokset_policymakers');
       $colorClass = NULL;
       if ($type === 'decision' && $id = $node->get('field_policymaker_id')->value) {
-        $colorClass = $policymakerService->getPolicymakerClass($node);
+        $colorClass = $policymakerService->getPolicymakerClassById($id);
       }
       elseif (in_array($type, $decisionMakers)) {
         $colorClass = $policymakerService->getPolicymakerClass($node);


### PR DESCRIPTION
Fix decision indexing to pass id of policymaker to `getPolicymakerClassById` rather than passing the decision node to `getPolicymakerClass`. 