### PR TITLE
PP-399: Councilmember info import form CSV file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "drush/drush": "^10.4",
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
+        "league/csv": "^9.8",
         "paatokset/paatokset_search": "1.0.9"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -7994,6 +7994,90 @@
             "time": "2021-07-09T08:23:52+00:00"
         },
         {
+            "name": "league/csv",
+            "version": "9.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^v3.4.0",
+                "phpstan/phpstan": "^1.3.0",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.11"
+            },
+            "suggest": {
+                "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CSV data manipulation made easy in PHP",
+            "homepage": "https://csv.thephpleague.com",
+            "keywords": [
+                "convert",
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "transform",
+                "write"
+            ],
+            "support": {
+                "docs": "https://csv.thephpleague.com",
+                "issues": "https://github.com/thephpleague/csv/issues",
+                "rss": "https://github.com/thephpleague/csv/releases.atom",
+                "source": "https://github.com/thephpleague/csv"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-01-04T00:13:07+00:00"
+        },
+        {
             "name": "league/uri",
             "version": "6.7.2",
             "source": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "191adc9727609fd924666f5b55893f4d",
+    "content-hash": "91fd05fda74df6ad58d962cc37ac864e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7613,7 +7613,8 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/josdejong/jsoneditor/archive/v5.29.1.zip"
+                "url": "https://github.com/josdejong/jsoneditor/archive/v5.29.1.zip",
+                "reference": "v5.29.1"
             },
             "type": "drupal-library"
         },

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -97,6 +97,7 @@ module:
   paatokset_ahjo_api: 0
   paatokset_ahjo_openid: 0
   paatokset_ahjo_proxy: 0
