### PR TITLE
PP-345: Site name translation

### DIFF
--- a/conf/cmi/language/fi/system.site.yml
+++ b/conf/cmi/language/fi/system.site.yml
@@ -1,0 +1,1 @@
+name: Päätökset

--- a/conf/cmi/language/sv/metatag.metatag_defaults.node__decision.yml
+++ b/conf/cmi/language/sv/metatag.metatag_defaults.node__decision.yml
@@ -1,3 +1,2 @@
 tags:
   canonical_url: '[current-page:url]?beslut=[current-page:query:beslut]'
-  title: '[node:title] – [node:field_dm_org_name:value] | [site:name] | Helsingfors stad'

--- a/conf/cmi/language/sv/system.site.yml
+++ b/conf/cmi/language/sv/system.site.yml
@@ -1,0 +1,1 @@
+name: Beslut

--- a/conf/cmi/metatag.metatag_defaults.global.yml
+++ b/conf/cmi/metatag.metatag_defaults.global.yml
@@ -9,8 +9,8 @@ label: Global
 tags:
   canonical_url: '[current-page:url]'
   image_src: '[site:base-url]/themes/custom/hdbt/src/images/og-global.png'
-  title: '[current-page:title] | [site:page-title-suffix]'
+  title: '[current-page:title] | [site:name] | [site:page-title-suffix]'
+  og_site_name: '[site:page-title-suffix]'
   twitter_cards_page_url: '[current-page:url]'
   twitter_cards_title: '[current-page:title] | [site:page-title-suffix]'
   twitter_cards_type: summary_large_image
-  og_site_name: '[site:page-title-suffix]'

--- a/conf/cmi/metatag.metatag_defaults.node.yml
+++ b/conf/cmi/metatag.metatag_defaults.node.yml
@@ -9,7 +9,7 @@ label: Content
 tags:
   canonical_url: '[node:url]'
   content_language: '[node:langcode]'
-  title: "[node:title] | [site:name] |\_Helsingin Kaupunki"
+  title: '[node:title] | [site:name] | [site:page-title-suffix]'
   article_modified_time: '[node:created:html_datetime]'
   article_published_time: '[node:created:html_datetime]'
   og_image_url: '[node:field_liftup_image:entity:field_media_image:og_image:url],[site:base-url]/themes/custom/hdbt/src/images/og-global.png'

--- a/conf/cmi/metatag.metatag_defaults.node__decision.yml
+++ b/conf/cmi/metatag.metatag_defaults.node__decision.yml
@@ -6,4 +6,4 @@ id: node__decision
 label: 'Sisältö: Decision'
 tags:
   canonical_url: '[current-page:url]?paatos=[current-page:query:asia]'
-  title: '[node:title] – [node:field_dm_org_name:value] | [site:name] | Helsingin Kaupunki'
+  title: '[node:title] – [node:field_dm_org_name:value] | [site:name] | [site:page-title-suffix]'

--- a/conf/cmi/openid_connect.client.tunnistamo.yml
+++ b/conf/cmi/openid_connect.client.tunnistamo.yml
@@ -14,5 +14,6 @@ settings:
   client_secret: 06426526-4e68-41c2-81a3-fe22ec8c318b
   is_production: 0
   auto_login: 0
-  client_scopes: ''
   environment_url: 'https://tunnistamo.test.hel.ninja'
+  client_scopes: ''
+  client_roles: {  }

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -2,13 +2,13 @@ _core:
   default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI
 langcode: en
 uuid: 060ed3cf-5793-4d2d-bdb7-06423f433850
-name: Päätökset
+name: Decisions
 mail: admin@example.com
 slogan: ''
 page:
   403: ''
   404: ''
-  front: /etusivu
+  front: /node/2799
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -7,7 +7,7 @@ dependencies:
     - toolbar
     - view_unpublished
 id: read_only
-label: 'Lukija'
+label: Lukija
 weight: 2
 is_admin: null
 permissions:


### PR DESCRIPTION
**To test**
- Checkout branch
- Edit or create the frontpage and add translations for en and sv versions. Make sure the URL alias is /etusivu for all of them
- Run `make drush-cr drush-cim`
- Open the frontpage on all languages.
  - The site name should be "Decisions", "Päätökset" or "Beslut".
  - The title attribute should be "[frontpage title] | Päätökset | Helsingin kaupunki", "[frontpage title] | Decisions | City of Helsinki" or "[frontpage title] | Beslut | Helsingfors stad"
- Open the 404 page (to test non node metatags)
  - The title attribute should be: "Sivua ei löydy | Päätökset | Helsingin kaupunki", "Page not found | Decisions | City of Helsinki" or "Sidan hittades inte | Beslut | Helsingfors stad"  