### PR TITLE
PP-0: Add toc field to page content

### DIFF
--- a/conf/cmi/core.entity_view_display.node.page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.page.default.yml
@@ -29,19 +29,29 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_metatags:
     type: metatag_empty_formatter
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  toc_enabled:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 1
     region: content
 hidden:
   field_has_hero: true
@@ -52,4 +62,3 @@ hidden:
   langcode: true
   published_at: true
   search_api_excerpt: true
-  toc_enabled: true


### PR DESCRIPTION
Enable toc on basic pages.

To test:
- `make drush-cim; make drush-cr`
- Open up a basic page with h2-elements or create one. (If you have data from testing, https://helsinki-paatokset.docker.so/fi/tietoa-paatoksenteosta/kuka-paattaa-ja-mista is a good one)
- Edit the page -> enable the table of contents toggle and enter value to **Table of contents title**
- View the page. Table of contents should be generated to the top of the page.