### PR TITLE
PP-327 origin meeting date field and moved meeting status

### DIFF
--- a/conf/cmi/core.entity_form_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_form_display.node.meeting.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.meeting.field_meeting_attachment_info
     - field.field.node.meeting.field_meeting_composition
     - field.field.node.meeting.field_meeting_date
+    - field.field.node.meeting.field_meeting_date_original
     - field.field.node.meeting.field_meeting_decision
     - field.field.node.meeting.field_meeting_dm
     - field.field.node.meeting.field_meeting_dm_id
@@ -32,6 +33,7 @@ dependencies:
     - json_field
     - media_library
     - path
+    - publication_date
     - scheduler
     - text
 third_party_settings:
@@ -59,6 +61,7 @@ third_party_settings:
       children:
         - field_meeting_id
         - field_meeting_date
+        - field_meeting_date_original
         - field_meeting_location
         - field_meeting_status
         - field_meeting_dm_id
@@ -186,7 +189,7 @@ content:
     third_party_settings: {  }
   field_agenda_items_processed:
     type: boolean_checkbox
-    weight: 37
+    weight: 38
     region: content
     settings:
       display_label: true
@@ -205,14 +208,14 @@ content:
     third_party_settings: {  }
   field_meeting_agenda_published:
     type: boolean_checkbox
-    weight: 36
+    weight: 37
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_meeting_attachment_info:
     type: text_textarea
-    weight: 39
+    weight: 40
     region: content
     settings:
       rows: 5
@@ -236,9 +239,15 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_meeting_date_original:
+    type: datetime_default
+    weight: 31
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_meeting_decision:
     type: text_textarea
-    weight: 35
+    weight: 36
     region: content
     settings:
       rows: 5
@@ -246,7 +255,7 @@ content:
     third_party_settings: {  }
   field_meeting_dm:
     type: string_textfield
-    weight: 34
+    weight: 35
     region: content
     settings:
       size: 60
@@ -254,7 +263,7 @@ content:
     third_party_settings: {  }
   field_meeting_dm_id:
     type: string_textfield
-    weight: 33
+    weight: 34
     region: content
     settings:
       size: 60
@@ -289,7 +298,7 @@ content:
     third_party_settings: {  }
   field_meeting_location:
     type: string_textfield
-    weight: 31
+    weight: 32
     region: content
     settings:
       size: 60
@@ -297,7 +306,7 @@ content:
     third_party_settings: {  }
   field_meeting_minutes_published:
     type: boolean_checkbox
-    weight: 38
+    weight: 39
     region: content
     settings:
       display_label: true
@@ -351,7 +360,7 @@ content:
     third_party_settings: {  }
   field_meeting_status:
     type: string_textfield
-    weight: 32
+    weight: 33
     region: content
     settings:
       size: 60

--- a/conf/cmi/core.entity_view_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.meeting.field_meeting_attachment_info
     - field.field.node.meeting.field_meeting_composition
     - field.field.node.meeting.field_meeting_date
+    - field.field.node.meeting.field_meeting_date_original
     - field.field.node.meeting.field_meeting_decision
     - field.field.node.meeting.field_meeting_dm
     - field.field.node.meeting.field_meeting_dm_id
@@ -93,6 +94,15 @@ content:
       format_type: long
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_meeting_date_original:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 23
     region: content
   field_meeting_decision:
     type: text_default

--- a/conf/cmi/core.entity_view_display.node.meeting.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.meeting.field_meeting_attachment_info
     - field.field.node.meeting.field_meeting_composition
     - field.field.node.meeting.field_meeting_date
+    - field.field.node.meeting.field_meeting_date_original
     - field.field.node.meeting.field_meeting_decision
     - field.field.node.meeting.field_meeting_dm
     - field.field.node.meeting.field_meeting_dm_id
@@ -46,6 +47,7 @@ hidden:
   field_meeting_attachment_info: true
   field_meeting_composition: true
   field_meeting_date: true
+  field_meeting_date_original: true
   field_meeting_decision: true
   field_meeting_dm: true
   field_meeting_dm_id: true

--- a/conf/cmi/field.field.node.meeting.field_meeting_date_original.yml
+++ b/conf/cmi/field.field.node.meeting.field_meeting_date_original.yml
@@ -1,0 +1,21 @@
+uuid: e0b6783c-ea66-45ff-a41f-66f591a35f30
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meeting_date_original
+    - node.type.meeting
+  module:
+    - datetime
+id: node.meeting.field_meeting_date_original
+field_name: field_meeting_date_original
+entity_type: node
+bundle: meeting
+label: 'Meeting date (original)'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.storage.node.field_meeting_date_original.yml
+++ b/conf/cmi/field.storage.node.field_meeting_date_original.yml
@@ -1,0 +1,20 @@
+uuid: 7a6e8faf-01cc-4dc0-bc0f-03edab18d720
+langcode: fi
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_meeting_date_original
+field_name: field_meeting_date_original
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_meetings.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_meetings.yml
@@ -96,6 +96,8 @@ source:
   ids:
     meeting_id:
       type: string
