### PR TITLE
PP-380: Throw 404 error if proxy returns an error.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1488,19 +1488,19 @@ class AhjoProxy implements ContainerInjectionInterface {
    * @param \Drupal\node\NodeInterface $node
    *   Meeting to check agenda for.
    *
-   * @return bool
-   *   Returns TRUE if all valid agenda items have decisions.
+   * @return array
+   *   List of missing decisions.
    */
-  public function checkMeetingDecisions(NodeInterface $node): bool {
+  public function checkMeetingDecisions(NodeInterface $node): array {
     if (!$node->hasField('field_meeting_agenda') || $node->get('field_meeting_agenda')->isEmpty()) {
-      return TRUE;
+      return [];
     }
 
     $meeting_id = $node->get('field_meeting_id')->value;
 
     /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
     $caseService = \Drupal::service('paatokset_ahjo_cases');
-    $missing = FALSE;
+    $missing = [];
     foreach ($node->get('field_meeting_agenda') as $field) {
       $item = json_decode($field->value, TRUE);
 
@@ -1521,12 +1521,11 @@ class AhjoProxy implements ContainerInjectionInterface {
       }
 
       if (!$url instanceof Url) {
-        $missing = TRUE;
-        break;
+        $missing[] = $item['PDF']['NativeId'];
       }
     }
 
-    return !$missing;
+    return $missing;
   }
 
   /**

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Controller/AhjoProxyController.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Controller/AhjoProxyController.php
@@ -54,6 +54,9 @@ class AhjoProxyController extends ControllerBase {
   public function meetings(Request $request): JsonResponse {
     $query_string = $request->getQueryString();
     $data = $this->ahjoProxy->getMeetings($query_string);
+    if (empty($data)) {
+      throw new NotFoundHttpException();
+    }
     return new JsonResponse($data);
   }
 
@@ -69,6 +72,9 @@ class AhjoProxyController extends ControllerBase {
   public function cases(Request $request): JsonResponse {
     $query_string = $request->getQueryString();
     $data = $this->ahjoProxy->getCases($query_string);
+    if (empty($data)) {
+      throw new NotFoundHttpException();
+    }
     return new JsonResponse($data);
   }
 
@@ -84,6 +90,9 @@ class AhjoProxyController extends ControllerBase {
   public function decisions(Request $request): JsonResponse {
     $query_string = $request->getQueryString();
     $data = $this->ahjoProxy->getDecisions($query_string);
+    if (empty($data)) {
+      throw new NotFoundHttpException();
+    }
     return new JsonResponse($data);
   }
 


### PR DESCRIPTION
This MR adds minor script improvements and 404 errors for API monitoring purposes.

**To test**
- Before checking out the branch, go to:
  - https://helsinki-paatokset.docker.so/fi/ahjo-proxy/meetings
  - https://helsinki-paatokset.docker.so/fi/ahjo-proxy/cases
  - https://helsinki-paatokset.docker.so/fi/ahjo-proxy/decisions
-  These should return empty JSON results with a 200 OK status code (at least if you have VPN off).
- Checkout branch, run `make drush-cr`
- Reload the ahjo-proxy URLs. These should now return 404 errors.
- If you can get the local API connection to work, connect to VPN and authenticate with the API: https://helsinki-paatokset.docker.so/fi/admin/ahjo-open-id
- Reload the pages again. You should get a proper response this time. (If you don't get the connection working we can just test this on develop and test environments).