### PR TITLE
PP-379: Handle motions to decisions updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2184,16 +2184,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "9.3.15",
+            "version": "9.3.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "c29310a4d08d5072d7f713da744c0831636b4779"
+                "reference": "eef5b91fa6689410325d569a0653878b2b1782ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/c29310a4d08d5072d7f713da744c0831636b4779",
-                "reference": "c29310a4d08d5072d7f713da744c0831636b4779",
+                "url": "https://api.github.com/repos/drupal/core/zipball/eef5b91fa6689410325d569a0653878b2b1782ed",
+                "reference": "eef5b91fa6689410325d569a0653878b2b1782ed",
                 "shasum": ""
             },
             "require": {
@@ -2215,7 +2215,7 @@
                 "ext-spl": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "guzzlehttp/guzzle": "^6.5.6",
+                "guzzlehttp/guzzle": "^6.5.7",
                 "laminas/laminas-diactoros": "^2.1",
                 "laminas/laminas-feed": "^2.12",
                 "masterminds/html5": "^2.1",
@@ -2435,13 +2435,13 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/9.3.15"
+                "source": "https://github.com/drupal/core/tree/9.3.16"
             },
-            "time": "2022-06-01T15:45:43+00:00"
+            "time": "2022-06-10T19:08:28+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "9.3.15",
+            "version": "9.3.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
@@ -2485,22 +2485,22 @@
                 "drupal"
             ],
             "support": {
-                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.3.15"
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.3.16"
             },
             "time": "2022-02-24T17:40:56+00:00"
         },
         {
             "name": "drupal/core-recommended",
-            "version": "9.3.15",
+            "version": "9.3.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-recommended.git",
-                "reference": "36b1d9dbe4f946b3c19fb91831aa1994e1e38782"
+                "reference": "11ea8b32924c646b29d7d767e655ffedd2982092"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/36b1d9dbe4f946b3c19fb91831aa1994e1e38782",
-                "reference": "36b1d9dbe4f946b3c19fb91831aa1994e1e38782",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/11ea8b32924c646b29d7d767e655ffedd2982092",
+                "reference": "11ea8b32924c646b29d7d767e655ffedd2982092",
                 "shasum": ""
             },
             "require": {
@@ -2509,9 +2509,9 @@
                 "doctrine/annotations": "1.13.2",
                 "doctrine/lexer": "1.2.1",
                 "doctrine/reflection": "1.2.2",
-                "drupal/core": "9.3.15",
+                "drupal/core": "9.3.16",
                 "egulias/email-validator": "3.1.2",
-                "guzzlehttp/guzzle": "6.5.6",
+                "guzzlehttp/guzzle": "6.5.7",
                 "guzzlehttp/promises": "1.5.1",
                 "guzzlehttp/psr7": "1.8.5",
                 "laminas/laminas-diactoros": "2.8.0",
@@ -2571,9 +2571,9 @@
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-recommended/tree/9.3.15"
+                "source": "https://github.com/drupal/core-recommended/tree/9.3.16"
             },
-            "time": "2022-06-01T15:45:43+00:00"
+            "time": "2022-06-10T19:08:28+00:00"
         },
         {
             "name": "drupal/crop",
@@ -7217,16 +7217,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.6",
+            "version": "6.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "f092dd734083473658de3ee4bef093ed77d2689c"
+                "reference": "724562fa861e21a4071c652c8a159934e4f05592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f092dd734083473658de3ee4bef093ed77d2689c",
-                "reference": "f092dd734083473658de3ee4bef093ed77d2689c",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/724562fa861e21a4071c652c8a159934e4f05592",
+                "reference": "724562fa861e21a4071c652c8a159934e4f05592",
                 "shasum": ""
             },
             "require": {
@@ -7312,7 +7312,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5.6"
+                "source": "https://github.com/guzzle/guzzle/tree/6.5.7"
             },
             "funding": [
                 {
@@ -7328,7 +7328,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-25T13:19:12+00:00"
+            "time": "2022-06-09T21:36:50+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -9596,6 +9596,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "symfony/error-handler",
             "time": "2021-09-24T13:30:14+00:00"
         },
         {
@@ -12485,16 +12486,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.2.13",
+            "version": "2.2.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "de11c9819ac45659fb0fafb2e704912f9994ed60"
+                "reference": "8c7a2d200bb0e66d6fafeff2f9c9a27188e52842"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/de11c9819ac45659fb0fafb2e704912f9994ed60",
-                "reference": "de11c9819ac45659fb0fafb2e704912f9994ed60",
+                "url": "https://api.github.com/repos/composer/composer/zipball/8c7a2d200bb0e66d6fafeff2f9c9a27188e52842",
+                "reference": "8c7a2d200bb0e66d6fafeff2f9c9a27188e52842",
                 "shasum": ""
             },
             "require": {
@@ -12564,7 +12565,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.2.13"
+                "source": "https://github.com/composer/composer/tree/2.2.14"
             },
             "funding": [
                 {
@@ -12580,7 +12581,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-25T19:37:25+00:00"
+            "time": "2022-06-06T14:32:50+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -13060,7 +13061,7 @@
         },
         {
             "name": "drupal/core-dev",
-            "version": "9.3.15",
+            "version": "9.3.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-dev.git",
@@ -13104,7 +13105,7 @@
             ],
             "description": "require-dev dependencies from drupal/drupal; use in addition to drupal/core-recommended to run tests from drupal/core.",
             "support": {
-                "source": "https://github.com/drupal/core-dev/tree/9.3.15"
+                "source": "https://github.com/drupal/core-dev/tree/9.3.16"
             },
             "time": "2021-11-30T05:41:29+00:00"
         },
@@ -13880,16 +13881,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.5.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "981cc368a216c988e862a75e526b6076987d1b50"
+                "reference": "76150ae7512439b4e6903db834e4a327596b617d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/981cc368a216c988e862a75e526b6076987d1b50",
-                "reference": "981cc368a216c988e862a75e526b6076987d1b50",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/76150ae7512439b4e6903db834e4a327596b617d",
+                "reference": "76150ae7512439b4e6903db834e4a327596b617d",
                 "shasum": ""
             },
             "require": {
@@ -13899,6 +13900,7 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
@@ -13918,9 +13920,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.5.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.2"
             },
