### PR TITLE
PP-360: Better creation of motions and matching of decisions to motions.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -613,16 +613,25 @@ function _paatokset_ahjo_api_lookup_case_nid(string $case_id): ?string {
 function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
   // First attempt to find node with native ID.
   $native_id = $values[0];
-  if (isset($values[1]) && isset($values[2]) && isset($values[3])) {
+  if (!empty($values[1])) {
     $case_id = $values[1];
-    $meeting_id = $values[2];
-    $title = $values[3];
   }
   else {
     $case_id = NULL;
+  }
+  if (!empty($values[2])) {
+    $meeting_id = $values[2];
+  }
+  else {
     $meeting_id = NULL;
+  }
+  if (!empty($values[3])) {
+    $title = $values[3];
+  }
+  else {
     $title = NULL;
   }
+
   $query = Drupal::entityQuery('node')
     ->condition('type', 'decision')
     ->condition('field_decision_native_id', $native_id)
@@ -634,18 +643,29 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
     return reset($ids);
   }
 
-  if (!$case_id || !$meeting_id) {
+  if (!$meeting_id) {
+    return NULL;
+  }
+
+  if (!$case_id && !$title) {
     return NULL;
   }
 
   $query = Drupal::entityQuery('node')
     ->condition('type', 'decision')
-    ->condition('field_diary_number', $case_id)
     ->condition('field_meeting_id', $meeting_id)
     ->condition('field_is_decision', 0)
+    ->condition('status', 1)
     ->range(0, 1)
     ->latestRevision();
   $ids = $query->execute();
+
+  if ($case_id) {
+    $query->condition('field_diary_number', $case_id);
+  }
+  else {
+    $query->condition('field_full_title', $title);
+  }
 
   if (!empty($ids)) {
     return reset($ids);

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -1323,8 +1323,8 @@ class CaseService {
   /**
    * Find or create motion as decision node.
    *
-   * @param string $case_id
-   *   Diary number for motion.
+   * @param string|null $case_id
+   *   Diary number for motion. Can be NULL.
    * @param string $meeting_id
    *   Meeting ID for motion.
    * @param string $title
@@ -1335,7 +1335,7 @@ class CaseService {
    * @return Drupal\node\NodeInterface|null
    *   Decision node as motion. NULL if not found or if a decision was found.
    */
-  public function findOrCreateMotion(string $case_id, string $meeting_id, string $title, bool $check_title = FALSE): ?NodeInterface {
+  public function findOrCreateMotion(?string $case_id, string $meeting_id, string $title, bool $check_title = FALSE): ?NodeInterface {
     if ($check_title) {
       $nodes = $this->decisionQuery([
         'case_id' => $case_id,

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1259,7 +1259,7 @@ class AhjoProxy implements ContainerInjectionInterface {
     // Handle cases where ids are blank.
     if (empty($ids) || !isset($ids['case_id'])) {
       $ids = [
-        'case_id' => '',
+        'case_id' => NULL,
       ];
     }
 


### PR DESCRIPTION
**Replicate issue before checking out branch:**
* Optional: Run `make new` to make testing clearer
* Login to the container and run the following commands (you'll need the proxy url env variable)
  * `drush ap:update organization 00400 -v`
  * `drush ap:update organization U02980 -v` 
  * `drush ap:update meetings U0298020224 -v` (if this meeting already has minutes published, pick another one that only has the agenda)
  * `drush ap:update meetings 00400202216 -v`
* Run  the command for generating motions: `drush ap:gm -v`
  * This should generate motions for all agenda items of the meeting your imported (this is easier to test if you ran `make new`).
* Reset the meeting status and generate motions again: `drush ap:rm -v;drush ap: gm -v`
  * This should skip all the agenda items with diary numbers, but will create duplicates for items where it is missing 
* Check the decisions list and confirm that the duplicates are present: https://helsinki-paatokset.docker.so/fi/admin/content/decisions

**To test**
* Checkout branch, run `make drush-cr`
* Reset the meeting status and try generating motions again: `drush ap:rm -v;drush ap:gm -v`
  * This should no longer create any duplicates. Try again one or two times.
* To test matching motions without diary numbers to decision, we'll use a decision from meeting 0400202216.
  * Edit one of the duplicate motions that was created and change some fields:
  * Title and full title: Kokouksen laillisuuden ja päätösvaltaisuuden toteaminen sekä pöytäkirjan tarkastajien valinta
  * Organization ID: 00400
  * Organization name: Kaupunginhallitus
  * Meeting ID: 00400202216
* Save the node and view it. It should now link to the correct meeting.
* Import the decision that should replace the motion: `drush ap:update decisions {66034CE5-D26C-4AC0-AD4F-276F7B8DCD34} -v`
   * Reload the motion. You should be redirected to the new decision.
* Check the meeting minutes page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus/asiakirjat/00400202216
  * The first item on the list should link to the new decision
* Confirm on the decisions content list that the motion you edited has been replaced by the decision: https://helsinki-paatokset.docker.so/fi/admin/content/decisions

**Test script for unpublishing and deleting orphaned motions**
- Migrate some new meetings to test with:
  - drush ap:update meetings U480202210 -v
  - drush ap:update meetings U0298020224 -v
  - drush ap:update meetings 00400202217 -v
  - drush ap:gm -v
- Edit one of the meetings and set the "Minutes published" toggle to true
- Run `drush ahjo-proxy:orphaned-motions`
  - This should list all the motions belonging to that meeting
- Run  `drush ahjo-proxy:orphaned-motions unpublish` and answer "yes" to the prompt. This should unpublish the listed motions
- Edit the second meeting and set the "minutes published" value to true
- Run `drush ahjo-proxy:orphaned-motions delete` and answer "yes". This should delete the motions
- Edit the third meeting and set the "minutes published" value to true
- Run `drush ahjo-proxy:orphaned-motions unpublished -y`. This should unpublish the listed motions without prompting you