### PR TITLE
PP-409: Entity blacklist and cache forms

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -4,3 +4,4 @@ ignored_config_entities:
   - 'hdbt_admin_tools.site_settings:site_settings'
   - paatokset_ahjo_api.default_texts
   - 'system.site:page.front'
+  - paatokset_ahjo_proxy.blacklist

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.routing.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.routing.yml
@@ -1,10 +1,10 @@
 paatokset_ahjo_api.default_texts:
-  path: '/admin/tools/default-texts'
+  path: '/admin/config/system/default-texts'
   defaults:
     _form: \Drupal\paatokset_ahjo_api\Form\DefaultTextSettingsForm
     _title: 'Default text element settings.'
   requirements:
-    _permission: 'administer nodes'
+    _permission: 'administer site configuration'
 
 paatokset_case.fi:
   path: 'asia/{case_id}'

--- a/public/modules/custom/paatokset_ahjo_api/src/Form/DefaultTextSettingsForm.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Form/DefaultTextSettingsForm.php
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Settings form for the AHJO API Open ID connector.
+ * Settings form for Päätökset default settings.
  *
  * @package Drupal\paatokset_ahjo_api\Form
  */

--- a/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.links.menu.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.links.menu.yml
@@ -1,0 +1,9 @@
+paatokset_ahjo_proxy.blacklist:
+  title: 'Ahjo API entity blacklist'
+  parent: system.admin_config_services
+  route_name: paatokset_ahjo_proxy.blacklist
+
+paatokset_ahjo_proxy.manual_cache:
+  title: 'Ahjo API manual cache'
+  parent: system.admin_config_services
+  route_name: paatokset_ahjo_proxy.manual_cache

--- a/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.routing.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.routing.yml
@@ -1,3 +1,19 @@
+paatokset_ahjo_proxy.blacklist:
+  path: '/admin/config/services/ahjo-blacklist'
+  defaults:
+    _form: \Drupal\paatokset_ahjo_proxy\Form\AhjoProxyBlacklistForm
+    _title: 'Ahjo API entity blacklist'
+  requirements:
+    _permission: 'administer site configuration'
+
+paatokset_ahjo_proxy.manual_cache:
+  path: '/admin/config/services/ahjo-manual-cache'
+  defaults:
+    _form: \Drupal\paatokset_ahjo_proxy\Form\AhjoProxyManualCacheForm
+    _title: 'Ahjo API manual cache'
+  requirements:
+    _permission: 'administer site configuration'
+
 paatokset_ahjo_proxy.meetings:
   path: '/ahjo-proxy/meetings'
   defaults:

--- a/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.services.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.services.yml
@@ -1,4 +1,4 @@
 services:
   paatokset_ahjo_proxy:
     class: Drupal\paatokset_ahjo_proxy\AhjoProxy