-            "time": "2022-05-05T11:32:40+00:00"
+            "time": "2022-06-10T09:29:33+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/conf/cmi/core.entity_form_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_form_display.node.decision.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - field.field.node.decision.field_meeting_id
     - field.field.node.decision.field_meeting_sequence_number
     - field.field.node.decision.field_organization_type
+    - field.field.node.decision.field_outdated_document
     - field.field.node.decision.field_policymaker_id
     - field.field.node.decision.field_top_category_name
     - field.field.node.decision.field_unique_id
@@ -68,7 +69,7 @@ third_party_settings:
       label: 'Decision data'
       region: content
       parent_name: ''
-      weight: 5
+      weight: 7
       format_type: details
       format_settings:
         classes: ''
@@ -87,7 +88,7 @@ third_party_settings:
       label: 'Organization data'
       region: content
       parent_name: ''
-      weight: 6
+      weight: 8
       format_type: details
       format_settings:
         classes: ''
@@ -105,7 +106,7 @@ third_party_settings:
       label: 'Meeting data'
       region: content
       parent_name: ''
-      weight: 7
+      weight: 9
       format_type: details
       format_settings:
         classes: ''
@@ -121,7 +122,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -221,7 +222,7 @@ content:
     third_party_settings: {  }
   field_decision_previous:
     type: json_textarea
-    weight: 8
+    weight: 10
     region: content
     settings:
       rows: 5
@@ -292,7 +293,7 @@ content:
     third_party_settings: {  }
   field_is_decision:
     type: boolean_checkbox
-    weight: 4
+    weight: 5
     region: content
     settings:
       display_label: true
@@ -325,6 +326,13 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_outdated_document:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_policymaker_id:
     type: string_textfield
@@ -370,39 +378,39 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 12
+    weight: 14
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 11
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 18
+    weight: 20
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 13
+    weight: 15
     region: content
     settings:
       display_label: true
@@ -417,7 +425,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 11
     region: content
     settings:
       match_operator: CONTAINS
@@ -427,12 +435,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 16
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 17
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_form_display.node.meeting.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.meeting.field_agenda_items_processed
+    - field.field.node.meeting.field_decisions_checked
     - field.field.node.meeting.field_meeting_agenda
     - field.field.node.meeting.field_meeting_agenda_files
     - field.field.node.meeting.field_meeting_agenda_published
@@ -70,6 +71,7 @@ third_party_settings:
         - field_meeting_agenda_published
         - field_agenda_items_processed
         - field_meeting_minutes_published
+        - field_decisions_checked
         - field_meeting_attachment_info
       label: 'Basic information'
       region: content
@@ -194,6 +196,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_decisions_checked:
+    type: boolean_checkbox
+    weight: 40
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_meeting_agenda:
     type: json_editor
     weight: 36
@@ -215,7 +224,7 @@ content:
     third_party_settings: {  }
   field_meeting_attachment_info:
     type: text_textarea
-    weight: 40
+    weight: 41
     region: content
     settings:
       rows: 5

--- a/conf/cmi/core.entity_view_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.default.yml
@@ -30,6 +30,7 @@ dependencies:
     - field.field.node.decision.field_meeting_id
     - field.field.node.decision.field_meeting_sequence_number
     - field.field.node.decision.field_organization_type
