### PR TITLE
PP-0: Fix sorting order on all initiatives list.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -350,8 +350,11 @@ function paatokset_ahjo_api_preprocess_block__all_initiatives(array &$variables)
   /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
   $policymakerService = \Drupal::service('paatokset_policymakers');
   $initiatives = $policymakerService->getAllInitiatives();
-
   $years = array();
+
+  usort($initiatives, function ($item1, $item2) {
+    return strtotime($item2['Date']) - strtotime($item1['Date']);
+  });
 
   foreach ($initiatives as $initiative ) {
     $date = date_format(date_create($initiative['Date']),"Y");
@@ -359,18 +362,6 @@ function paatokset_ahjo_api_preprocess_block__all_initiatives(array &$variables)
       $years[] = $date;
     }
   }
-
-  function value_reverse($array) {
-    $keys = array_keys($array);
-    $reversed_values = array_reverse(array_values($array), true);
-    return array_combine($keys, $reversed_values);
-  }
-
-  $years = value_reverse($years);
-
-  usort($initiatives, function ($item1, $item2) {
-    return $item1['Date'] <=> $item2['Date'];
-  });
 
   $by_year = array();
 

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -369,7 +369,7 @@ function paatokset_ahjo_api_preprocess_block__all_initiatives(array &$variables)
     $filtered = array_filter($initiatives, function ($var) use ($year) {
         return (str_contains(date_format(date_create($var['Date']),"Y"), $year));
     });
-    $by_year[$year] = array_reverse($filtered);
+    $by_year[$year] = $filtered;
   };
 
   $variables['initiatives'] = $by_year;


### PR DESCRIPTION
**To test**
- Checkout branch, run `make drush-cr`
- To get up-to-date initiative data, ssh to the container and run: `drush mim ahjo_trustees:council --update` (you'll need the proxy URL environment variable for this)
- Go to https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/aloitteet OR create a page with /aloitteet as the URL alias
- The initiatives should be sorted from newest to oldest and the year tabs should be in the correct order