### PR TITLE
PP-352: Decision migration changes

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
@@ -32,6 +32,10 @@ source:
       label: Native ID
       selector: NativeId
     -
+      name: language
+      label: Language
+      selector: PDF/Language
+    -
       name: case_id
       label: Case ID
       selector: CaseID
@@ -108,6 +112,7 @@ process:
     default_value: decision
   langcode:
     plugin: default_value
+    source: language
     default_value: fi
   field_decision_native_id: native_id
   nid:
@@ -118,6 +123,7 @@ process:
       - case_id
       - meeting_id
       - title
+      - language
   title:
     callable: _paatokset_ahjo_api_truncate_value
     plugin: callback

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -532,6 +532,13 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
     $title = NULL;
   }
 
+  if (!empty($values[4])) {
+    $language = $values[4];
+  }
+  else {
+    $language = NULL;
+  }
+
   $query = Drupal::entityQuery('node')
     ->condition('type', 'decision')
     ->condition('field_decision_native_id', $native_id)
@@ -558,7 +565,10 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
     ->condition('status', 1)
     ->range(0, 1)
     ->latestRevision();
-  $ids = $query->execute();
+
+  if ($language) {
+    $query->condition('langcode', $language);
+  }
 
   if ($case_id) {
     $query->condition('field_diary_number', $case_id);
@@ -566,6 +576,8 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
   else {
     $query->condition('field_full_title', $title);
   }
+
+  $ids = $query->execute();
 
   if (!empty($ids)) {
     return reset($ids);

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -521,6 +521,8 @@ class CaseService {
       return $decision->toUrl();
     }
 
+    $decision = $this->getDecisionTranslation($decision, $langcode);
+
     // Special fallback for decisions without diary numbers.
     if (!$decision->hasField('field_diary_number') || $decision->get('field_diary_number')->isEmpty()) {
       $localizedRoute = 'paatokset_case.' . $langcode;
@@ -531,8 +533,6 @@ class CaseService {
       }
       return NULL;
     }
-
-    $decision = $this->getDecisionTranslation($decision, $langcode);
 
     $decision_id = $decision->get('field_decision_native_id')->value;
     $decision_id = $this->normalizeNativeId($decision_id);

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1021,6 +1021,9 @@ class AhjoProxy implements ContainerInjectionInterface {
     if (isset($record_content['MeetingID'])) {
       $unique_id .= $record_content['MeetingID'] . '-';
     }
+    else if (!$node->get('field_meeting_id')->isEmpty()) {
+      $unique_id .= $node->get('field_meeting_id')->value . '-';
+    }
     else {
       $unique_id .= '0-';
     }
@@ -1486,7 +1489,12 @@ class AhjoProxy implements ContainerInjectionInterface {
     /** @var \Drupal\paatokset_ahjo_api\Service\CaseService */
     $case_service = \Drupal::service('paatokset_ahjo_cases');
 
-    $ids = $ahjo_proxy->getCaseDataFromHtml($data['html']);
+    if (!empty($data['html'])) {
+      $ids = $ahjo_proxy->getCaseDataFromHtml($data['html']);
+    }
+    else {
+      $ids = [];
+    }
 
     // Handle cases where ids are blank.
     if (empty($ids) || !isset($ids['case_id'])) {
@@ -1564,6 +1572,7 @@ class AhjoProxy implements ContainerInjectionInterface {
     // If record content can't or won't be fetched, use PDF from agenda item.
     elseif (!empty($data['pdf'])) {
       $node->set('field_decision_record', json_encode($data['pdf']));
+      $record_content = $data['pdf'];
     }
     // If neither can't be used, mark this item as failed.
     else {
@@ -1596,6 +1605,10 @@ class AhjoProxy implements ContainerInjectionInterface {
       'value' => $motion,
       'format' => 'plain_text',
     ]);
+
+    if (!empty($record_content)) {
+      $ahjo_proxy->updateDecisionRecordData($node, $record_content);
+    }
 
     if ($node->save()) {
       $context['results']['items'][] = $data['title'];

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1021,7 +1021,7 @@ class AhjoProxy implements ContainerInjectionInterface {
     if (isset($record_content['MeetingID'])) {
       $unique_id .= $record_content['MeetingID'] . '-';
     }
-    else if (!$node->get('field_meeting_id')->isEmpty()) {
+    elseif (!$node->get('field_meeting_id')->isEmpty()) {
       $unique_id .= $node->get('field_meeting_id')->value . '-';
     }
     else {

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -1741,8 +1741,13 @@ class AhjoAggregatorCommands extends DrushCommands {
       foreach ($node->get('field_meeting_agenda') as $field) {
         $item = json_decode($field->value, TRUE);
 
+        // Do nothing if PDF record isn't available.
+        if (!isset($item['PDF'])) {
+          continue;
+        }
+
         // Only create finnish or swedish language motions.
-        if (!isset($item['PDF']) || !in_array($item['PDF']['Language'], ['fi', 'sv'])) {
+        if (!in_array($item['PDF']['Language'], ['fi', 'sv'])) {
           continue;
         }
 

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -1741,8 +1741,8 @@ class AhjoAggregatorCommands extends DrushCommands {
       foreach ($node->get('field_meeting_agenda') as $field) {
         $item = json_decode($field->value, TRUE);
 
-        // Only create finnish language motions.
-        if (!isset($item['PDF']) || $item['PDF']['Language'] !== 'fi') {
+        // Only create finnish or swedish language motions.
+        if (!isset($item['PDF']) || !in_array($item['PDF']['Language'], ['fi', 'sv'])) {
           continue;
         }
 


### PR DESCRIPTION
This PR enables swedish language motion generation and adds some fixes to the motion -> decision conversion to make it work with multiple languages.

**To test:**
- Create a database dump with your current status and change the filename (so the dump doesn't get overridden) if you want to return to it later
- Checkout branch, run `make new` to start from scratch (we need old meetings for testing and your local might have updated versions of these)
- Login to the test environment and create a new user with the "API User" role and get the user's API Key from the key authentication tab. (You can also get this from Juho if you can't create new users or the role is not visible)
- Do the same in your local environment. Save the API keys in a text file so you have access to both

**Fetch old meetings for testing:**
- Update the `.env.local file` to fetch data locally:
  - `AHJO_PROXY_BASE_URL=http://helsinki-paatokset.docker.so:8080/`
  - `LOCAL_PROXY_API_KEY=[local-api-key]`
- Run `make up`
- Login to the container and run `drush ap:fs -v;drush mim ahjo_meetings:latest --update`
- Check that these meetings are available, have their agenda published but not minutes:
  - https://helsinki-paatokset.docker.so/fi/admin/content/meetings?field_meeting_id_value=U54020020225
  - https://helsinki-paatokset.docker.so/fi/admin/content/meetings?field_meeting_id_value=0290020225

**Fetch updated data:**
- Update the `.env.local` file to fetch data from the test environment:
  - `AHJO_PROXY_BASE_URL=https://nginx-paatokset-test.agw.arodevtest.hel.fi/`
  - `LOCAL_PROXY_API_KEY=[test-api-key]`
- Run `make up` to use the new env variables
- Fetch organisations:
  - `drush ap:update organization U540200 -v`
  - `drush ap:update organization 02900 -v`
- Check that the agenda pages work:
  - https://helsinki-paatokset.docker.so/fi/paattajat/kaupunkiymparistolautakunnan-ymparisto-ja-lupajaosto/asiakirjat/U54020020225
  - https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat/0290020225
  - https://helsinki-paatokset.docker.so/sv/beslutsfattare/02900/dokumenter/0290020225
- Take another database backup with `make drush-create-dump` so you don't need to swap around the env variables in case something goes wrong
- Generate motions for the meetings: `drush ap:gm -v`
  - Reload the pages, make sure all agenda items link to a motion
- In the Kaupunginvaltuusto meeting, open the first and fourth agenda points (both FI and SV versions)
  - Check that the language switching works and that the language data is correct (titles should be OK, but content can be mixed between finnish and swedish due to old API data)
  - Keep the motion pages open in your browser
- Update meetings:
  - `drush ap:update meetings U54020020225 -v `
  - `drush ap:update meetings 0290020225 -v`
  - Reload the meeting pages. They should now have minutes published and no decisions should be linked
- Update the decisions:
  - `drush ap:update decisions {AA2EA1A2-C6B1-4658-8366-8D75965D17FF} -v`
  - `drush ap:update decisions {B59E4877-5DA5-4735-831C-FDC6C65FD8DC} -v`
  - `drush ap:update decisions {53DC961D-E5CD-43F6-825E-25A833DB625D} -v`
  - `drush ap:update decisions {9C41B425-5AB6-4465-924E-D179B92478B9} -v`
- Reload the motion pages, they should redirect to the decisions
  - Check that the language switching works between decisions 
- Reload the Kaupunginvaltuusto meeting page, both languages should now link to correct decisions