+    - field.field.node.decision.field_outdated_document
     - field.field.node.decision.field_policymaker_id
     - field.field.node.decision.field_top_category_name
     - field.field.node.decision.field_unique_id
@@ -259,6 +260,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 19
+    region: content
+  field_outdated_document:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 31
     region: content
   field_policymaker_id:
     type: string

--- a/conf/cmi/core.entity_view_display.node.decision.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.teaser.yml
@@ -31,6 +31,7 @@ dependencies:
     - field.field.node.decision.field_meeting_id
     - field.field.node.decision.field_meeting_sequence_number
     - field.field.node.decision.field_organization_type
+    - field.field.node.decision.field_outdated_document
     - field.field.node.decision.field_policymaker_id
     - field.field.node.decision.field_top_category_name
     - field.field.node.decision.field_unique_id
@@ -76,6 +77,7 @@ hidden:
   field_meeting_id: true
   field_meeting_sequence_number: true
   field_organization_type: true
+  field_outdated_document: true
   field_policymaker_id: true
   field_top_category_name: true
   field_unique_id: true

--- a/conf/cmi/core.entity_view_display.node.meeting.default.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.meeting.field_agenda_items_processed
+    - field.field.node.meeting.field_decisions_checked
     - field.field.node.meeting.field_meeting_agenda
     - field.field.node.meeting.field_meeting_agenda_files
     - field.field.node.meeting.field_meeting_agenda_published
@@ -45,6 +46,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 22
+    region: content
+  field_decisions_checked:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 24
     region: content
   field_meeting_agenda:
     type: json

--- a/conf/cmi/core.entity_view_display.node.meeting.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.meeting.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.meeting.field_agenda_items_processed
+    - field.field.node.meeting.field_decisions_checked
     - field.field.node.meeting.field_meeting_agenda
     - field.field.node.meeting.field_meeting_agenda_files
     - field.field.node.meeting.field_meeting_agenda_published
@@ -41,6 +42,7 @@ content:
     region: content
 hidden:
   field_agenda_items_processed: true
+  field_decisions_checked: true
   field_meeting_agenda: true
   field_meeting_agenda_files: true
   field_meeting_agenda_published: true

--- a/conf/cmi/field.field.node.decision.field_outdated_document.yml
+++ b/conf/cmi/field.field.node.decision.field_outdated_document.yml
@@ -1,0 +1,23 @@
+uuid: fb133b57-1df0-4623-8fa0-62a620640c76
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_outdated_document
+    - node.type.decision
+id: node.decision.field_outdated_document
+field_name: field_outdated_document
+entity_type: node
+bundle: decision
+label: 'Outdated document'
+description: 'PDF document is outdated and needs to be updated from Ahjo API.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.field.node.meeting.field_decisions_checked.yml
+++ b/conf/cmi/field.field.node.meeting.field_decisions_checked.yml
@@ -1,0 +1,23 @@
+uuid: ca38f60b-bd2f-4eda-bbfd-6e507a0ecac5
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_decisions_checked
+    - node.type.meeting
+id: node.meeting.field_decisions_checked
+field_name: field_decisions_checked
+entity_type: node
+bundle: meeting
+label: 'Decisions checked'
+description: 'Check if all valid decisions are found for meeting.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.storage.node.field_decisions_checked.yml
+++ b/conf/cmi/field.storage.node.field_decisions_checked.yml
@@ -1,0 +1,18 @@
+uuid: 6ef7aacf-0d90-4eca-9081-4248ac3c7e99
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_decisions_checked
+field_name: field_decisions_checked
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_outdated_document.yml
+++ b/conf/cmi/field.storage.node.field_outdated_document.yml
@@ -1,0 +1,18 @@
+uuid: d92960ff-5c9a-40ec-b57f-e0d2adb284d3
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_outdated_document
+field_name: field_outdated_document
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docker/openshift/crons/run-immediate-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-immediate-ahjo-integrations.sh
@@ -8,6 +8,8 @@ do
   drush ahjo-proxy:get-motions
   echo "Updating decision and motion data: $(date)"
   drush ahjo-proxy:update-decisions
