### PR TITLE
PP-390: Add securityreasons field to decision attachments.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -832,7 +832,14 @@ class CaseService {
 
       // Override title if attachment is not public.
       if ($publicity_class !== 'Julkinen') {
-        $title = t('Non-public');
+        if (!empty($data['SecurityReasons'])) {
+          $title = t('Non-public: @reasons', [
+            '@reasons' => implode(', ', $data['SecurityReasons']),
+          ]);
+        }
+        else {
+          $title = t('Non-public');
+        }
       }
 
       $file_url = NULL;


### PR DESCRIPTION
**Before checking out the branch:**
- SSH into the container with: `make shell`
- Inside the container, run: `drush ap:update decisions 46d4100a-3421-48bf-b22f-d3078b3890bf -v;drush ap:ud -v`
- Open this decision: https://helsinki-paatokset.docker.so/fi/asia/hel-2022-003453/46d4100a-3421-48bf-b22f-d3078b3890bf
- There should be an attachment with the title "Non-public" and an eye icon

**To test**
- Checkout branch, run `make drush-cr`
- Reload the decision page
- The non-public attachment title should change to: "Non-public: JulkL (621/1999) 24.1 § 20 k"