### PR TITLE
PP-337: Minutes of discussion fixes

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -327,7 +327,7 @@ class MeetingService {
     $minutes_id = NULL;
     foreach ($entity->get('field_meeting_documents') as $field) {
       $json = json_decode($field->value, TRUE);
-      if (isset($json['Language']) && $json['Language'] !== $langcode) {
+      if (isset($json['Language']) && strpos($json['Language'], $langcode) === FALSE) {
         continue;
       }
 

--- a/public/modules/custom/paatokset_ahjo_api/templates/component/document.html.twig
+++ b/public/modules/custom/paatokset_ahjo_api/templates/component/document.html.twig
@@ -29,6 +29,14 @@
         {% endif %}
       </span>
     </div>
+    {% if document.type == 'minutes-of-discussion' %}
+    <div class="paatokset_download-link-container">
+      <span class="paatokset__link-plain">
+        {% include '@hdbt/misc/icon.twig' with {icon: 'document'} %}
+        {{ 'Download minutes of discussion (PDF)'|trans }}
+      </span>
+    </div>
+    {% endif %}
   </a>
 
   {% if document.decision_link %}

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -1227,17 +1227,13 @@ class PolicymakerService {
           'publish_date' => $dateLong,
           'publish_date_short' => $dateShort,
           'title' => $entity->label(),
+          'type' => 'minutes-of-discussion',
         ];
-
-        $link = $this->getMinutesRoute($nodes[$meeting_id]->get('field_meeting_id')->value);
-        if ($link) {
-          $result['link'] = $link;
-        }
 
         if ($entity->get('field_document')->target_id) {
           $file_id = $entity->get('field_document')->target_id;
           $download_link = \Drupal::service('file_url_generator')->generateAbsoluteString(File::load($file_id)->getFileUri());
-          $result['origin_url'] = $download_link;
+          $result['link'] = $download_link;
         }
 
         if ($byYear) {

--- a/public/modules/custom/paatokset_policymakers/templates/content/minutes.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/content/minutes.html.twig
@@ -114,9 +114,9 @@
           </a>
         </div>
       {% endfor %}
-    <div>
+    </div>
   {% endif %}
-  
+
   {# Social media share links #}
   {{ drupal_block('hdbt_content_social_sharing_block') }}
 </div>


### PR DESCRIPTION
**Replicate issues**
- **Before checking out the branch**, run `make drush-cr ahjo-migrations drush uli` (make sure you have the ahjo local proxy url pointing to test so you can get latest data)
- Run these migration commands in the container:
  - `drush ap:update meetings 00400202210 -v`
  - `drush ap:update meetings 00400202211 -v`
  - `drush ap:update meetings 00400202212 -v`
- Check the Kaupunginhallitus page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus
  - There should be only one item in the recent documents list
- Add meeting minutes to one Kaupunginvaltuusto meeting: https://helsinki-paatokset.docker.so/fi/media/add/minutes_of_the_discussion
  - Find the meeting and open its minutes page: https://helsinki-paatokset.docker.so/fi/admin/content/meetings?title=kaupunginvaltuusto
  - The layout should be broken.
  - Open the minutes of discussion list for kaupunginvaltuusto: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/keskustelup%C3%B6yt%C3%A4kirjat 
  - The link should take you to the meeting minutes page, not the PDF

**Test fixes**
- Checkout the branch and run `make drush-cr`.
  - Reload the Kaupunginhallitus page. There should now be two items.
- Reload the meeting minutes page where you added the minutes of discussion file. The layout should be fixed now
- Reload the minutes of discussion list for Kaupunginvaltuusto. The link should now directly take you to the PDF and there should be additional text about the link being a pdf.
