### PR TITLE
PP-349: Unify translations

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/config/install/paatokset_ahjo_api.default_texts.yml
+++ b/public/modules/custom/paatokset_ahjo_api/config/install/paatokset_ahjo_api.default_texts.yml
@@ -19,3 +19,5 @@ banner_text:
 banner_heading: 'Sanat hukassa?'
 banner_label: 'Siirry sanakirjaan'
 banner_url: '/fi/tietoa-paatoksenteosta/paatoksenteon-sanakirja'
+committees_boards_url: '/fi/paattajat'
+office_holders_url: '/fi/paattajat'

--- a/public/modules/custom/paatokset_ahjo_api/config/schema/paatokset_ahjo_api.schema.yml
+++ b/public/modules/custom/paatokset_ahjo_api/config/schema/paatokset_ahjo_api.schema.yml
@@ -73,3 +73,9 @@ paatokset_ahjo_api.default_texts:
     banner_url:
       type: label
       label: 'Banner CTA button URL'
+    committees_boards_url:
+      type: label
+      label: 'Committees and boards URL'
+    office_holders_url:
+      type: label
+      label: 'Office holders URL'

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -15,6 +15,8 @@ use Drupal\Core\Link;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 
+use function GuzzleHttp\default_ca_bundle;
+
 /**
  * Implements hook_theme().
  */
@@ -198,7 +200,7 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
       'title' => $node['first_name'] . ' ' . $node['last_name'],
       'link' => $node['url'],
       'organization_type' => 'trustee',
-      'trustee_type' => t('Valtuutettu')
+      'trustee_type' => t('Councillor')
     ];
   };
 
@@ -209,7 +211,7 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
       'title' => $node['first_name'] . ' ' . $node['last_name'],
       'link' => $node['url'],
       'organization_type' => 'trustee',
-      'trustee_type' => t('Varavaltuutettu')
+      'trustee_type' => t('Deputy councillor')
     ];
   };
 
@@ -322,22 +324,42 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
   $variables['cards'] = [$accordion_contents['valtuusto'][1], $accordion_contents['hallitus'][1]];
 
   $accordions_1 = [
-    'Kaupunginhallituksen jaostot' => $hallituksen_jaosto,
-    'Lautakunnat ja johtokunnat' => $sectors,
+    'City Board sub-committees' => $hallituksen_jaosto,
+    'Committees and Boards' => $sectors,
   ];
 
   $accordions_2 = [];
 
   foreach ($sectors_occupants as $key => $value) {
+    switch ($key) {
+      case 'Kasvatuksen ja koulutuksen toimiala':
+        $tkey = 'Education Division';
+        break;
+      case 'Kaupunkiympäristön toimiala':
+        $tkey = 'Urban Environment Division';
+        break;
+      case 'Keskushallinto':
+        $tkey = 'Central Administration';
+        break;
+      case 'Kulttuurin ja vapaa-ajan toimiala':
+        $tkey = 'Culture and Leisure Division';
+        break;
+      case 'Sosiaali- ja terveystoimiala':
+        $tkey = 'Social Services and Health Care Division';
+        break;
+      default:
+        $tkey = $key;
+        break;
+    }
     if (strlen($key) !== 0 ) {
-      $accordion_key = 'Viranhaltijat: ' . $key;
+      $accordion_key = 'Office holders: ' . $tkey;
       $accordions_2[$accordion_key] = $value;
     }
   }
 
   $accordions_3 = [
-    'Luottamushenkilöpäättäjät' => $accordion_contents['trustee'][1],
-    'Kaupunginvaltuuston jäsenet' => array_merge($members_formatted, $deputies_formatted)
+    'Elected official decisionmakers' => $accordion_contents['trustee'][1],
+    'City Council members' => array_merge($members_formatted, $deputies_formatted)
   ];
 
   $accordions = array_merge($accordions_1, array_merge($accordions_2, $accordions_3));
@@ -446,6 +468,17 @@ function paatokset_ahjo_api_preprocess_block__decision_tree(array &$variables): 
   /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
   $policymakerService = \Drupal::service('paatokset_policymakers');
 
