### PR TITLE
PP-376: Decision mass removal

### DIFF
--- a/conf/cmi/core.entity_form_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_form_display.node.decision.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.decision.field_attachments_checked
     - field.field.node.decision.field_classification_code
     - field.field.node.decision.field_classification_title
+    - field.field.node.decision.field_dates_checked
     - field.field.node.decision.field_decision_attachment_files
     - field.field.node.decision.field_decision_attachments
     - field.field.node.decision.field_decision_case_title
@@ -151,6 +152,13 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_dates_checked:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_decision_attachments:
     type: json_textarea

--- a/conf/cmi/core.entity_view_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.decision.field_attachments_checked
     - field.field.node.decision.field_classification_code
     - field.field.node.decision.field_classification_title
+    - field.field.node.decision.field_dates_checked
     - field.field.node.decision.field_decision_attachment_files
     - field.field.node.decision.field_decision_attachments
     - field.field.node.decision.field_decision_case_title
@@ -73,6 +74,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 10
+    region: content
+  field_dates_checked:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 34
     region: content
   field_decision_attachment_files:
     type: entity_reference_entity_view

--- a/conf/cmi/core.entity_view_display.node.decision.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.decision.field_attachments_checked
     - field.field.node.decision.field_classification_code
     - field.field.node.decision.field_classification_title
+    - field.field.node.decision.field_dates_checked
     - field.field.node.decision.field_decision_attachment_files
     - field.field.node.decision.field_decision_attachments
     - field.field.node.decision.field_decision_case_title
@@ -55,6 +56,7 @@ hidden:
   field_attachments_checked: true
   field_classification_code: true
   field_classification_title: true
+  field_dates_checked: true
   field_decision_attachment_files: true
   field_decision_attachments: true
   field_decision_case_title: true

--- a/conf/cmi/field.field.node.decision.field_dates_checked.yml
+++ b/conf/cmi/field.field.node.decision.field_dates_checked.yml
@@ -1,0 +1,23 @@
+uuid: 0aadc557-b8c1-4c0a-a994-27e7d2b74d27
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_dates_checked
+    - node.type.decision
+id: node.decision.field_dates_checked
+field_name: field_dates_checked
+entity_type: node
+bundle: decision
+label: 'Dates checked'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.storage.node.field_dates_checked.yml
+++ b/conf/cmi/field.storage.node.field_dates_checked.yml
@@ -1,0 +1,18 @@
+uuid: f8fdd4a0-7453-45ed-acf2-72384ced8bc6
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_dates_checked
+field_name: field_dates_checked
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
@@ -103,10 +103,20 @@ source:
       name: previous_decisions
       label: Previous Decisions
       selector: PreviousDecisions
+    -
+      name: decision_date
+      label: Decision Date
+      selector: DateDecision
   ids:
     native_id:
       type: string
 process:
+  _skip:
+    plugin: skip_disallowed_decisions
+    source:
+      - organization_id
+      - decision_date
+      - section
   type:
     plugin: default_value
     default_value: decision

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
@@ -92,6 +92,10 @@ source:
       label: Meeting Id
       selector: Meeting/MeetingID
     -
+      name: meeting_date
+      label: Meeting Date
+      selector: Meeting/DateMeeting
+    -
       name: voting_results
       label: Voting Results
       selector: VotingResults
@@ -107,6 +111,10 @@ source:
       name: decision_date
       label: Decision Date
       selector: DateDecision
+    -
+      name: issued_date
+      label: Issued Date
+      selector: PDF/Issued
   ids:
     native_id:
       type: string
@@ -199,6 +207,35 @@ process:
     -
       plugin: callback
       callable: json_encode