+  constants:
+    meeting_date_orig_field: field_meeting_date_original
 process:
   type:
     plugin: default_value
@@ -153,13 +155,21 @@ process:
     plugin: callback
     callable: json_encode
     source: meeting_documents
-  field_meeting_date:
+  _meeting_date:
     plugin: format_date
     from_format: 'Y-m-d\TH:i:s.000'
     to_format: 'Y-m-d\TH:i:s'
     from_timezone: Europe/Helsinki
     to_timezone: UTC
     source: meeting_date
+  field_meeting_date: '@_meeting_date'
+  field_meeting_date_original:
+    plugin: callback
+    callable: _paatokset_ahjo_api_get_existing_value
+    source:
+      - '@nid'
+      - 'constants/meeting_date_orig_field'
+      - '@_meeting_date'
   field_meeting_agenda_published:
     -
       callable: _paatokset_ahjo_api_true_if_not_empty

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_meetings.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_meetings.yml
@@ -170,6 +170,7 @@ process:
       - '@nid'
       - 'constants/meeting_date_orig_field'
       - '@_meeting_date'
+      - '@langcode'
   field_meeting_agenda_published:
     -
       callable: _paatokset_ahjo_api_true_if_not_empty

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -93,6 +93,17 @@ class MeetingService {
       $timestamp = $node->get('field_meeting_date')->date->getTimeStamp();
       $date = date('Y-m-d', $timestamp);
 
+      // Check if meeting was moved.
+      $orig_timestamp = NULL;
+      if ($node->hasField('field_meeting_date_original') && !$node->get('field_meeting_date_original')->isEmpty()) {
+        $orig_timestamp = $node->get('field_meeting_date_original')->date->getTimeStamp();
+      }
+
+      $additional_info = NULL;
+      if ($orig_timestamp && $orig_timestamp !== $timestamp) {
+        $additional_info = t('Meeting moved');
+      }
+
       $transformedResult = [
         'title' => $node->get('title')->value,
         'meeting_date' => $timestamp,
@@ -100,6 +111,7 @@ class MeetingService {
         'policymaker_name' => $node->get('field_meeting_dm')->value,
         'policymaker' => $node->get('field_meeting_dm_id')->value,
         'start_time' => date('H:i', $timestamp),
+        'additional_info' => $additional_info,
       ];
 
       if ($node->get('field_meeting_minutes_published')->value) {

--- a/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-calendar.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/block/block--policymaker-calendar.html.twig
@@ -25,7 +25,11 @@
         <tr class="policymaker-calendar__table-row">
           <td>{{ date|date("d.m.Y") }}</td>
           <td>{{ row.start_time}}</td>
-          <td></td>
+          <td>
+          {% if row.additional_info %}
+            {{ row.additional_info }}
+          {% endif %}
+          </td>
           {% if row.minutes_link %}
             <td>
               <a href="{{row.minutes_link}}">


### PR DESCRIPTION
**To test**
- Before checking out branch, import meeting data with: `make ahjo-migrations`
- Also add the test site ahjo proxy url and run `make up` so you can fetch latest meeting data
- Checkout branch, login to container and run `drush cr;drush cim -y;`
- Check some meetings: https://helsinki-paatokset.docker.so/fi/admin/content/meetings
  - There should be a new "Meeting date (original)" field, but it should be empty
- Check the Kaupunginvaltuusto page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
  - The "Additional information / Lisätietoja" field should be empty
  - Run `drush ap:rmod -v` and try to edit some meetings again. This should fill in the current meeting date as the original value.
  - Edit a Kaupunginvaltuusto meeting that is visible in the calendar block and change one of the date fields
  - After saving, the "Lisätietoja" column should now say "Meeting moved"
- Run `drush migrate-rollback ahjo_meetings:latest`. All the meeting should be gone.
  - (If you get an error about a redirect, delete the meeting it's complaining about manually and run `drush migrate-reset-status ahjo_meetings:latest;drush migrate-rollback ahjo_meetings:latest;`
 - Import the meetings again: `drush migrate-import ahjo_meetings:latest`. Now they should have the original date filled by default.