### PR TITLE
PP-0: Add new command for creating site structure.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -10,8 +10,12 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\paatokset_ahjo_proxy\AhjoProxy;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\node\NodeStorageInterface;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\Entity\PathAlias;
 use Symfony\Component\Console\Helper\Table;
 
 /**
@@ -1484,6 +1488,313 @@ class AhjoAggregatorCommands extends DrushCommands {
       $this->writeln(sprintf('Decision added to queue: %s', $item['PDF']['NativeId']));
       $this->ahjoProxy->addItemToAhjoQueue('decisions', $item['PDF']['NativeId']);
     }
+  }
+
+  /**
+   * Create basic site structure after fresh install.
+   *
+   * @command ahjo-proxy:create-site-structure
+   *
+   * @aliases ap:site
+   */
+  public function createSiteStructure(): void {
+    $pages = [
+      [
+        'title' => 'Etusivu',
+        'path' => '/etusivu',
+        'type' => 'landing_page',
+        'translations' => [
+          'sv' => [
+            'title' => 'Framsidan',
+            'path' => '/etusivu',
+          ],
+          'en' => [
+            'title' => 'Home',
+            'path' => '/etusivu',
+          ],
+        ]
+      ],
+      [
+        'title' => 'Päättäjät',
+        'path' => '/paattajat',
+        'type' => 'landing_page',
+        'translations' => [
+          'sv' => [
+            'title' => 'Beslutsfattare',
+            'path' => '/beslutsfattare',
+          ],
+        ],
+      ],
+      [
+        'title' => 'Kokouskalenteri',
+        'path' => '/kokouskalenteri',
+        'type' => 'landing_page',
+        'translations' => [
+          'sv' => [
+            'title' => 'Möteskalender',
+            'path' => '/moteskalender',
+          ],
+        ],
+      ],
+      [
+        'title' => 'Tietoa Helsingin päätöksenteosta',
+        'path' => '/tietoa-paatoksenteosta',
+        'type' => 'page',
+        'translations' => [
+          'sv' => [
+            'title' => 'Information om beslutsfattning',
+            'path' => '/information-om-beslutsfattning'
+          ]
+        ],
+      ],
+      [
+        'title' => 'Kuulutukset',
+        'path' => '/tietoa-paatoksenteosta/kuulutukset',
+        'type' => 'page',
+        'translations' => [
+          'sv' => [
+            'title' => 'Kungörelser',
+            'path' => '/information-om-beslutsfattning/kungorelser'
+          ]
+        ],
+      ],
+      [
+        'title' => 'Sidonnaisuusilmoitukset',
+        'path' => '/tietoa-paatoksenteosta/sidonnaisuusilmoitukset',
+        'type' => 'page',
+        'translations' => [],
+      ],
+    ];
+
+    $menu = [
+      [
+        'title' => 'Hae päätöksiä',
+        'path' => 'internal:/fi/asia',
+        'translations' => [
+          'sv' => [
+            'title' => 'Arende',
+            'path' => 'internal:/sv/arende',
+          ]
+        ],
+      ],
+      [
+        'title' => 'Päättäjät',
+        'path' => 'internal:/fi/paattajat',
+        'translations' => [
+          'sv' => [
+            'title' => 'Beslutsfattare',
+            'path' => 'internal:/sv/beslutsfattare',
+          ]
+        ],
+      ],
+      [
+        'title' => 'Kokouskalenteri',
+        'path' => 'internal:/fi/kokouskalenteri',
+        'translations' => [
+          'sv' => [
+            'title' => 'Möteskalender',
+            'path' => 'internal:/sv/moteskalender',
+          ],
+        ],
+      ],
+      [
+        'title' => 'Tietoa päätöksenteosta',
+        'path' => 'internal:/fi/tietoa-paatoksenteosta',
+        'translations' => [
+          'sv' => [
+            'title' => 'Information om beslutsfattning',
+            'path' => 'internal:/sv/information-om-beslutsfattning',
+          ],
+        ],
+        'children' => [
+          [
+            'title' => 'Kuulutukset',
+            'path' => 'internal:/fi/tietoa-paatoksenteosta/kuulutukset',
+            'translations' => [
+              'sv' => [
+                'title' => 'Kungörelser',
+                'path' => 'internal:/sv/information-om-beslutsfattning/kungorelser'
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    foreach ($pages as $page) {
+      $node = $this->createNode($page['title'], $page['type'], $page['path']);
+      if (!$node) {
+        $this->writeln(sprintf('Could not create node: %s', $page['title']));
+        continue;
+      }
+      $this->writeln(sprintf('Created node: %s', $page['title']));
+
+      foreach ($page['translations'] as $langcode => $translation) {
+        $this->addNodeTranslation($node, $langcode, $translation['title'], $translation['path']);
+        $this->writeln(sprintf('...Added %s translation: %s', $langcode, $translation['title']));
+      }
+    }
+
+    foreach ($menu as $item) {
+      $menu_item = $this->addMenuItem($item['title'], $item['path']);
+
+      if (!$menu_item) {
+        $this->writeln(sprintf('Could not create menu item: %s', $item['title']));
+        continue;
+      }
+      $this->writeln(sprintf('Created menu item: %s', $item['title']));
+
+      foreach ($item['translations'] as $langcode => $translation) {
+        $this->addMenuTranslation($menu_item, $langcode, $translation['title'], $translation['path']);
+        $this->writeln(sprintf('...Added %s translation: %s', $langcode, $translation['title']));
+      }
+
+      if (empty($item['children'])) {
+        continue;
+      }
+
+      foreach ($item['children'] as $child) {
+        $child_item = $this->addMenuItem($child['title'], $child['path'], $menu_item);
+
+        if (!$child_item) {
+          $this->writeln(sprintf('...Could not create menu item: %s', $child['title']));
+        }
+
+        $this->writeln(sprintf('...Created child menu item: %s', $child['title']));
+
+        foreach ($child['translations'] as $langcode => $ct_item) {
+          $this->addMenuTranslation($child_item, $langcode, $ct_item['title'], $ct_item['path']);
+          $this->writeln(sprintf('......Added %s translation: %s', $langcode, $ct_item['title']));
+        }
+      }
+    }
+  }
+
+  private function createNode(string $title, string $type, string $path): ?NodeInterface {
+    $query = $this->entityTypeManager->getStorage('node')->getQuery()
+      ->condition('type', $type)
+      ->condition('title', $title)
+      ->range('0', 1)
+      ->latestRevision();
+    $nids = $query->execute();
+
+    if (empty($nids)) {
+      $node = Node::create([
+        'type' => $type,
+        'title' => $title,
+        'langcode' => 'fi',
+      ]);
+    } else {
+      $node = Node::load(reset($nids));
+    }
+
+    if (!$node instanceof NodeInterface) {
+      return NULL;
+    }
+
+    $node->save();
+
+    $path_storage = $this->entityTypeManager->getStorage('path_alias');
+    $query = $path_storage->getQuery()
+      ->condition('path', '/node/' . $node->id())
+      ->range('0', 1)
+      ->condition('langcode', 'fi');
+    $pids = $query->execute();
+    if (empty($pids)) {
+      $path_alias = PathAlias::create([
+        'path' => '/node/' . $node->id(),
+        'alias' => $path,
+        'langcode' => 'fi',
+      ]);
+      $path_alias->save();
+    }
+    else {
+      $path_alias = PathAlias::load(reset($pids));
+      $path_alias->set('alias', $path);
+      $path_alias->save();
+    }
+
+    return $node;
+  }
+
+  private function addNodeTranslation(NodeInterface $node, string $langcode, string $title, string $path): ?NodeInterface {
+    if ($node->hasTranslation($langcode)) {
+      return $node;
+    }
+    $node->addTranslation($langcode, [
+      'title' => $title,
+    ]);
+
+    $node->save();
+
+    $path_storage = $this->entityTypeManager->getStorage('path_alias');
+    $query = $path_storage->getQuery()
+      ->condition('path', '/node/' . $node->id())
+      ->range('0', 1)
+      ->condition('langcode', $langcode);
+    $pids = $query->execute();
+    if (empty($pids)) {
+      $path_alias = PathAlias::create([
+        'path' => '/node/' . $node->id(),
+        'alias' => $path,
+        'langcode' => $langcode,
+      ]);
+      $path_alias->save();
+    }
+    else {
+      $path_alias = PathAlias::load(reset($pids));
+      $path_alias->set('alias', $path);
+      $path_alias->save();
+    }
+
+    return $node;
+  }
+
+  private function addMenuItem(string $title, string $path, ?MenuLinkContentInterface $parent = NULL): ?MenuLinkContentInterface {
+    $menu_storage = $this->entityTypeManager->getStorage('menu_link_content');
+    $query = $menu_storage->getQuery()
+      ->condition('title', $title)
+      ->condition('langcode', 'fi');
+    $mids = $query->execute();
+    if (empty($mids)) {
+      $menu_item = MenuLinkContent::create([
+        'menu_name' => 'main',
+        'title' => $title,
+        'link' => ['uri' => $path],
+        'langcode' => 'fi',
+        'expanded' => TRUE,
+      ]);
+    } else {
+      $menu_item = MenuLinkContent::load(reset($mids));
+    }
+
+    if (!$menu_item instanceof MenuLinkContentInterface) {
+      return NULL;
+    }
+
+    if ($parent instanceof MenuLinkContentInterface) {
+      $menu_item->set('parent', 'menu_link_content:' . $parent->uuid());
+    }
+
+    $menu_item->save();
+
+    return $menu_item;
+  }
+
+  private function addMenuTranslation(MenuLinkContentInterface $item, string $langcode, string $title, string $path): ?MenuLinkContentInterface {
+    if ($item->hasTranslation($langcode)) {
+      return $item;
+    }
+
+    $item->addTranslation($langcode, [
+      'title' => $title,
+      'link' => ['uri' => $path],
+      'expanded' => TRUE,
+    ]);
+
+    $item->save();
+
+    return $item;
   }
 
   /**

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -1512,7 +1512,7 @@ class AhjoAggregatorCommands extends DrushCommands {
             'title' => 'Home',
             'path' => '/etusivu',
           ],
-        ]
+        ],
       ],
       [
         'title' => 'Päättäjät',
@@ -1543,8 +1543,8 @@ class AhjoAggregatorCommands extends DrushCommands {
         'translations' => [
           'sv' => [
             'title' => 'Information om beslutsfattning',
-            'path' => '/information-om-beslutsfattning'
-          ]
+            'path' => '/information-om-beslutsfattning',
+          ],
         ],
       ],
       [
@@ -1554,8 +1554,8 @@ class AhjoAggregatorCommands extends DrushCommands {
         'translations' => [
           'sv' => [
             'title' => 'Kungörelser',
-            'path' => '/information-om-beslutsfattning/kungorelser'
-          ]
+            'path' => '/information-om-beslutsfattning/kungorelser',
+          ],
         ],
       ],
       [
@@ -1574,7 +1574,7 @@ class AhjoAggregatorCommands extends DrushCommands {
           'sv' => [
             'title' => 'Arende',
             'path' => 'internal:/sv/arende',
-          ]
+          ],
         ],
       ],
       [
@@ -1584,7 +1584,7 @@ class AhjoAggregatorCommands extends DrushCommands {
           'sv' => [
             'title' => 'Beslutsfattare',
             'path' => 'internal:/sv/beslutsfattare',
-          ]
+          ],
         ],
       ],
       [
@@ -1613,7 +1613,7 @@ class AhjoAggregatorCommands extends DrushCommands {
             'translations' => [
               'sv' => [
                 'title' => 'Kungörelser',
-                'path' => 'internal:/sv/information-om-beslutsfattning/kungorelser'
+                'path' => 'internal:/sv/information-om-beslutsfattning/kungorelser',
               ],
             ],
           ],
@@ -1670,6 +1670,19 @@ class AhjoAggregatorCommands extends DrushCommands {
     }
   }
 
+  /**
+   * Create or update node and add a custom path.
+   *
+   * @param string $title
+   *   Node title.
+   * @param string $type
+   *   Node type.
+   * @param string $path
+   *   Custom path alias.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   *   Created node or NULL if one couldn't be created.
+   */
   private function createNode(string $title, string $type, string $path): ?NodeInterface {
     $query = $this->entityTypeManager->getStorage('node')->getQuery()
       ->condition('type', $type)
@@ -1684,7 +1697,8 @@ class AhjoAggregatorCommands extends DrushCommands {
         'title' => $title,
         'langcode' => 'fi',
       ]);
-    } else {
+    }
+    else {
       $node = Node::load(reset($nids));
     }
 
@@ -1717,6 +1731,21 @@ class AhjoAggregatorCommands extends DrushCommands {
     return $node;
   }
 
+  /**
+   * Add a translation for a node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node to add translation to.
+   * @param string $langcode
+   *   Langcode for translation.
+   * @param string $title
+   *   Node title.
+   * @param string $path
+   *   Custom path for translation.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   *   Original node or NULL if adding translation fails.
+   */
   private function addNodeTranslation(NodeInterface $node, string $langcode, string $title, string $path): ?NodeInterface {
     if ($node->hasTranslation($langcode)) {
       return $node;
@@ -1750,6 +1779,19 @@ class AhjoAggregatorCommands extends DrushCommands {
     return $node;
   }
 
+  /**
+   * Add a menu link content item.
+   *
+   * @param string $title
+   *   Menu link title.
+   * @param string $path
+   *   Menu link URI.
+   * @param \Drupal\menu_link_content\MenuLinkContentInterface|null $parent
+   *   Parent menu link item, or NULL if this item is at root.
+   *
+   * @return \Drupal\menu_link_content\MenuLinkContentInterface|null
+   *   Created menu link item or NULL if one couldn't be created.
+   */
   private function addMenuItem(string $title, string $path, ?MenuLinkContentInterface $parent = NULL): ?MenuLinkContentInterface {
     $menu_storage = $this->entityTypeManager->getStorage('menu_link_content');
     $query = $menu_storage->getQuery()
@@ -1764,7 +1806,8 @@ class AhjoAggregatorCommands extends DrushCommands {
         'langcode' => 'fi',
         'expanded' => TRUE,
       ]);
-    } else {
+    }
+    else {
       $menu_item = MenuLinkContent::load(reset($mids));
     }
 
@@ -1781,6 +1824,21 @@ class AhjoAggregatorCommands extends DrushCommands {
     return $menu_item;
   }
 
+  /**
+   * Add translation to menu link item.
+   *
+   * @param \Drupal\menu_link_content\MenuLinkContentInterface $item
+   *   Item to add translation to.
+   * @param string $langcode
+   *   Langcode for translation.
+   * @param string $title
+   *   Link title.
+   * @param string $path
+   *   Link URL.
+   *
+   * @return \Drupal\menu_link_content\MenuLinkContentInterface|null
+   *   Original menu link item, or NULL if adding translation fails.
+   */
   private function addMenuTranslation(MenuLinkContentInterface $item, string $langcode, string $title, string $path): ?MenuLinkContentInterface {
     if ($item->hasTranslation($langcode)) {
       return $item;


### PR DESCRIPTION
**To test**
- Checkout branch
- Run `make new` (take a backup of your local site to save your current setup)
- SSH into the container and run `drush ahjo-proxy:create-site-structure`
- This should create some nodes and menu items for the basic site structure (frontpage, decisionmakers, calendar, etc)