### PR TITLE
PP-435: Article publish date fixes

### DIFF
--- a/conf/cmi/core.entity_form_display.node.article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.article.default.yml
@@ -12,10 +12,8 @@ dependencies:
     - node.type.article
   module:
     - hdbt_admin_editorial
-    - metatag
     - paragraphs
     - path
-    - publication_date
     - scheduler
     - select2
 _core:
@@ -60,14 +58,6 @@ content:
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }
-  field_metatags:
-    type: metatag_firehose
-    weight: 16
-    region: content
-    settings:
-      sidebar: false
-      use_details: true
-    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0
@@ -77,7 +67,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -94,14 +84,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  published_at:
-    type: publication_date_timestamp
-    weight: 8
+  scheduler_settings:
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
-  scheduler_settings:
-    weight: 12
+  simple_sitemap:
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -114,7 +103,7 @@ content:
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 9
+    weight: 8
     region: content
     settings:
       display_label: true
@@ -157,4 +146,6 @@ hidden:
   field_author: true
   field_lead: true
   field_liftup_image: true
+  field_metatags: true
   hide_sidebar_navigation: true
+  published_at: true

--- a/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
+++ b/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
@@ -485,9 +485,5 @@ function helfi_paatokset_preprocess_page(&$variables) {
  */
 function helfi_paatokset_preprocess_node__article(&$variables) {
   $node = $variables['node'];
-  if ($node->hasField('published_at') && $node->get('published_at')->isEmpty()) {
-    $variables['published_at'] = $node->get('published_at')->value;
-  } else {
-    $variables['published_at'] = $node->get('created')->value;
-  }
+  $variables['published_at'] = $node->get('created')->value;
 }


### PR DESCRIPTION
This changes the way article publication date and time are displayed.

**To test**
- Run `make drush-cr drush-cim` (run `make new` if you run into issues with config import)
- Create new articles and follow these test cases: https://helsinki-paatokset.docker.so/fi/node/add/article
  - Create one article and set it to be published in a few minutes when you're still creating it.
  - Create one article as unpublished. Then edit it and schedule it to be published in a few minutes.
  - Create one article and publish it. Edit it and set it to be published in a few minutes (this should unpublish the article).
- For all of these, the time should be the time the node was created, not yet the scheduled publication time.
- Wait until a minute or two past the scheduled time, ssh into the container with `make shell` and run `drush cron`
  - For all nodes, the publication time should be the scheduled time, NOT the time when they were originally created and NOT the time when you ran the cron command
- Edit one of the nodes again and set it to be published in a few minutes. This should again unpublish the node
- Wait until the publication time and run `drush cron` again
- The node's publication time should now be updated to the new scheduled time