+  field_decision_date:
+    plugin: format_date
+    from_format: 'Y-m-d\TH:i:s.000'
+    to_format: 'Y-m-d\TH:i:s'
+    from_timezone: Europe/Helsinki
+    to_timezone: UTC
+    source: issued_date
+  _created_date:
+    -
+      plugin: get
+      source:
+        - meeting_date
+        - decision_date
+    -
+      plugin: callback
+      callable: array_filter
+    -
+      plugin: callback
+      callable: current
+  field_meeting_date:
+    plugin: format_date
+    from_format: 'Y-m-d\TH:i:s.000'
+    to_format: 'Y-m-d\TH:i:s'
+    from_timezone: Europe/Helsinki
+    to_timezone: UTC
+    source: '@_created_date'
+  field_dates_checked:
+    plugin: default_value
+    default_value: 1
   field_top_category_name:
     callable: _paatokset_ahjo_api_get_top_category
     plugin: callback

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.links.action.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.links.action.yml
@@ -1,0 +1,5 @@
+entity.disallowed_decisions.add_form:
+  route_name: entity.disallowed_decisions.add_form
+  title: 'Add Disallowed Decisions'
+  appears_on:
+    - entity.disallowed_decisions.collection

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.links.menu.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.links.menu.yml
@@ -2,3 +2,8 @@ paatokset_ahjo_api.default_texts:
   title: 'Päätökset default texts'
   parent: system.admin_config_system
   route_name: paatokset_ahjo_api.default_texts
+entity.disallowed_decisions.collection:
+  title: 'Disallowed Decisions'
+  route_name: entity.disallowed_decisions.collection
+  description: 'Administer Disallowed Decisions.'
+  parent: system.admin_config_system