+  $defaults_config = \Drupal::config('paatokset_ahjo_api.default_texts');
+  $committees_url = $defaults_config->get('committees_boards_url');
+  if (!$committees_url) {
+    $committees_url = '/fi/paattajat';
+  }
+  $office_holders_url = $defaults_config->get('office_holders_url');
+  if (!$office_holders_url) {
+    $office_holders_url = '/fi/paattajat';
+  }
+
+
   // Helpful $content variable for templates.
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
@@ -456,40 +489,40 @@ function paatokset_ahjo_api_preprocess_block__decision_tree(array &$variables): 
 
   $variables['decision_process'] = [
     '0' => [
-      'title' => t('Asia tulee vireille'),
+      'title' => t('Initiation'),
     ],
     '1' => [
-      'title' => t('Lauta- ja johtokunta'),
-      'link' => t('/fi/paattajat#lautakunnat-ja-johtokunnat')
+      'title' => t('Committees and Boards'),
+      'link' => $committees_url,
     ],
     '2' => [
-      'title' => t('Kaupunginhallitus'),
+      'title' => t('City council'),
       'link' => $policymakerService->getPolicymaker('00400')->toUrl()->toString()
     ],
     '3' => [
-      'title' => t('Kaupuginvaltuusto'),
+      'title' => t('City board'),
       'link' => $policymakerService->getPolicymaker('02900')->toUrl()->toString()
     ],
     '4' => [
-      'title' => t('Päätös pannaan täytäntöön'),
+      'title' => t('Implementation'),
       ]
   ];
 
   $variables['decisionmaker_process'] = [
     '0' => [
-      'title' => t('Asia tulee vireille'),
+      'title' => t('Initiation'),
     ],
     '1' => [
-      'title' => t('Viranhaltija päättää'),
-      'link' => t('/fi/paattajat#viranhaltijat:-sosiaali--ja-terveystoimiala')
+      'title' => t('Office holder decision'),
+      'link' => $office_holders_url,
     ],
     '2' => [
-      'title' => t('Päätös pannaan täytäntöön'),
+      'title' => t('Implementation'),
     ]
   ];
 
