### PR TITLE
PP-402: Handle dissolved decisionmakers

### DIFF
--- a/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
@@ -39,6 +39,8 @@ do
   drush migrate-reset-status ahjo_decisionmakers:latest_sv
   drush migrate-import ahjo_decisionmakers:latest --update
   drush migrate-import ahjo_decisionmakers:latest_sv --update
+  echo "Checking for inactive decisionmakers: $(date)"
+  drush ahjo-proxy:check-dm-status -v
   # Sleep for 23 hours.
   sleep 82800
 done

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1246,6 +1246,58 @@ class AhjoProxy implements ContainerInjectionInterface {
   }
 
   /**
+   * Static callback function for checking decisionmaker status.
+   *
+   * @param mixed $data
+   *   Data for operation.
+   * @param mixed $context
+   *   Context for batch operation.
+   */
+  public static function processDmStatusCheck($data, &$context) {
+    $messenger = \Drupal::messenger();
+    $context['message'] = 'Importing item number ' . $data['count'];
+
+    if (!isset($context['results']['items'])) {
+      $context['results']['items'] = [];
+    }
+    if (!isset($context['results']['failed'])) {
+      $context['results']['failed'] = [];
+    }
+    if (!isset($context['results']['starttime'])) {
+      $context['results']['starttime'] = microtime(TRUE);
+    }
+
+    /** @var \Drupal\paatokset_ahjo_proxy\AhjoProxy $ahjo_proxy */
+    $ahjo_proxy = \Drupal::service('paatokset_ahjo_proxy');
+    $node = Node::load($data['nid']);
+
+    if ($node->bundle() !== 'policymaker') {
+      return;
+    }
+
+    // Fetch updated content from endpoint.
+    $content = $ahjo_proxy->getData($data['endpoint'], NULL);
+
+    // Local and proxy data is formatted a bit differently than API data.
+    if (isset($content['decisionMakers'][0]['Organization'])) {
+      $content = $content['decisionMakers'][0]['Organization'];
+    }
+
+    if (empty($content)) {
+      $messenger->addMessage('Could not fetch data for Org ID ' . $data['org_id'] . ' (nid: ' . $node->id() . ')');
+      $context['results']['failed'][] = $node->id();
+    }
+    else {
+      $context['results']['items'][] = $node->id();
+      if (isset($content['Existing']) && $content['Existing'] === 'false') {
+        $messenger->addMessage('Found inactive organization with Org ID ' . $data['org_id'] . '(nid:' . $node->id() . ')');
+        $node->set('field_policymaker_existing', 0);
+        $node->save();
+      }
+    }
+  }
+
+  /**
    * Add entity to callback queue.
    *
    * @param string $endpoint


### PR DESCRIPTION
This PR adds a new drush command for checking all organization and office holder statuses and marks the as inactive if they are no longer existing.

**To test**
- Checkout branch, run `make drush-cr`
- SSH in to the container and import decisionmaker content: `drush migrate-import ahjo_decisionmakers:all;drush migrate-import ahjo_decisionmakers:all_sv`
- Run these commands to get a decision from an inactive office holder:
- `drush ap:update cases HEL-2021-010957 -v; drush ap:update decisions {F32B8346-CAA4-46F3-99FD-780973D211A2} -v`
- Run the command: `drush ahjo-proxy:check-dm-status -v` (this will take about 20 minutes)
- Check the output from the command. Find the inactive nodes from: https://helsinki-paatokset.docker.so/fi/admin/content/decisionmakers
- Open one of the inactive nodes. The subnavi should have all the document links etc disabled and a notice should be displayed on the page.
- Also open the imported decision: https://helsinki-paatokset.docker.so/fi/asia/hel-2021-010957/f32b8346-caa4-46f3-99fd-780973d211a2
  - This should also have the notice about the decision maker being inactive 
- Run the command again. It should not recheck the inactive nodes again (the "Total nodes" line should be smaller).
- Read the code changes. Anything you would change with how the command works? Any ideas on how to possibly speed this up?