+  drush ahjo-proxy:update-decisions --logic=uniqueid --limit=100
+  drush ahjo-proxy:update-decisions --logic=outdated --limit=100
   # Sleep for 5 minutes.
   sleep 300
 done

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -867,7 +867,7 @@ class AhjoProxy implements ContainerInjectionInterface {
   protected function updateDecisionRecordData(NodeInterface &$node, array $record_content): void {
     $node->set('field_decision_record', json_encode($record_content));
 
-    // If this is a decision (not a motion), set outdated flag to false
+    // If this is a decision (not a motion), set outdated flag to false.
     if ($node->get('field_is_decision')->value) {
       $node->set('field_outdated_document', 0);
     }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -867,6 +867,11 @@ class AhjoProxy implements ContainerInjectionInterface {
   protected function updateDecisionRecordData(NodeInterface &$node, array $record_content): void {
     $node->set('field_decision_record', json_encode($record_content));
 
+    // If this is a decision (not a motion), set outdated flag to false
+    if ($node->get('field_is_decision')->value) {
+      $node->set('field_outdated_document', 0);
+    }
+
     if (isset($record_content['Issued'])) {
       $date = new \DateTime($record_content['Issued'], new \DateTimeZone('Europe/Helsinki'));
       $date->setTimezone(new \DateTimeZone('UTC'));
@@ -1335,6 +1340,7 @@ class AhjoProxy implements ContainerInjectionInterface {
 
     $node->set('field_full_title', $title);
     $node->set('field_is_decision', 0);
+    $node->set('field_outdated_document', 1);
     $node->set('field_top_category_name', $top_category);
     $node->set('field_classification_code', $classification_code);
     $node->set('field_decision_native_id', $native_id);

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -591,6 +591,10 @@ class AhjoAggregatorCommands extends DrushCommands {
       if ($logic === 'record') {
         $query->notExists('field_decision_record');
       }
+      if ($logic === 'outdated') {
+        $query->condition('field_is_decision', 1);
+        $query->condition('field_outdated_document', 1);
+      }
       elseif ($logic === 'case') {
         $query->notExists('field_decision_case_title');
         $query->condition('field_diary_number', '', '<>');


### PR DESCRIPTION
This PR makes the motions -> decision update path better. Previously some decision records weren't updated because there was data remaining from the motion phase.

This PR also adds checks to make sure all motions and decisions are created for meetings.

**Test decision record fetching**
- Run `make new` to make testing easier (take a database backup of your previous state if you wish to return to it)
- Import some organizations and decisions to test with:
  - `drush ap:update organization U540200 -v`
  - `drush ap:update organization U02978 -v`
  - `drush ap:update meetings U540200202211 -v` (This should be a meeting with only agenda published, not minutes). Replace the ID with another meeting if this has been updated).
  - `drush ap:update meetings U0297820227 -v`
- Edit both meetings and set the "minutes published" setting to false
- Create motions for both meetings: `drush ap:gm -v`
- Run `drush ap:ud --logic=uniqueid -v` to fill in missing date for the motions
- Check one of the decisions, they should have the "Outdated document" field set to true
- Try running `drush ap:ud --logic=outdated -v`
  - This should not update anything because it only acts on decisions, not motions
- Edit this meeting and set the minutes published to true: https://helsinki-paatokset.docker.so/fi/kokoukset/u0297820227
- Run `drush ap:om -v` to check for orphaned motions. This should now list all the motions for the u0297820227 meeting
- Set decisions for the u0297820227 meeting into the callback queue: `drush ap:imd U0297820227 -v`
- Run `drush queue:run ahjo_api_subscriber_queue` to process the que
  - You might get some errors about cases, this should be fine
- Check the orphans again: `drush ap:om -v`
  - This time the list should be empty
- Try running: `drush ap:ud -v`
  - This should not update anything, because the decisions still have the motion records
- Run `drush ap:ud --logic=outdated -v`
  - This should update the new decisions. Try running the command again. It should return with 0 results this time
- Check one of the created decisions, it should have the "Oudated document" field set to false

**Test motion and decision checking**
- Delete one of the motions nodes for the meeting `U540200202211`
  - You can confirm this by opening the meeting agenda / minutes page. The link should be missing for the agenda item whose node you just deleted 
- Run `drush ahjo-proxy:check-motion-processing -v`
- The meeting `U540200202211` should now have the "Agenda items processed" set as false
- Run `drush ap:gm -v`
- This should recreate the motion you just deleted and skip the rest
- Run `drush ahjo-proxy:check-motion-processing -v` again. It shouldn't complain about missing motions any more.
- Delete one or more decisions for the meeting `U0297820227`
- Run `drush ahjo-proxy:check-decision-processing -v`
- It should complain about missing decisions
- Add the meeting's decisions to the queue by running: `drush ahjo-proxy:check-decision-processing --queue -v`
- Execute the queue with: `drush queue:run ahjo_api_subscriber_queue`
- Run the command again: `drush ahjo-proxy:check-decision-processing -v`
- This time there should be no missing decisions and the meeting's "Decisions checked" field should be set to true
- Confirm this by running the command yet again: `drush ahjo-proxy:check-decision-processing -v`
  - Should return 0 nodes this time. 