### PR TITLE
PP-353: Display default name for on decision if policymaker node is missing

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -664,13 +664,24 @@ class CaseService {
       return NULL;
     }
 
+    if ($decision->hasField('field_dm_org_name') && !$decision->get('field_dm_org_name')->isEmpty()) {
+      $default_name = $decision->get('field_dm_org_name')->value;
+    }
+    else {
+      $default_name = NULL;
+    }
+
     if (!$decision->hasField('field_policymaker_id') || $decision->get('field_policymaker_id')->isEmpty()) {
-      return NULL;
+      return $default_name;
     }
 
     /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
     $policymakerService = \Drupal::service('paatokset_policymakers');
-    return $policymakerService->getPolicymakerNameById($decision->get('field_policymaker_id')->value);
+    $policymaker_name = $policymakerService->getPolicymakerNameById($decision->get('field_policymaker_id')->value);
+    if (!$policymaker_name) {
+      return $default_name;
+    }
+    return $policymaker_name;
   }
 
   /**

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -1552,7 +1552,7 @@ class PolicymakerService {
     if ($node instanceof NodeInterface) {
       return $this->getPolicyMakerClass($node);
     }
-    return 'color-none';
+    return 'color-sumu';
   }
 
 }


### PR DESCRIPTION
**To test**
- Checkout branch
- Run `make drush-cr`
- Import the following decisions and meetings:
  - `drush ap:update decisions {EEE8CF3C-FF11-4006-A793-FFCC89BBB608} -v`
  - `drush ap:update decisions {FE649278-C812-C96D-B0E7-75DF96700001} -v`
  - `drush ap:update cases HEL-2021-010378 -v`
  - `drush ap update meetings 8100020177 -v`
  - `drush ap:update meetings U540100202119 -v`
- Open the this decision: https://helsinki-paatokset.docker.so/fi/asia/hel-2021-010378/fe649278-c812-c96d-b0e7-75df96700001
  - The policymaker name should be visible and should have the default color-sumu color coding
  -  Even though the meeting has been imported, the "see other decisions" link should not be visible because the policymaker node does not exist
- Edit the decision node and add ?HEL-2021-010378` as the case ID
- The dropdown should show the other decision you imported. The title and color coding should work (except the title is the decision title, because the policymaker is missing).
- Import the missing policymaker: `drush ap:update organization 81000 -v`
- The link to the meeting minutes should be working now.