### PR TITLE
PP-378: English language decisionmaker URLs

### DIFF
--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -321,6 +321,11 @@ function paatokset_policymakers_pathauto_pattern_alter(&$pattern, array $context
   /** @var \Drupal\node\NodeInterface $node */
   $node = $context['data']['node'];
 
+  // No overrides for english language nodes.
+  if ($node->get('langcode')->value === 'en') {
+    return;
+  }
+
   // Only act on policymaker nodes and make sure fields exist.
   if (!$node->bundle() === 'policymaker' || !$node->hasField('field_ahjo_title') || !$node->hasField('field_dm_org_name') || !$node->hasField('field_organization_type')) {
     return;

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerLazyBuilder.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerLazyBuilder.php
@@ -92,10 +92,12 @@ class PolicymakerLazyBuilder implements TrustedCallbackInterface {
 
       $cache_tags[] = 'node:' . $node->id();
 
-      $title = $node->get('field_ahjo_title')->value;
+      $title = $node->get('title')->value;
+      $ahjo_title = $node->get('field_ahjo_title')->value;
 
       $cards[] = [
         'title' => $title,
+        'ahjo_title' => $ahjo_title,
         'link' => $this->policymakerService->getPolicymakerRoute($node, $this->currentLanguage),
         'image' => $node->get('field_policymaker_image')->view('default'),
         'organization_color' => $this->policymakerService->getPolicymakerClassById($node->get('field_policymaker_id')->value),
@@ -329,7 +331,8 @@ class PolicymakerLazyBuilder implements TrustedCallbackInterface {
       }
 
       $filtered[] = [
-        'title' => $node->get('field_ahjo_title')->value,
+        'title' => $node->get('title')->value,
+        'ahjo_title' => $node->get('field_ahjo_title')->value,
         'link' => $this->policymakerService->getPolicymakerRoute($node, $this->currentLanguage),
         'organization_type' => $node->get('field_organization_type')->value,
         'organization_name' => $node->get('field_dm_org_name')->value,

--- a/public/modules/custom/paatokset_policymakers/templates/component/policymaker-cards.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/component/policymaker-cards.html.twig
@@ -1,12 +1,12 @@
 <div class="policymaker-card__container">
   {% for card in cards %}
     <a class="policymaker-card" href="{{ card.link }}">
-      <div class="policymaker-card__color-title {{ card.organization_color }}">{{ card.title|t }}</div>
+      <div class="policymaker-card__color-title {{ card.organization_color }}">{{ card.ahjo_title|t }}</div>
       <div class="policymaker-card__image">
         {{ card.image }}
       </div>
       <div class="policymaker-card__title-icon">
-        <h4>{{ card.title|t }}</h4>
+        <h4>{{ card.title }}</h4>
         <i class="hel-icon hel-icon--arrow-right"></i>
       </div>
     </a>

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
@@ -147,7 +147,7 @@ class PolicymakerSideNav extends BlockBase {
     $routeProvider = \Drupal::service('router.route_provider');
 
     $items[] = [
-      'title' => $policymaker->get('field_ahjo_title')->value,
+      'title' => $policymaker->get('title')->value,
       'url' => $this->policymakerService->getLocalizedUrl(),
       'attributes' => new Attribute(),
     ];

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
@@ -142,9 +142,8 @@ class PolicymakerSideNav extends BlockBase {
    */
   protected function getDynamicLinks(NodeInterface $policymaker): array {
     $items = [];
-    $policymaker_url = $policymaker->toUrl()->toString();
-    $policymaker_url_bits = explode('/', $policymaker_url);
-    $policymaker_org = array_pop($policymaker_url_bits);
+    $policymaker_org = $this->policymakerService->getPolicymakerOrganizationFromUrl($policymaker, $this->currentLang);
+
     $routeProvider = \Drupal::service('router.route_provider');
 
     $items[] = [


### PR DESCRIPTION
This adds better support for localizing organization titles and URLs, and removes finnish words from untranslated URLs.

**To test**
- Checkout branch, run `make drush-cr drush-cim`
- Run `make ahjo-migrations` if you don't have ahjo data
- Read through the code changes

**Fully translated organization**
- Run `drush ap:update organization 02900 -v;drush ap:update organization_sv 02900 -v`
- Make sure you have added this organization to the menu under "Päättäjät"
- Create some test pages and add them menu links under the organization
- Create some test pages and add them as custom links under this organization
- Create an english translation of the page manually (delete the previous one if it was already translated)
  - Change the title to "Helsinki City Council": https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
  - Make sure the menu link is translated also
- Check that the side navigation links work on all language versions
- Check that switching to different language versions work (also on custom routes and pages added as menu and custom links)
  - The URL for the english version should not change depending on which page you are on
- Change the english URL alias of the organization to something else (for example /decision/helsinki-city-council)
  - This new URL should appear on all the other pages too and it should not revert to the default one
- Check the päättäjät page (all language versions) https://helsinki-paatokset.docker.so/fi/paattajat/
  - The translated titles should appear in the card display, except for the subheading, which should still be the Ahjo title 

**Organization with only FI + SV translations**
- Run `drush ap:update organization 00400 -v;drush ap:update organization_sv 00400 -v`
- Make sure you have added this organization to the menu under "Päättäjät"
- Create some test pages and add them menu links under the organization
- Create some test pages and add them as custom links under this organization
- Navigate across side navigation, document and language switcher links (especially english), and make sure everything works correctly

**Only FI translation**
- Run `drush ap:update organization U420 -v`
- Delete the swedish and english translations if they exist: https://helsinki-paatokset.docker.so/fi/paattajat/kasvatus-ja-koulutuslautakunta
- Create some test pages and add them as custom links under this organization
- Navigate across side navigation, document and language switcher links (this time especially swedish and make sure everything works correctly 