### PR TITLE
PP-0:  Org chart language functionality

### DIFF
--- a/conf/cmi/field.field.node.organization.field_organization_data.yml
+++ b/conf/cmi/field.field.node.organization.field_organization_data.yml
@@ -14,7 +14,7 @@ bundle: organization
 label: 'Organization data'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.organization.field_policymaker_id.yml
+++ b/conf/cmi/field.field.node.organization.field_policymaker_id.yml
@@ -12,7 +12,7 @@ bundle: organization
 label: 'Organization ID'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/language.content_settings.node.organization.yml
+++ b/conf/cmi/language.content_settings.node.organization.yml
@@ -4,8 +4,15 @@ status: true
 dependencies:
   config:
     - node.type.organization
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 id: node.organization
 target_entity_type_id: node
 target_bundle: organization
 default_langcode: fi
-language_alterable: false
+language_alterable: true

--- a/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
@@ -273,6 +273,8 @@ class AhjoCallbackCommands extends DrushCommands {
    *
    * @usage ahjo-callback:start-org-queue 00001 3
    *   Get first three levels of organization data.
+   * @usage ahjo-callback:start-org-queue 00001 3 sv
+   *   Get Swedish translations of the first three levels.
    *
    * @aliases ac:sorg
    */
@@ -343,6 +345,7 @@ class AhjoCallbackCommands extends DrushCommands {
       $table->addRow([
         $item->data['id'],
         $item->item_id,
+        $item->data['langcode'],
         date('Y-m-d H:i:s', (int) $item->created),
         $step,
         $max_steps,

--- a/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
@@ -266,6 +266,8 @@ class AhjoCallbackCommands extends DrushCommands {
    *   Org ID to start from.
    * @param int $max_steps
    *   Maximum amount of steps.
+   * @param string $langcode
+   *   Language to get org data with.
    *
    * @command ahjo-callback:start-org-queue
    *
@@ -274,19 +276,21 @@ class AhjoCallbackCommands extends DrushCommands {
    *
    * @aliases ac:sorg
    */
-  public function startOrgQueue(string $start_id, int $max_steps = 5) {
+  public function startOrgQueue(string $start_id, int $max_steps = 5, string $langcode = 'fi') {
     $data = [
       'id' => $start_id,
       'step' => 0,
       'max_steps' => $max_steps,
+      'langcode' => $langcode,
     ];
 
     $item_id = $this->orgQueue->createItem($data);
 
     if ($item_id) {
       $this->writeln(sprintf('Started org queue from %s with %d steps.', $start_id, $max_steps));
-      $this->logger->info('Added item to org chart queue: @id, @step out of @max_steps).', [
+      $this->logger->info('Added item to org chart queue: @id (@langcode), @step out of @max_steps).', [
         '@id' => $start_id,
+        '@langcode' => $langcode,
         '@step' => 0,
         '@max_steps' => $max_steps,
       ]);
@@ -306,7 +310,7 @@ class AhjoCallbackCommands extends DrushCommands {
   public function listOrgQueue(): void {
     $table = new Table($this->output());
     $table->setHeaders([
-      'OrgID', 'ID', 'Time', 'Step', 'Max steps',
+      'OrgID', 'ID', 'Lang', 'Time', 'Step', 'Max steps',
     ]);
 
     $count = 0;

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoOrgChartQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoOrgChartQueueWorker.php
@@ -89,7 +89,7 @@ class AhjoOrgChartQueueWorker extends QueueWorkerBase implements ContainerFactor
     }
     else {
       $url = 'organization';
-      $query_string = 'orgid=' . (string) $id . '&apireqlang='. (string) $langcode;
+      $query_string = 'orgid=' . (string) $id . '&apireqlang=' . (string) $langcode;
     }
 
     $data = $this->ahjoProxy->getData($url, $query_string);

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoOrgChartQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoOrgChartQueueWorker.php
@@ -84,7 +84,7 @@ class AhjoOrgChartQueueWorker extends QueueWorkerBase implements ContainerFactor
     }
 
     if (!empty(getenv('AHJO_PROXY_BASE_URL'))) {
-      $url = 'organization/single/' . (string) $id . '&apireqlang=' . (string) $langcode;
+      $url = 'organization/single/' . (string) $id . '?apireqlang=' . (string) $langcode;
       $query_string = NULL;
     }
     else {
@@ -196,12 +196,14 @@ class AhjoOrgChartQueueWorker extends QueueWorkerBase implements ContainerFactor
       $found_node = Node::load(reset($ids));
     }
 
+    $title = Unicode::truncate($title, '255', TRUE, TRUE);
+
     if (!$found_node instanceof NodeInterface) {
       $found_node = Node::create([
         'type' => 'organization',
         'langcode' => $langcode,
         'field_policymaker_id' => $id,
-        'title' => Unicode::truncate($title, '255', TRUE, TRUE),
+        'title' => $title,
       ]);
     }
     else {
@@ -211,11 +213,12 @@ class AhjoOrgChartQueueWorker extends QueueWorkerBase implements ContainerFactor
       else {
         $found_node = $found_node->addTranslation($langcode, [
           'type' => 'organization',
-          'title' => Unicode::truncate($title, '255', TRUE, TRUE),
+          'title' => $title,
         ]);
       }
     }
 
+    $found_node->set('title', $title);
     return $found_node;
   }
 

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -437,15 +437,16 @@ class AhjoProxy implements ContainerInjectionInterface {
    *   Organization ID to start from.
    * @param int $steps
    *   Maximum levels to include in chart.
+   * @param string $langcode
+   *   Langcode for organization chart.
    *
    * @return array|null
    *   Structured array with organizations, or NULL if first org is not found.
    */
-  public function getOrgChart(string $orgId, int $steps = 3): ?array {
+  public function getOrgChart(string $orgId, int $steps = 3, string $langcode = 'fi'): ?array {
     $query = \Drupal::entityQuery('node')
       ->condition('status', 1)
       ->range(0, 1)
-      ->condition('langcode', 'fi')
       ->condition('field_policymaker_id', $orgId)
       ->condition('type', 'organization');
 
@@ -460,7 +461,11 @@ class AhjoProxy implements ContainerInjectionInterface {
       return NULL;
     }
 
-    $data = $this->getOrgChartStructure($node, 0, $steps);
+    if ($node->hasTranslation($langcode)) {
+      $node = $node->getTranslation($langcode);
+    }
+
+    $data = $this->getOrgChartStructure($node, 0, $steps, $langcode);
     return [$data];
   }
 
@@ -473,14 +478,17 @@ class AhjoProxy implements ContainerInjectionInterface {
    *   Current level.
    * @param int $max_steps
    *   Maximum level.
+   * @param string $langcode
+   *   Langcode for organization chart.
    *
    * @return array
    *   Structured organization data.
    */
-  protected function getOrgChartStructure(NodeInterface $node, int $step = 0, int $max_steps = 3): array {
+  protected function getOrgChartStructure(NodeInterface $node, int $step = 0, int $max_steps = 3, string $langcode = 'fi'): array {
     $data = [
       'Name' => $node->title->value,
       'ID' => $node->field_policymaker_id->value,
+      'Language' => $node->langcode->value,
     ];
 
     if ($node->hasField('field_organization_data') && !$node->get('field_organization_data')->isEmpty()) {
@@ -510,7 +518,6 @@ class AhjoProxy implements ContainerInjectionInterface {
       $query = \Drupal::entityQuery('node')
         ->condition('status', 1)
         ->range(0, 1)
-        ->condition('langcode', 'fi')
         ->condition('field_policymaker_id', $field->value)
         ->condition('type', 'organization');
 
@@ -522,7 +529,10 @@ class AhjoProxy implements ContainerInjectionInterface {
       $id = reset($ids);
       $child_node = Node::load($id);
       if ($child_node instanceof NodeInterface) {
-        $orgs_below[] = $this->getOrgChartStructure($child_node, $step + 1, $max_steps);
+        if ($child_node->hasTranslation($langcode)) {
+          $child_node = $child_node->getTranslation($langcode);
+        }
+        $orgs_below[] = $this->getOrgChartStructure($child_node, $step + 1, $max_steps, $langcode);
       }
     }
 

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -1588,6 +1588,7 @@ class AhjoAggregatorCommands extends DrushCommands {
       ->condition('status', 1)
       ->condition('field_decision_record', '', '<>')
       ->condition('field_is_decision', 0)
+      ->sort('field_meeting_date', 'DESC')
       ->latestRevision();
 
     if ($limit) {
@@ -1694,6 +1695,7 @@ class AhjoAggregatorCommands extends DrushCommands {
       ->condition('status', 1)
       ->condition('field_meeting_minutes_published', 1)
       ->condition('field_meeting_agenda', '', '<>')
+      ->sort('field_meeting_date', 'DESC')
       ->latestRevision();
 
     if ($limit) {
@@ -1781,6 +1783,7 @@ class AhjoAggregatorCommands extends DrushCommands {
     $query = $this->nodeStorage->getQuery()
       ->condition('type', 'decision')
       ->condition('status', 1)
+      ->sort('field_meeting_date', 'DESC')
       ->latestRevision();
 
     if ($motions) {
@@ -2364,6 +2367,7 @@ class AhjoAggregatorCommands extends DrushCommands {
     $query = $this->nodeStorage->getQuery()
       ->condition('type', 'decision')
       ->condition('status', 1)
+      ->sort('field_meeting_date', 'DESC')
       ->condition('field_is_decision', 0)
       ->latestRevision();
 
@@ -2387,6 +2391,7 @@ class AhjoAggregatorCommands extends DrushCommands {
     $meeting_query = $this->nodeStorage->getQuery()
       ->condition('type', 'meeting')
       ->condition('status', 1)
+      ->sort('field_meeting_date', 'DESC')
       ->condition('field_meeting_id', array_keys($motions), 'IN')
       ->latestRevision();
     $meeting_ids = $meeting_query->execute();

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Controller/AhjoProxyController.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Controller/AhjoProxyController.php
@@ -6,6 +6,7 @@ namespace Drupal\paatokset_ahjo_proxy\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\paatokset_ahjo_proxy\AhjoProxy;
+use Drupal\Core\Language\LanguageManager;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,6 +21,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class AhjoProxyController extends ControllerBase {
 
   /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManager
+   */
+  protected $languageManager;
+
+  /**
    * Ahjo proxy service.
    *
    * @var \Drupal\paatokset_ahjo_proxy\AhjoProxy
@@ -29,8 +37,9 @@ class AhjoProxyController extends ControllerBase {
   /**
    * Constructor.
    */
-  public function __construct(AhjoProxy $ahjo_proxy) {
+  public function __construct(LanguageManager $language_manager, AhjoProxy $ahjo_proxy) {
     $this->ahjoProxy = $ahjo_proxy;
+    $this->languageManager = $language_manager;
   }
 
   /**
@@ -38,6 +47,7 @@ class AhjoProxyController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('language_manager'),
       $container->get('paatokset_ahjo_proxy')
     );
   }
@@ -243,7 +253,8 @@ class AhjoProxyController extends ControllerBase {
    *   JSON data containing organization chart.
    */
   public function getOrgChart(string $orgId, int $steps): JsonResponse {
-    $data = $this->ahjoProxy->getOrgChart($orgId, $steps);
+    $langcode = $this->languageManager()->getCurrentLanguage()->getId();
+    $data = $this->ahjoProxy->getOrgChart($orgId, $steps, $langcode);
     return new JsonResponse($data);
   }
 


### PR DESCRIPTION
**To test**
- Checkout branch, run `make drush-cr drush-cim`
- Run the following commands to fetch the finnish organization chart: `drush ahjo-callback:start-org-queue 00001 10 -v`
  - Confirm that it was added to the queue by running: `ahjo-callback:list-org-queue` then run `drush queue:run ahjo_api_org_queue -v` (this will take a while)
  - Check the organization endpoint data: https://helsinki-paatokset.docker.so/fi/ahjo-proxy/org-chart/00001/10 (you have to be logged in for this URL to work)
- Check the swedish version and confirm that it shows finnish nodes: https://helsinki-paatokset.docker.so/sv/ahjo-proxy/org-chart/00001/10 (Each object has "Language: fi" and the names should be in finnish)
- Fetch the swedish translations of the organizations:  `drush ahjo-callback:start-org-queue 00001 10 sv -v`
  - Confirm that it was added to the queue by running: `ahjo-callback:list-org-queue` then run `drush queue:run ahjo_api_org_queue -v`
  - Reload the swedish version of the of the endpoint. The content should now be translated
- Confirm that the swedish organization nodes are translations of the finnish nodes by going to: https://helsinki-paatokset.docker.so/fi/admin/content?title=&type=organization and opening the translation page for  a few of them