-  $variables['info_1'] = t('Tavallisin päätöksen tekemisen prosessi');
-  $variables['info_2'] = t('Tavallinen viranhaltijapäätös');
+  $variables['info_1'] = t('Standard decision-making process');
+  $variables['info_2'] = t('Standard process for office holder decisions');
 }
 
 /**

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -237,6 +237,13 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
       $node = $node->getTranslation($currentLanguage);
     }
 
+    if ($node->hasField('field_sector_name') && !$node->get('field_sector_name')->isEmpty()) {
+      $sector = _paatokset_ahjo_api_get_sector_english_translation($node->get('field_sector_name')->value);
+    }
+    else {
+      $sector = '';
+    }
+
     $filtered[] = [
       'title' => $node->get('field_ahjo_title')->value,
       'link' => $policymakerService->getPolicymakerRoute($node, $currentLanguage),
@@ -245,7 +252,7 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
       'image' => $node->get('field_policymaker_image')->view('default'),
       'organization_color' => $policymakerService->getPolicymakerClassById($node->get('field_policymaker_id')->value),
       'is_city_council_division' => $node->get('field_city_council_division')->value,
-      'sector' => $node->get('field_sector_name')->value,
+      'sector' => $sector,
     ];
   }
 
@@ -331,27 +338,8 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
   $accordions_2 = [];
 
   foreach ($sectors_occupants as $key => $value) {
-    switch ($key) {
-      case 'Kasvatuksen ja koulutuksen toimiala':
-        $tkey = 'Education Division';
-        break;
-      case 'Kaupunkiympäristön toimiala':
-        $tkey = 'Urban Environment Division';
-        break;
-      case 'Keskushallinto':
-        $tkey = 'Central Administration';
-        break;
-      case 'Kulttuurin ja vapaa-ajan toimiala':
-        $tkey = 'Culture and Leisure Division';
-        break;
-      case 'Sosiaali- ja terveystoimiala':
-        $tkey = 'Social Services and Health Care Division';
-        break;
-      default:
-        $tkey = $key;
-        break;
-    }
-    if (strlen($key) !== 0 ) {
+    $tkey = _paatokset_ahjo_api_get_sector_english_translation($key);
+    if (strlen($tkey) !== 0 ) {
       $accordion_key = 'Office holders: ' . $tkey;
       $accordions_2[$accordion_key] = $value;
     }
@@ -367,6 +355,39 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
   $variables['accordions'] = $accordions;
 
   $variables['title'] = $variables['elements']['content']['label'];
+}
+
+/**
+ * Get english version of finnish sector name.
+ *
+ * @param string $sector
+ *   Sector name.
+ * @return string
+ *   English translation of sector, or original value.
+ */
+function _paatokset_ahjo_api_get_sector_english_translation(string $sector): string {
+  switch ($sector) {
+    case 'Kasvatuksen ja koulutuksen toimiala':
+      $value = 'Education Division';
+      break;
+    case 'Kaupunkiympäristön toimiala':
+      $value = 'Urban Environment Division';
+      break;
+    case 'Keskushallinto':
+      $value = 'Central Administration';
+      break;
+    case 'Kulttuurin ja vapaa-ajan toimiala':
+      $value = 'Culture and Leisure Division';
+      break;
+    case 'Sosiaali- ja terveystoimiala':
+      $value = 'Social Services and Health Care Division';
+      break;
+    default:
+      $value = $sector;
+      break;
+  }
+
+  return $value;
 }
 
 /**

--- a/public/modules/custom/paatokset_ahjo_api/src/Form/DefaultTextSettingsForm.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Form/DefaultTextSettingsForm.php
@@ -44,7 +44,27 @@ class DefaultTextSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('paatokset_ahjo_api.default_texts');
 
-    $form['alerts'] = $form['defaults'] = [
+    $form['links'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Links and URLs'),
+      '#open' => TRUE,
+    ];
+
+    $form['links']['committees_boards_url'] = [
+      '#type' => 'textfield',
+      '#default_value' => $config->get('committees_boards_url'),
+      '#title' => t('Committees and boards URL'),
+      '#description' => t('Used on the decision tree page.'),
+    ];
+
+    $form['links']['office_holders_url'] = [
+      '#type' => 'textfield',
+      '#default_value' => $config->get('office_holders_url'),
+      '#title' => t('Office holders URL'),
+      '#description' => t('Used on the decision tree page.'),
+    ];
+
+    $form['alerts'] = [
       '#type' => 'details',
       '#title' => $this->t('Messages and alerts'),
       '#open' => TRUE,
@@ -132,6 +152,8 @@ class DefaultTextSettingsForm extends ConfigFormBase {
     parent::submitForm($form, $form_state);
 
     $this->config('paatokset_ahjo_api.default_texts')
+      ->set('committees_boards_url', $form_state->getValue('committees_boards_url'))
+      ->set('office_holders_url', $form_state->getValue('office_holders_url'))
       ->set('hidden_decisions_text.value', $form_state->getValue('hidden_decisions_text')['value'])
       ->set('hidden_decisions_text.format', $form_state->getValue('hidden_decisions_text')['format'])
       ->set('documents_description.value', $form_state->getValue('documents_description')['value'])

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
@@ -57,11 +57,11 @@ class TrusteeService {
     if ($title = $trustee->get('field_trustee_title')->value) {
 
       if ($title === 'Jäsen') {
-        return t('Valtuutettu');
+        return t('Councillor');
       }
 
       if ($title === 'Varajäsen') {
-        return t('Varavaltuutettu');
+        return t('Deputy councillor');
       }
 
       return $title;

--- a/public/modules/custom/paatokset_ahjo_api/templates/block/block--policymaker-listing.html.twig
+++ b/public/modules/custom/paatokset_ahjo_api/templates/block/block--policymaker-listing.html.twig
@@ -41,7 +41,7 @@
       <div class="accordion-item__content handorgel__content">
         <div class="accordion-item__content__inner handorgel__content__inner">
           {% for row_key, row in values %}
-            {% if key == 'Lautakunnat ja johtokunnat'%}
+            {% if key == 'Committees and Boards'%}
               {% if row_key %}
                 <h4 class="sector-title">{{ row_key|t }}</h4>
               {% endif %}

--- a/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
+++ b/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
@@ -233,7 +233,7 @@ function helfi_paatokset_preprocess_node__trustee(&$variables) {
     usort($content_initiatives, 'datecmp');
 
     $variables['initiatives'] = [
-      'title' => t('Valtuutetun tekemät aloitteet'),
+      'title' => t('Initiatives by the councillor'),
       'content' => $content_initiatives,
     ];
   };
@@ -247,14 +247,14 @@ function helfi_paatokset_preprocess_node__trustee(&$variables) {
     usort($content_resolutions, 'datecmp');
 
     $variables['resolutions'] = [
-      'title' => t('Valtuutetun tekemät ponnet'),
+      'title' => t('Resolutions by the councillor'),
       'content' => $content_resolutions
     ];
   };
 
   if ($speaking_turns = TrusteeService::getSpeakingTurns($node)) {
     $variables['speaking_turns'] = [
-      'title' => t('Valtuutetun puheenvuorot'),
+      'title' => t('Speaking turns by the councillor'),
       'content' => $speaking_turns,
     ];
   }


### PR DESCRIPTION
This PR changes default translation texts from finnish to english.

**To test**
* Checkout branch, run `make drush-cr drush-cim`
* Open the decisionmakers page: https://helsinki-paatokset.docker.so/fi/paattajat
  * All the main headings and accordion titles should be in english now
  * Check that the headings can be translated: https://helsinki-paatokset.docker.so/fi/admin/config/regional/translate
* Open the decision tree page: https://helsinki-paatokset.docker.so/fi/tietoa-paatoksenteosta
  * The texts should be in english
  * The links should be `fi/paattajat` by default and editable in the default texts settings: https://helsinki-paatokset.docker.so/fi/admin/tools/default-texts
  * Try changing the links to something and check that the changes appear on the page
  * The texts should be translatable through UI translation: https://helsinki-paatokset.docker.so/fi/admin/config/regional/translate