-    arguments: ['@http_client', '@cache.default', '@entity_type.manager', '@plugin.manager.migration', '@logger.factory', '@file.repository', '@paatokset_ahjo_openid']
+    arguments: ['@http_client', '@cache.default', '@entity_type.manager', '@plugin.manager.migration', '@logger.factory', '@file.repository', '@config.factory', '@paatokset_ahjo_openid']

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -694,6 +694,14 @@ class AhjoProxy implements ContainerInjectionInterface {
 
     /** @var \Drupal\paatokset_ahjo_proxy\AhjoProxy $ahjo_proxy */
     $ahjo_proxy = \Drupal::service('paatokset_ahjo_proxy');
+
+    // Check if ID is blacklisted.
+    $disallowed_ids = $ahjo_proxy->getBlacklistedIds();
+    if (in_array($data['item_id'], $disallowed_ids)) {
+      $context['results']['failed'][] = $data['item'];
+      return;
+    }
+
     $full_data = $ahjo_proxy->getFullContentForItem($data['item']);
 
     if (!empty($full_data)) {
@@ -702,8 +710,6 @@ class AhjoProxy implements ContainerInjectionInterface {
     else {
       // Add failed items to callback queue so they can be retried later.
       if (!empty($data['endpoint']) && !empty($data['item_id'])) {
-        /** @var \Drupal\paatokset_ahjo_proxy\AhjoProxy $ahjo_proxy */
-        $ahjo_proxy = \Drupal::service('paatokset_ahjo_proxy');
         $ahjo_proxy->addItemToAhjoQueue($data['endpoint'], $data['item_id']);
       }
 

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -2220,7 +2220,12 @@ class AhjoProxy implements ContainerInjectionInterface {
     }
 
     if ($data = $this->dataCache->get($key)) {
-      return $data->data;
+      if (is_array($data->data)) {
+        return $data->data;
+      }
+      else {
+        return json_decode($data->data, TRUE);
+      }
     }
     return NULL;
   }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -8,6 +8,7 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Url;
 use Drupal\file\FileRepositoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
@@ -79,6 +80,13 @@ class AhjoProxy implements ContainerInjectionInterface {
   protected $fileRepository;
 
   /**
+   * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $config;
+
+  /**
    * Ahjo Open ID service.
    *
    * @var \Drupal\paatokset_ahjo_openid\AhjoOpenId
@@ -121,13 +129,15 @@ class AhjoProxy implements ContainerInjectionInterface {
    *   The logger factory service.
    * @param \Drupal\file\FileRepositoryInterface $file_repository
    *   File repository.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory.
    * @param \Drupal\paatokset_ahjo_openid\AhjoOpenId $ahjo_open_id
    *   Ahjo Open ID service.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function __construct(ClientInterface $http_client, CacheBackendInterface $data_cache, EntityTypeManagerInterface $entity_type_manager, MigrationPluginManager $migration_manager, LoggerChannelFactoryInterface $logger_factory, FileRepositoryInterface $file_repository, AhjoOpenId $ahjo_open_id) {
+  public function __construct(ClientInterface $http_client, CacheBackendInterface $data_cache, EntityTypeManagerInterface $entity_type_manager, MigrationPluginManager $migration_manager, LoggerChannelFactoryInterface $logger_factory, FileRepositoryInterface $file_repository, ConfigFactoryInterface $config_factory, AhjoOpenId $ahjo_open_id) {
     $this->httpClient = $http_client;
     $this->dataCache = $data_cache;
     $this->ahjoOpenId = $ahjo_open_id;
@@ -135,6 +145,7 @@ class AhjoProxy implements ContainerInjectionInterface {
     $this->migrationManager = $migration_manager;
     $this->fileRepository = $file_repository;
     $this->logger = $logger_factory->get('paatokset_ahjo_proxy');
+    $this->config = $config_factory;
   }
 
   /**
@@ -148,6 +159,7 @@ class AhjoProxy implements ContainerInjectionInterface {
       $container->get('plugin.manager.migration'),
       $container->get('logger.factory'),
       $container->get('file.repository'),
+      $container->get('config.factory'),
       $container->get('paatokset_ahjo_openid')
     );
   }
@@ -1927,6 +1939,25 @@ class AhjoProxy implements ContainerInjectionInterface {
     $executable = new MigrateExecutable($migration, new MigrateMessage());
     $status = $executable->import();
     return $status;
+  }
+
+  /**
+   * Get blacklisted entity IDs from config.
+   *
+   * @return array
+   *   Empty array or valus from config.
+   */
+  public function getBlacklistedIds(): array {
+    $blacklist_config = $this->config->get('paatokset_ahjo_proxy.blacklist');
+    $ids_text = $blacklist_config->get('ids');
+    if (empty($ids_text)) {
+      return [];
+    }
+    $ids = explode(PHP_EOL, $ids_text);
+    foreach ($ids as $key => $value) {
+      $ids[$key] = trim($value);
+    }
+    return $ids;
   }
 
   /**

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyBlacklistForm.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyBlacklistForm.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\paatokset_ahjo_proxy\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for the AHJO API entity blacklist.
+ *
+ * @package Drupal\paatokset_ahjo_proxy\Form
+ */
+class AhjoProxyBlacklistForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    // Instantiates this form class.
+    $instance = parent::create($container);
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'paatokset_ahjo_proxy_blacklist';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditableConfigNames() {
+    return [
+      'paatokset_ahjo_proxy.blacklist',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('paatokset_ahjo_proxy.blacklist');
+
+    $form['blacklist'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('List of disallowed entity IDs, separated by a new line.'),
+      '#default_value' => $config->get('ids'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('paatokset_ahjo_proxy.blacklist')
+      ->set('ids', $form_state->getValue('blacklist'))
+      ->save();
+  }
+}

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyBlacklistForm.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyBlacklistForm.php
@@ -63,4 +63,5 @@ class AhjoProxyBlacklistForm extends ConfigFormBase {
       ->set('ids', $form_state->getValue('blacklist'))
       ->save();
   }
+
 }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyManualCacheForm.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyManualCacheForm.php
@@ -95,7 +95,8 @@ class AhjoProxyManualCacheForm extends FormBase {
     $delete = $form_state->getValue('delete_urls');
 
     if (!empty($url) && !empty($content)) {
-      $this->dataCache->set($url, $content, $this->getCacheMaxAge(), []);
+      $set_key = $this->getCacheKey($url);
+      $this->dataCache->set($set_key, $content, $this->getCacheMaxAge(), []);
       $this->messenger()->addMessage(
         $this->t('Added %url to dataCache.', [
           '%url' => $url,
@@ -109,13 +110,29 @@ class AhjoProxyManualCacheForm extends FormBase {
     $delete_urls = explode(PHP_EOL, $delete);
     foreach ($delete_urls as $delete_url) {
       $delete_url = trim($delete_url);
-      $this->dataCache->delete($delete_url);
+      $delete_key = $set_key = $this->getCacheKey($delete_url);
+      $this->dataCache->delete($delete_key);
       $this->messenger()->addMessage(
         $this->t('Deleted %url from dataCache', [
           '%url' => $delete_url,
         ]),
       );
     }
+  }
+
+  /**
+   * Gets the cache key for given id.
+   *
+   * @param string $id
+   *   The id.
+   *
+   * @return string
+   *   The cache key.
+   */
+  protected function getCacheKey(string $id) : string {
+    $id = preg_replace('/[^a-z0-9_]+/s', '_', $id);
+
+    return sprintf('ahjo-proxy-%s', $id);
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyManualCacheForm.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxyManualCacheForm.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\paatokset_ahjo_proxy\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for the AHJO API Open ID connector.
+ *
+ * @package Drupal\paatokset_ahjo_proxy\Form
+ */
+class AhjoProxyManualCacheForm extends FormBase {
+
+  /**
+   * The cache.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected CacheBackendInterface $dataCache;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() : int {
+    // Set one day for cache max age.
+    return time() + 60 * 60 * 24;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    // Instantiates this form class.
+    $instance = parent::create($container);
+    $instance->dataCache = $container->get('cache.default');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'paatokset_ahjo_proxy_manual_cache';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['add'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Add to cache'),
+      '#open' => TRUE,
+    ];
+
+    $form['add']['url'] = [
+      '#type' => 'textfield',
+      '#title' => t('URL'),
+      '#default_value' => 'https://ahjo.hel.fi:9802/ahjorest/v1/',
+    ];
+
+    $form['add']['content'] = [
+      '#type' => 'textarea',
+      '#title' => t('Content to cache'),
+    ];
+
+    $form['delete'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Delete from cache'),
+      '#open' => TRUE,
+    ];
+
+    $form['delete']['delete_urls'] = [
+      '#type' => 'textarea',
+      '#title' => t('Cached URLs to delete, one for each line.'),
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#default_value' => t('Submit'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $url = $form_state->getValue('url');
+    $content = $form_state->getValue('content');
+    $delete = $form_state->getValue('delete_urls');
+
+    if (!empty($url) && !empty($content)) {
+      $this->dataCache->set($url, $content, $this->getCacheMaxAge(), []);
+      $this->messenger()->addMessage(
+        $this->t('Added %url to dataCache.', [
+          '%url' => $url,
+        ]),
+      );
+    }
+
+    if (empty($delete)) {
+      return;
+    }
+    $delete_urls = explode(PHP_EOL, $delete);
+    foreach ($delete_urls as $delete_url) {
+      $delete_url = trim($delete_url);
+      $this->dataCache->delete($delete_url);
+      $this->messenger()->addMessage(
+        $this->t('Deleted %url from dataCache', [
+          '%url' => $delete_url,
+        ]),
+      );
+    }
+  }
+
+}


### PR DESCRIPTION
**To test**
- Checkout branch, run `make drush-cr drush-cim`
- Check that these forms exist and that they both work:
  - https://helsinki-paatokset.docker.so/fi/admin/config/services/ahjo-blacklist
  - https://helsinki-paatokset.docker.so/fi/admin/config/services/ahjo-manual-cache
    - It's enough that the form can be submitted and that it shows messages about adding and removing URLs from cache. It can't be tested locally.
- Add values to the blacklist form, then run `make drush-cex`. It should show that some values will be exported
- Change the values in the form again, then run `make drush-cim`. This should NOT override the values you just changed because of config ignore.