+  paatokset_council_info: 0
   paatokset_helsinki_kanava: 0
   paatokset_lang_switcher: 0
   paatokset_news_importer: 0

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/TrusteeService.php
@@ -38,7 +38,12 @@ class TrusteeService {
    */
   public static function transformTrusteeName(string $title): string {
     $nameParts = explode(',', $title);
-    return trim($nameParts[1] . ' ' . $nameParts[0]);
+    if (isset($nameParts[1])) {
+      return trim($nameParts[1] . ' ' . $nameParts[0]);
+    }
+    else {
+      return $nameParts[0];
+    }
   }
 
   /**

--- a/public/modules/custom/paatokset_council_info/paatokset_council_info.info.yml
+++ b/public/modules/custom/paatokset_council_info/paatokset_council_info.info.yml
@@ -1,0 +1,6 @@
+name: Päätökset Councilmember info importer
+type: module
+description: Imports info for councilmembers from CSV file.
+package: Custom
+core: 8.x
+core_version_requirement: ^8 || ^9

--- a/public/modules/custom/paatokset_council_info/paatokset_council_info.links.menu.yml
+++ b/public/modules/custom/paatokset_council_info/paatokset_council_info.links.menu.yml
@@ -1,0 +1,4 @@
+paatokset_council_info.import:
+  title: 'Council member info import'
+  parent: system.admin_config_system
+  route_name: paatokset_council_info.import

--- a/public/modules/custom/paatokset_council_info/paatokset_council_info.routing.yml
+++ b/public/modules/custom/paatokset_council_info/paatokset_council_info.routing.yml
@@ -1,0 +1,7 @@
+paatokset_council_info.import:
+  path: '/admin/config/system/council-import'
+  defaults:
+    _title: 'Councilmember info import'
+    _form: '\Drupal\paatokset_council_info\Form\InfoImportForm'
+  requirements:
+    _permission: 'administer content'

--- a/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
+++ b/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_council_info\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\file\FileInterface;
+use Drupal\node\Entity\Node;
+use League\Csv\Reader;
+
+/**
+ * Councilmember info import form.
+ */
+class InfoImportForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'council_info_import';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['#attributes'] = ['enctype' => 'multipart/form-data'];
+
+    $form['file'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Info file'),
+      '#open' => TRUE,
+    ];
+    $form['file']['info_file'] = [
+      '#type' => 'managed_file',
+      '#name' => 'info_file',
+      '#title' => $this->t('File upload'),
+      '#description' => $this->t('Councilmember data as a CSV file. Should use ; as delimiter.'),
+      '#upload_validators' => [
+        'file_validate_extensions' => ['csv'],
+      ],
+      '#upload_location' => 'public://council_info/',
+    ];
+
+    $form['file']['existing_info_file'] = [
+      '#type' => 'entity_autocomplete',
+      '#name' => 'existing_info_file',
+      '#target_type' => 'file',
+      '#title' => $this->t('Existing file'),
+      '#description' => $this->t('Use a previously uploaded file.'),
+    ];
+
+    $form['file']['file_storage'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('File storage options'),
+      '#description' => $this->t('Set or change file storage options.'),
+      '#options' => [
+        'permanent' => $this->t('Permanent file'),
+        'temporary' => $this->t('Temporary file'),
+        'do_nothing' => $this->t('No change (store uploaded as temporary)'),
+      ],
+      '#default_value' => 'do_nothing',
+    ];
+
+    $form['submit_button'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Start import'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    if (empty($form_state->getValue('info_file')) && $form_state->getValue('existing_info_file') === NULL) {
+      $form_state->setErrorByName('file', $this->t('File missing.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $file_id = NULL;
+    if (!empty($form_state->getValue('info_file'))) {
+      $file_id = reset($form_state->getValue('info_file'));
+    }
+    elseif (!empty($form_state->getValue('existing_info_file'))) {
+      $file_id = $form_state->getValue('existing_info_file');
+    }
+    else {
+      $this->messenger->addError('File missing.');
+      return;
+    }
+
+    $entity_manager = \Drupal::service('entity_type.manager');
+    $file_storage = $entity_manager->getStorage('file');
+    $messenger = \Drupal::service('messenger');
+    $file = $file_storage->load($file_id);
+
+    if (!$file instanceof FileInterface) {
+      $messenger->addError('File could not be loaded.');
+      return;
+    }
+
+    if ($file->get('filemime')->value !== 'text/csv') {
+      $messenger->addError('File must be a CSV file.');
+      return;
+    }
+
+    $file_setting = $form_state->getValue('file_storage');
+    if ($file_setting === 'permanent') {
+      $file->setPermanent();
+      $file->save();
+      $messenger->addMessage('File is now stored permanently.');
+    }
+    elseif ($file_setting === 'temporary') {
+      $file->setTemporary();
+      $file->save();
+      $messenger->addMessage('File storage set to temporary.');
+    }
+
+    try {
+      $csv_reader = $this->getCsvReader($file);
+    }
+    catch (\Exception $e) {
+      $messenger->addMessage($e->getMessage(), 'error');
+      return;
+    }
+
+    $operations = [];
+    $count = 0;
+    foreach ($csv_reader->getRecords() as $record) {
+      $count++;
+      $record['count'] = $count;
+      $operations[] = [
+        '\Drupal\paatokset_council_info\Form\InfoImportForm::doProcess', [
+          $record,
+        ],
+      ];
+    }
+
+    if (empty($operations)) {
+      $messenger->addWarning('Nothing to import');
+      return;
+    }
+
+    $batch = [
+      'title' => t('Importing council member information.'),
+      'operations' => $operations,
+      'init_message'     => t('Starting batch'),
+      'progress_message' => t('Processed @current out of @total.'),
+      'error_message'    => t('An error occurred during processing'),
+      'finished' => '\Drupal\paatokset_council_info\Form\InfoImportForm::finishedCallback',
+    ];
+
+    batch_set($batch);
+  }
+
+  /**
+   * Get CSV reader for file.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   File to load CSV data from.
+   *
+   * @return \League\Csv\Reader
+   *   CSV reader.
+   */
+  protected function getCsvReader(FileInterface $file): Reader {
+    $contents = file_get_contents($file->getFileUri());
+    $reader = Reader::createFromString($contents);
+    $reader->setDelimiter(';');
+    $reader->setHeaderOffset(0);
+    return $reader;
+  }
+
+  /**
+   * Static callback for processing batch items.
+   *
+   * @param mixed $data
+   *   Data for operation.
+   * @param mixed $context
+   *   Context for batch operation.
+   */
+  public static function doProcess($data, &$context) {
+    $logger = \Drupal::logger('paatokset_council_info');
+    $context['message'] = 'Importing item number ' . $data['count'];
+    if (!isset($context['results']['items'])) {
+      $context['results']['items'] = [];
+    }
+    if (!isset($context['results']['failed'])) {
+      $context['results']['failed'] = [];
+    }
+
+    $query = \Drupal::entityQuery('node')
+      ->condition('status', 1)
+      ->condition('type', 'trustee')
+      ->condition('field_first_name', trim($data['Etunimet']))
+      ->condition('field_last_name', trim($data['Sukunimi']))
+      ->range('0', '1');
+
+    $ids = $query->execute();
+
+    if (!empty($ids)) {
+      $node = Node::load(reset($ids));
+      $logger->info('Found node for ' . $data['Sukunimi'] . ', ' . $data['Etunimet'] . ' with title ' . $node->title->value . ' (' . $node->id() . ').');
+      $context['results']['items'][] = $data;
+    }
+    else {
+      $logger->notice('Could not find node for ' . $data['Sukunimi'] . ', ' . $data['Etunimet']);
+      $context['results']['failed'][] = $data;
+    }
+  }
+
+  /**
+   * Static callback function for finishing batch.
+   *
+   * @param mixed $success
+   *   If batch succeeded or not.
+   * @param array $results
+   *   Aggregated results.
+   * @param array $operations
+   *   Operations with errors.
+   */
+  public static function finishedCallback($success, array $results, array $operations) {
+    $message = 'Processed ' . count($results['items']) . ' items with ' . count($results['failed']) . ' items failed.';
+    $logger = \Drupal::logger('paatokset_council_info');
+    $logger->info($message);
+    $messenger = \Drupal::messenger();
+    $messenger->addMessage($message);
+  }
+
+}

--- a/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
+++ b/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
@@ -214,7 +214,7 @@ class InfoImportForm extends FormBase {
       $context['results']['items'][] = $data;
     }
     else {
-      $logger->notice('Could not find node for ' . $data['Sukunimi'] . ', ' . $data['Etunimet']);
+      $logger->warning('Could not find node for ' . $data['Sukunimi'] . ', ' . $data['Etunimet']);
       $context['results']['failed'][] = $data;
     }
   }

--- a/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
+++ b/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
@@ -10,7 +10,6 @@ use Drupal\file\FileInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use League\Csv\Reader;
-use Drupal\Component\Utility;
 use Drupal\Component\Utility\UrlHelper;
 
 /**
@@ -279,18 +278,23 @@ class InfoImportForm extends FormBase {
       case "Kotikaupunginosa":
         $key = 'field_trustee_home_district';
         break;
+
       case "Puhelinnumero verkossa":
         $key = 'field_trustee_phone';
         break;
+
       case "Sähköposti verkossa":
         $key = 'field_trustee_email';
         break;
+
       case "Kotisivu":
         $key = 'field_trustee_homepage';
         break;
+
       case "Ammatti":
         $key = 'field_trustee_profession';
         break;
+
       default:
         $key = NULL;
         break;


### PR DESCRIPTION
This PR adds a new form for importing council member data from a CSV file.

**To test**
- The excel file can be found in the ticket: https://helsinkisolutionoffice.atlassian.net/browse/PP-399
- Download the file and save it as an CSV. Use `;` as the delimiter
- Checkout branch
- Run `make fresh`, `make new` or `make composer-install drush-cim drush-cr`
  - Composer install is needed for a new CSV parsing library
- SSH into the container and run `drush migrate-import ahjo_trustees:council --update`
- Login as admin and go to https://helsinki-paatokset.docker.so/fi/admin/config/system/council-import
- Select the CSV file and upload it
  - The excel has info on people who aren't council members at the moment, so not all of the data can be imported
  - Check the logs for more info on which nodes were found: https://helsinki-paatokset.docker.so/fi/admin/reports/dblog
    - Filter by "Info" to see successful node updates and by "Warning" to see names that didn't match a node
  - The file you just uploaded should be visible here as a temporary file: https://helsinki-paatokset.docker.so/fi/admin/content/files
- Reload the form and this time pick the same file from the reference field
  - Select "Permament file" from the options and start the import again
  - Check the files list. The file should have been changed to permanent now
- Read the code changes. Anything you would change in the node update or file handling logic? 