--- a/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsListBuilder.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsListBuilder.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api;
+
+use Drupal\Core\Config\Entity\DraggableListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a listing of Disallowed Decisions entities.
+ */
+class DisallowedDecisionsListBuilder extends DraggableListBuilder {
+
+  /**
+   * The entity storage class.
+   *
+   * @var \Drupal\paatokset_ahjo_api\DisallowedDecisionsStorageManager
+   */
+  protected $storage;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'disallowed_decisions_overview_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['sorter'] = '';
+    $header['label'] = $this->t('Label');
+    $header['id'] = $this->t('Machine name');
+    $header['configuration'] = $this->t('Configuration');
+
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    $row['sorter'] = ['#markup' => ''];
+    $row['label'] = $entity->label();
+    $row['id'] = $entity->id();
+    $row['configuration'] = $entity->get('configuration');
+
+    return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    $form['actions']['submit']['#value'] = $this->t('Save configuration');
+    return $form;
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
@@ -49,6 +49,51 @@ class DisallowedDecisionsStorageManager extends ConfigEntityStorage {
   }
 
   /**
+   * Get disallowed decision org IDs.
+   *
+   * @return array
+   *   Org IDs in uppercase.
+   */
+  public function getDisallowedDecisionOrgs(): array {
+    $orgs = [];
+    $entities = $this->loadMultiple();
+    foreach ($entities as $entity) {
+      if (!$entity->get('status')) {
+        continue;
+      }
+      $orgs[] = strtoupper($entity->id());
+    }
+    return $orgs;
+  }
+
+  /**
+   * Check if decision values match a disallowed entity.
+   *
+   * @param string $dm_id
+   *   Organization ID.
+   * @param string $year
+   *   Year from decision date.
+   * @param string $section
+   *   Decision section.
+   *
+   * @return bool
+   *   If decision is flagged for mass removal.
+   */
+  public function checkIfDisallowed(string $dm_id, string $year, string $section): bool {
+    $disallowed = $this->getDisallowedDecisionsById($dm_id);
+    if (empty($disallowed)) {
+      return FALSE;
+    }
+    if (empty($disallowed[$year])) {
+      return FALSE;
+    }
+    if (in_array($section, $disallowed[$year])) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
    * Get disallowed sections grouped by year from config entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity

--- a/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
@@ -87,4 +87,5 @@ class DisallowedDecisionsStorageManager extends ConfigEntityStorage {
     }
     return NULL;
   }
+
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api;
+
+use Drupal\Core\Config\Entity\ConfigEntityStorage;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * The disallowed decisions storage manager class.
+ */
+class DisallowedDecisionsStorageManager extends ConfigEntityStorage {
+
+  /**
+   * Load and return all active disallowed decision entities.
+   *
+   * @return array
+   *   Disallowed decisions grouped by entity.
+   */
+  public function getDisallowedDecisions(): array {
+    $disallowed_decisions = [];
+    $dd_entities = $this->loadMultiple();
+    foreach ($dd_entities as $entity) {
+      $values = $this->getDisallowedSectionsByYearFromEntity($entity);
+      if (!empty($values)) {
+        $disallowed_decisions[$entity->id()] = $values;
+      }
+    }
+
+    return $disallowed_decisions;
+  }
+
+  /**
+   * Load disallowed decisions config by organization ID.
+   *
+   * @param string $id
+   *   Organization ID.
+   *
+   * @return array|null
+   *   Disallowed sections groped by year, or NULL if entity does not exist.
+   */
+  public function getDisallowedDecisionsById(string $id): ?array {
+    $entity = $this->load(strtolower($id));
+    if (!$entity instanceof EntityInterface) {
+      return NULL;
+    }
+    return $this->getDisallowedSectionsByYearFromEntity($entity);
+  }
+
+  /**
+   * Get disallowed sections grouped by year from config entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity to get configuration data from.
+   *
+   * @return array|null
+   *   Sections grouped by year. NULL if data is invalid or entity is hidden.
+   */
+  protected function getDisallowedSectionsByYearFromEntity(EntityInterface $entity): ?array {
+    if (!$entity->get('status')) {
+      return NULL;
+    }
+
+    $configuration = $entity->get('configuration');
+    $configuration = explode('---', $configuration);
+    $values = [];
+    foreach ($configuration as $year) {
+      $sections = explode(PHP_EOL, $year);
+      $year = FALSE;
+      foreach ($sections as $section) {
+        $section = trim($section);
+        if (empty($section)) {
+          continue;
+        }
+        if (!$year) {
+          $year = $section;
+          $values[$year] = [];
+          continue;
+        }
+        $values[$year][] = $section;
+      }
+    }
+
+    if (!empty($values)) {
+      return $values;
+    }
+    return NULL;
+  }
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Entity/DisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Entity/DisallowedDecisions.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityBase;
+
+/**
+ * Defines the Disallowed Decisions entity.
+ *
+ * @ConfigEntityType(
+ *   id = "disallowed_decisions",
+ *   label = @Translation("Disallowed Decisions"),
+ *   label_collection = @Translation("Disallowed Decisions"),
+ *   handlers = {
+ *     "storage" = "Drupal\paatokset_ahjo_api\DisallowedDecisionsStorageManager",
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "list_builder" = "Drupal\paatokset_ahjo_api\DisallowedDecisionsListBuilder",
+ *     "form" = {
+ *       "add" = "Drupal\paatokset_ahjo_api\Form\DisallowedDecisionsForm",
+ *       "edit" = "Drupal\paatokset_ahjo_api\Form\DisallowedDecisionsForm",
+ *       "delete" = "Drupal\paatokset_ahjo_api\Form\DisallowedDecisionsDeleteForm"
+ *     },
+ *     "route_provider" = {
+ *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider",
+ *     },
+ *   },
+ *   config_prefix = "disallowed_decisions",
+ *   config_export = {
+ *     "id",
+ *     "label",
+ *     "configuration",
+ *   },
+ *   admin_permission = "administer content",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *     "uuid" = "uuid",
+ *     "configuration" = "configuration",
+ *   },
+ *   links = {
+ *     "add-form" = "/admin/config/system/disallowed-decisions/add",
+ *     "edit-form" = "/admin/config/system/disallowed-decisions/{disallowed_decisions}/edit",
+ *     "delete-form" = "/admin/config/system/disallowed-decisions/{disallowed_decisions}/delete",
+ *     "collection" = "/admin/config/system/disallowed-decisions"
+ *   }
+ * )
+ */
+class DisallowedDecisions extends ConfigEntityBase {
+
+  /**
+   * The Disallowed Decisions ID.
+   *
+   * @var string
+   */
+  protected $id;
+
+  /**
+   * The Disallowed Decisions label.
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
+   * The Disallowed Decisions configuration.
+   *
+   * @var string
+   */
+  public $configuration;
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Entity/DisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Entity/DisallowedDecisions.php
@@ -69,4 +69,5 @@ class DisallowedDecisions extends ConfigEntityBase {
    * @var string
    */
   public $configuration;
+
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsDeleteForm.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsDeleteForm.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Form;
+
+use Drupal\Core\Entity\EntityConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Builds the form to delete disallowed decision entities.
+ */
+class DisallowedDecisionsDeleteForm extends EntityConfirmFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to remove %name?', ['%name' => $this->entity->label()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.disallowed_decisions.collection');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->entity->delete();
+
+    $this->messenger()->addMessage(
+      $this->t('content @type: deleted @label.', [
+        '@type' => $this->entity->bundle(),
+        '@label' => $this->entity->label(),
+      ])
+    );
+
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsForm.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsForm.php
@@ -72,7 +72,7 @@ class DisallowedDecisionsForm extends EntityForm {
       '#type' => 'textarea',
       '#title' => $this->t('Configuration'),
       '#default_value' => $disallowed_decisions->get('configuration'),
-      '#description' => $this->t("Configuration of disallowed decisions. Year followed by section numberm, separated by a | character. One per line."),
+      '#description' => $this->t("Configuration of disallowed decisions. Year followed by section numbers. Years separated by ---"),
       '#required' => TRUE,
     ];
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsForm.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsForm.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Form;
+
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Disallowed Decisions entity form.
+ */
+class DisallowedDecisionsForm extends EntityForm {
+
+  /**
+   * The Disallowed Decisions Storage Manager.
+   *
+   * @var \Drupal\paatokset_ahjo_api\DisallowedDecisionsStorageManager
+   */
+  protected $entityStorageManager;
+
+  /**
+   * Constructs a DisallowedDecisionsForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entityTypeManager.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    $disallowed_decisions = $this->entity;
+    $form['label'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Label'),
+      '#maxlength' => 255,
+      '#default_value' => $disallowed_decisions->label(),
+      '#description' => $this->t("Organization ID for disallowed decisions."),
+      '#required' => TRUE,
+    ];
+
+    $form['id'] = [
+      '#type' => 'machine_name',
+      '#default_value' => $disallowed_decisions->id(),
+      '#machine_name' => [
+        'exists' => '\Drupal\paatokset_ahjo_api\Entity\DisallowedDecisions::load',
+      ],
+      '#changeable_state' => !$disallowed_decisions->isNew(),
+    ];
+
+    $form['configuration'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Configuration'),
+      '#default_value' => $disallowed_decisions->get('configuration'),
+      '#description' => $this->t("Configuration of disallowed decisions. Year followed by section numberm, separated by a | character. One per line."),
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $disallowed_decisions = $this->entity;
+    $status = $disallowed_decisions->save();
+    $status = 0;
+
+    switch ($status) {
+      case SAVED_NEW:
+        $this->messenger()
+          ->addMessage($this->t('Added disallowed decisions for: %label.', [
+            '%label' => $disallowed_decisions->label(),
+          ]));
+        break;
+
+      default:
+        $this->messenger()
+          ->addMessage($this->t('Saved disallowed decisions for %label.', [
+            '%label' => $disallowed_decisions->label(),
+          ]));
+    }
+    $form_state->setRedirectUrl($disallowed_decisions->toUrl('collection'));
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Plugin\migrate\process;
+
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\MigrateSkipRowException;
+
+/**
+ * Skips processing the current row if the decision is flagged for mass removal.
+ *
+ * The skip_disallowed_decisions process plugin checks multiple values.
+ * If those values correspond to a decision flagged for removal,
+ * a MigrateSkipRowException is thrown.
+ *
+ * Available configuration keys:
+ * - source: Array of Organization ID, Date and Section fields. Must be in this
+ *    order.
+ *
+ * Example:
+ *
+ * @code
+ *  process:
+ *    settings:
+ *      plugin: skip_disallowed_decisions
+ *      source:
+ *        - organization_id
+ *        - decision_date
+ *        - section
+ * @endcode
+ *
+ * This will return $data['contact'] if it exists. Otherwise, the row will be
+ * skipped and the message "Missed the 'data' key" will be logged in the
+ * message table.
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ *
+ * @MigrateProcessPlugin(
+ *   id = "skip_disallowed_decisions",
+ *   handle_multiples = TRUE
+ * )
+ */
+class SkipDisallowedDecisions extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($values, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (empty($values) || !is_array($values)) {
+      return;
+    }
+
+    $dm_id = $values[0];
+    $date = $values[1];
+    $section = $values[2];
+
+    if (empty($dm_id) || empty($date) || empty($section)) {
+      return;
+    }
+
+    if ($this->checkIfDisallowed($dm_id, $date, $section)) {
+      $message = 'Skipped decision. ID: ' . $dm_id . ', section: ' . $section . ', date: ' . $date;
+      \Drupal::logger('paatokset_disallowed_decisions')->warning($message);
+      throw new MigrateSkipRowException($message);
+    }
+  }
+
+  /**
+   * Check if decision is disallowed based on ID, Date and Section.
+   *
+   * @param string $dm_id
+   *   Organization ID.
+   * @param string $date_str
+   *   Decision date.
+   * @param string $section
+   *   Decision section.
+   *
+   * @return bool
+   *   TRUE if values match a disallowed decision config entity.
+   */
+  protected function checkIfDisallowed(string $dm_id, string $date_str, string $section): bool {
+    $year = date('Y', strtotime($date_str));
+    $dd_manager = \Drupal::service('entity_type.manager')->getStorage('disallowed_decisions');
+    $disallowed = $dd_manager->getDisallowedDecisionsById($dm_id);
+    if (empty($disallowed)) {
+      return FALSE;
+    }
+    if (empty($disallowed[$year])) {
+      return FALSE;
+    }
+    if (in_array($section, $disallowed[$year])) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
@@ -82,19 +82,34 @@ class SkipDisallowedDecisions extends ProcessPluginBase {
    *   TRUE if values match a disallowed decision config entity.
    */
   protected function checkIfDisallowed(string $dm_id, string $date_str, string $section): bool {
+    // Check if decision years match before proceeding.
+    $years = [
+      '2017',
+      '2018',
+      '2019',
+    ];
     $year = date('Y', strtotime($date_str));
+    if (!in_array($year, $years)) {
+      return;
+    }
+
+    // Check ID prefix matches before loading disallowed decision entities.
+    $dm_ids = [
+      'U320200',
+    ];
+    $id_match = FALSE;
+    foreach ($dm_ids as $id_prefix) {
+      if (strpos($id_prefix, $dm_id) !== FALSE) {
+        $id_match = TRUE;
+        break;
+      }
+    }
+    if (!$id_match) {
+      return FALSE;
+    }
+
     $dd_manager = \Drupal::service('entity_type.manager')->getStorage('disallowed_decisions');
-    $disallowed = $dd_manager->getDisallowedDecisionsById($dm_id);
-    if (empty($disallowed)) {
-      return FALSE;
-    }
-    if (empty($disallowed[$year])) {
-      return FALSE;
-    }
-    if (in_array($section, $disallowed[$year])) {
-      return TRUE;
-    }
-    return FALSE;
+    return $dd_manager->checkIfDisallowed($dm_id, $year, $section);
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
@@ -96,4 +96,5 @@ class SkipDisallowedDecisions extends ProcessPluginBase {
     }
     return FALSE;
   }
+
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
@@ -90,7 +90,7 @@ class SkipDisallowedDecisions extends ProcessPluginBase {
     ];
     $year = date('Y', strtotime($date_str));
     if (!in_array($year, $years)) {
-      return;
+      return FALSE;
     }
 
     // Check ID prefix matches before loading disallowed decision entities.

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
@@ -96,10 +96,11 @@ class SkipDisallowedDecisions extends ProcessPluginBase {
     // Check ID prefix matches before loading disallowed decision entities.
     $dm_ids = [
       'U320200',
+      'U420300',
     ];
     $id_match = FALSE;
     foreach ($dm_ids as $id_prefix) {
-      if (strpos($id_prefix, $dm_id) !== FALSE) {
+      if (strpos($dm_id, $id_prefix) !== FALSE) {
         $id_match = TRUE;
         break;
       }

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -765,7 +765,7 @@ class CaseService {
       $label = $org_label . ' ' . $decision_date;
     }
     else {
-      $label = $node->title->value;
+      $label = $node->title->value . ' ' . $decision_date;
     }
 
     return $label;


### PR DESCRIPTION
This PR adds a new configuration entity for blocking specific decisions based on Org ID, year and section number from being migrated and a new drush command for cleaning up disallowed decisions that have already been migrated. This also includes the PP-407 ticket with updated decision date handling.

**To test**
* Checkout branch, run `make composer-install drush-cr drush-cim`
* Check that the configuration entity form is accessible: https://helsinki-paatokset.docker.so/fi/admin/config/system/disallowed-decisions
* Migrate the "all" dataset from test environment: `drush migrate-import ahjo_decisions:all --update`
  * This should get data from the beginning of 2018 with 838 decisions. If you get a different dataset, ask Juho for more info
* Open the decisions list: https://helsinki-paatokset.docker.so/admin/content/decisions
  * All of the recently imported decisions should have issued and creation dates, even without runnin the update decision data command.
* Open this decision: https://helsinki-paatokset.docker.so/fi/asia/hel-2018-001561/bfe58236-1c91-4eef-85e1-e2d63a3aaf58
  * The dropdown should include the decision date
* Add these disallowed decision entities with the following config: https://helsinki-paatokset.docker.so/fi/admin/config/system/disallowed-decisions/add
**U3202003080VH2**
```
2018
3
8
16
27
---
2019
8
```
**U320200201010VH1**
```
2017
2
3
4
7
8
9
12
---
2018
3
4
5
6
7
8
10
11
12
13
16
---
2019
2
3
5
6
7
8
9
10
```
**U320200203060VH1**
```
2018
2
3
4
5
6
7
```
**Test decision unpublishing and skipping**
* Get the list of org ids affected: `drush ahjo-proxy:get-flagged-ids -v`
* Check which nodes would be affected: `drush ahjo-proxy:check-disallowed-decisions --dry`
  * Check that the  version limited by org ID works too: `drush ahjo-proxy:check-disallowed-decisions --dry --org=U320200203060VH1 -v`
*  Try to migrate an affect decision ID: `drush ap:update decisions {86CABE02-DCB7-CB85-84E1-62BDC0700000} -v`
  * This should complete with status: 1, but should raise a notice about it being skipped
* Try to migrate the "all" dataset again: `drush migrate-import ahjo_decisions:all --update`
  * This should skip all the affected decisions
  * Check that the skips are visible in the logs too: https://helsinki-paatokset.docker.so/fi/admin/reports/dblog?type%5B%5D=paatokset_disallowed_decisions  