### PR TITLE
PP-268: Get councillor memberships and roles

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
@@ -106,8 +106,8 @@ class TrusteeService {
    */
   public static function getMemberships(NodeInterface $node): array {
     $chairmanships = [];
-    if($node->hasField('field_trustee_chairmanships') && !$node->get('field_trustee_chairmanships')->isEmpty()) {
-      foreach($node->get('field_trustee_chairmanships') as $json) {
+    if ($node->hasField('field_trustee_chairmanships') && !$node->get('field_trustee_chairmanships')->isEmpty()) {
+      foreach ($node->get('field_trustee_chairmanships') as $json) {
         $data = json_decode($json->value, TRUE);
         $chairmanships[] = $data['Position'] . ', ' . $data['OrganizationName'];
       };

--- a/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
+++ b/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
@@ -259,6 +259,13 @@ function helfi_paatokset_preprocess_node__trustee(&$variables) {
     ];
   }
 
+  if ($memberships = TrusteeService::getMemberships($node)) {
+    $variables['memberships'] = [
+      'title' => t('Memberships and roles'),
+      'content' => $memberships,
+    ];
+  }
+
   $trustee_title = TrusteeService::getTrusteeTitle($node);
   if ($trustee_title) {
     $variables['content']['field_trustee_title'] = $trustee_title;

--- a/public/themes/custom/helfi_paatokset/templates/content/node--trustee.html.twig
+++ b/public/themes/custom/helfi_paatokset/templates/content/node--trustee.html.twig
@@ -220,4 +220,30 @@
     </div>
   </div>
   {% endif %}
+
+  {% if memberships.content is not empty %}
+  <div class="accordion__wrapper handorgel accordion_speaking-turn">
+    <h2 class="accordion-item__header handorgel__header">
+      <button class="accordion-item__button accordion-item__button--toggle handorgel__header__button">
+        <span>{{ memberships.title }}</span>
+        <div class="accordion-item__icon">
+          {% include '@hdbt/misc/icon.twig' with {icon: 'angle-down'} %}
+        </div>
+      </button>
+    </h2>
+    <div class="accordion-item__content handorgel__content">
+      <div class="accordion-item__content__inner handorgel__content__inner">
+        {% for row in memberships.content %}
+        <div>
+          {{ row }}
+        </div>
+        {% endfor %}
+        <span class="accordion-item__button accordion-item__button--close" role="button" tabindex="0">
+          {{ 'Close'|t }}
+          {% include '@hdbt/misc/icon.twig' with {icon: 'angle-up'} %}
+        </span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
 </article>


### PR DESCRIPTION
**To test**
- Checkout branch, run `make drush-cr`
- Make sure you have councillors and meetings from the Ahjo API: `make ahjo-migrations`
- Check out some councillors: https://helsinki-paatokset.docker.so/fi/admin/content/trustees
  - Compare the printed data to what's in the node and what's in the organization meeting compositions
- Read the code changes
  - Is this a reasonable way to fetch and iterate this data from the database?
  - Can you think of a more efficient way to get this data? Could this cause issues in the production environment?  