### PR TITLE
PP-335: Hide null deputy info

### DIFF
--- a/public/modules/custom/paatokset_policymakers/js/policymaker_members.js
+++ b/public/modules/custom/paatokset_policymakers/js/policymaker_members.js
@@ -47,7 +47,7 @@
                 <span v-if="member.party" class="member-party"> {{ member.party }}</span>
               </div>
               <span v-if="member.email" class="member-email">{{ processEmail(member.email) }}</span>
-              <template v-if="policymakerType !== 'Valtuusto'">
+              <template v-if="member.deputy_of">
                 <span v-if ="member.deputy_of" class="deputy-of">{{ deputyOf }}: {{ member.deputy_of }}</span>
               </template>
             </div>

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -700,6 +700,12 @@ class PolicymakerService {
       if (!empty($data)) {
         $formatted_name = $this->formatTrusteeName($data['Name']);
         $names[] = $formatted_name;
+
+        // Normalize unknown deputyof fields.
+        if ($data['DeputyOf'] === 'null null' || $data['DeputyOf'] === 'null') {
+          $data['DeputyOf'] = NULL;
+        }
+
         $composition[$formatted_name] = $data;
 
         // Special handling for combined last names or middle names.

--- a/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
+++ b/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
@@ -396,6 +396,13 @@ function helfi_paatokset_preprocess_block(&$variables) {
  * Implements hook_preprocess_page().
  */
 function helfi_paatokset_preprocess_page(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // Remove title block on 404 and 403 pages.
+  if($route_name === 'system.404'|| $route_name === 'system.403') {
+    unset($variables['page']['before_content']['helfi_paatokset_page_title']);
+  }
+
   // Set a variable to always show sidebar in policymaker pages.
   // Check by dictionary block appearing to handle unstranslated nodes on sv.
   if (isset($variables['page']['content']) && array_key_exists('paatoksetdecisionsdictionarybanner', $variables['page']['content'])) {


### PR DESCRIPTION
**Replicate issue:**
- Before checking out the branch
- If you don't have data imported, run the following commands in the container. You'll need the ahjo local proxy url env variable to point to test for these.
  - `drush migrate-import ahjo_decisionmakers:all`
  - `drush ap:update meetings 0290020224 -v`
  - `drush ap:update meetings U11500202124 -v`
- Open the kaupunginvaltuusto page and the composition JSON: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto and https://helsinki-paatokset.docker.so/fi/ahjo_api/org_composition/02900
  - Scroll down to the members list and toggle the "Show deputies" option
  - The "Deputy of" field should not be visible for the members that show up
  - The composition should have multiple members where the "DeputyOf" field is "null null" as a string
- Open the Keskusvaalilautakunta page and the composition JSON: https://helsinki-paatokset.docker.so/fi/paattajat/keskusvaalilautakunta
  - Scroll down to the members list and toggle the "Show deputies" option
  - The "Deputy of" field should show up with the "null null" value
  - The composition should have multiple members where the "DeputyOf" field is "null null" as a string

**To test:**
- Checkout branch, run `make drush-cr`
- Reload the pages
  - The composition should now always have `null` instead of "null null" string.
  - The deputyof fields should be missing from both the kaupunginvaltuusto and the keskusvaalilautakunta member lists. 