### PR TITLE
PP-433: Translation fixes

### DIFF
--- a/docker/openshift/crons/run-immediate-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-immediate-ahjo-integrations.sh
@@ -16,6 +16,7 @@ do
   drush ahjo-proxy:update-decisions --logic=outdated --limit=100 -v
   drush ahjo-proxy:update-decisions --logic=history --limit=100 -v
   drush ahjo-proxy:update-decisions --logic=case --limit=100 -v
+  drush ahjo-proxy:update-decisions --logic=language --limit=100 -v
   # Sleep for 10 minutes.
   sleep 600
 done

--- a/public/modules/custom/paatokset_ahjo_api/js/meetings_calendar.js
+++ b/public/modules/custom/paatokset_ahjo_api/js/meetings_calendar.js
@@ -254,13 +254,13 @@
             return dayjs(this.selectedDate).daysInMonth();
           },
           openMotions(){
-            return window.Drupal.t('Open motions');
+            return window.Drupal.t('Open agenda');
           },
           openMinutes() {
             return window.Drupal.t('Open minutes');
           },
           openDecisions() {
-            return window.Drupal.t('Open decisions');
+            return window.Drupal.t('Open decision announcement');
           },
           noMeetings() {
             return window.Drupal.t('No meetings');
@@ -272,10 +272,10 @@
             return window.Drupal.t('meeting moved', {}, {context: 'Meetings calendar'});
           },
           nextMonth() {
-            return window.Drupal.t('Seuraava kuukausi');
+            return window.Drupal.t('Next month');
           },
           previousMonth() {
-            return window.Drupal.t('Edellinen kuukausi');
+            return window.Drupal.t('Previous month');
           },
           days() {
             let allDays = [];

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_cases.yml
@@ -130,7 +130,9 @@ process:
   field_top_category_name:
     callable: _paatokset_ahjo_api_get_top_category
     plugin: callback
-    source: classification_code
+    source:
+      - classification_code
+      - 'fi'
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
@@ -255,7 +255,9 @@ process:
   field_top_category_name:
     callable: _paatokset_ahjo_api_get_top_category
     plugin: callback
-    source: classification_code
+    source:
+      - classification_code
+      - language
   field_dm_org_name: organization_name
   field_policymaker_id: organization_id
   field_organization_type: organization_type

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -99,8 +99,8 @@ function paatokset_ahjo_api_preprocess_block__frontpage_calendar(array &$variabl
     $meetings_with_color[] = $meeting;
   }
 
-  $variables['open_motions'] = t('Open motions');
-  $variables['open_decisions'] = t('Open decisions');
+  $variables['open_motions'] = t('Open agenda');
+  $variables['open_decisions'] = t('Open decision announcement');
   $variables['open_minutes'] = t('Open minutes');
   if ($currentLanguage === 'fi') {
     $variables['calendar_link'] = '/fi/kokouskalenteri';
@@ -154,7 +154,7 @@ function template_preprocess_block__meetings_calendar(array &$variables) {
     $all_meetings = array_slice($all_meetings, 0, 8);
   }
 
-  $variables['open_motions'] = t('Open motions');
+  $variables['open_motions'] = t('Open agenda');
   $variables['open_minutes'] = t('Open minutes');
   $variables['open_meeting_calendar'] = t('Open meeting calendar');
   $variables['meetings'] = $all_meetings;

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -806,13 +806,16 @@ function _paatokset_ahjo_api_get_existing_value(array $values) {
  * @return string|null
  *   Top category name based on the first part of the code, if found.
  */
-function _paatokset_ahjo_api_get_top_category($value): ?string {
-  if (!is_string($value)) {
-    NULL;
+function _paatokset_ahjo_api_get_top_category(array $values): ?string {
+  if (!is_array($values)) {
+    return NULL;
   }
+  $value = $values[0];
+  $langcode = $values[1];
+
   /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
   $caseService = \Drupal::service('paatokset_ahjo_cases');
-  return $caseService->getTopCategoryFromClassificationCode($value);
+  return $caseService->getTopCategoryFromClassificationCode($value, $langcode);
 }
 
 /**

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -811,7 +811,12 @@ function _paatokset_ahjo_api_get_top_category(array $values): ?string {
     return NULL;
   }
   $value = $values[0];
-  $langcode = $values[1];
+  if (!empty($values[1])) {
+    $langcode = $values[1];
+  }
+  else {
+    $langcode = 'fi';
+  }
 
   /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
   $caseService = \Drupal::service('paatokset_ahjo_cases');

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -25,11 +25,6 @@ class CaseService {
   const DECISION_NODE_TYPE = 'decision';
 
   /**
-   * Machine name for meeting document media type.
-   */
-  const DOCUMENT_TYPE = 'ahjo_document';
-
-  /**
    * Case node.
    *
    * @var \Drupal\node\Entity\Node

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -1466,73 +1466,136 @@ class CaseService {
    *
    * @param string $code
    *   Classification code.
+   * @param string $langcode
+   *   Language to get category name for.
    *
    * @return string|null
    *   Top category name, if found.
    */
-  public function getTopCategoryFromClassificationCode(string $code): ?string {
+  public function getTopCategoryFromClassificationCode(string $code, string $langcode = 'fi'): ?string {
     $bits = explode(' ', (string) $code);
     $code = array_shift($bits);
+    $key = $code . '-' . $langcode;
 
-    switch ($code) {
-      case "00":
+    switch ($key) {
+      case "00-fi":
         $name = "Hallintoasiat";
         break;
 
-      case "01":
+      case "00-sv":
+        $name = "Förvaltningsärenden";
+        break;
+
+      case "01-fi":
         $name = "Henkilöstöasiat";
         break;
 
-      case "02":
+      case "01-sv":
+        $name = "Personalärenden";
+        break;
+
+      case "02-fi":
         $name = "Talousasiat, verotus ja omaisuuden hallinta";
         break;
 
-      case "03":
+      case "02-sv":
+        $name = "Ekonomi, beskattning och egendomsförvaltning";
+        break;
+
+      case "03-fi":
         $name = "Lainsäädäntö ja lainsäädännön soveltaminen";
         break;
 
-      case "04":
+      case "03-sv":
+        $name = "Lagstiftning och dess tillämpning";
+        break;
+
+      case "04-fi":
         $name = "Kansainvälinen toiminta ja maahanmuuttopolitiikka";
         break;
 
-      case "05":
+      case "04-sv":
+        $name = "Internationell verksamhet och migrationspolitik";
+        break;
+
+      case "05-fi":
         $name = "Sosiaalitoimi";
         break;
 
-      case "06":
+      case "05-sv":
+        $name = "Socialvård";
+        break;
+
+      case "06-fi":
         $name = "Terveydenhuolto";
         break;
 
-      case "07":
+      case "06-sv":
+        $name = "Hälsovård";
+        break;
+
+      case "07-fi":
         $name = "Tiedon hallinta";
         break;
 
-      case "08":
+      case "07-sv":
+        $name = "Informationshantering";
+        break;
+
+      case "08-fi":
         $name = "Liikenne";
         break;
 
-      case "09":
+      case "08-sv":
+        $name = "Trafik";
+        break;
+
+      case "09-fi":
         $name = "Turvallisuus ja yleinen järjestys";
         break;
 
-      case "10":
+      case "09-sv":
+        $name = "Säkerhet och allmän ordning";
+        break;
+
+      case "10-fi":
         $name = "Maankäyttö, rakentaminen ja asuminen";
         break;
 
-      case "11":
+      case "10-sv":
+        $name = "Markanvändning, byggande och boende";
+        break;
+
+      case "11-fi":
         $name = "Ympäristöasia";
         break;
 
-      case "12":
+      case "11-sv":
+        $name = "Miljöärenden";
+        break;
+
+      case "12-fi":
         $name = "Opetus- ja sivistystoimi";
         break;
 
-      case "13":
+      case "12-sv":
+        $name = "Undervisnings- och bildningsväsende";
+        break;
+
+      case "13-fi":
         $name = "Tutkimus- ja kehittämistoiminta";
         break;
 
-      case "14":
+      case "13-sv":
+        $name = "Forskning och utveckling";
+        break;
+
+      case "14-fi":
         $name = "Elinkeino- ja työvoimapalvelut";
+        break;
+
+      case "14-sv":
+        $name = "Näringslivs- och arbetskraftstjänster";
         break;
 
       default:

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\paatokset_ahjo_api\Service;
 
-use Drupal\media\MediaInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
@@ -18,11 +17,6 @@ class MeetingService {
    * Machine name for meeting node type.
    */
   const NODE_TYPE = 'meeting';
-
-  /**
-   * Machine name for meeting document media type.
-   */
-  const DOCUMENT_TYPE = 'ahjo_document';
 
   /**
    * Query Ahjo API meetings from database.
@@ -404,7 +398,7 @@ class MeetingService {
   /**
    * Get URL from AHJO document.
    *
-   * @param array
+   * @param array $document
    *   Ahjo Document to get URL for (array decoded from JSON).
    *
    * @return string|null

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1768,16 +1768,6 @@ class AhjoProxy implements ContainerInjectionInterface {
     $org_name = $data['meeting_data']['org_name'];
     $attachments = $data['attachments'];
 
-    // Get top category name.
-    if (isset($ids['classification_code'])) {
-      $classification_code = $ids['classification_code'];
-      $top_category = $case_service->getTopCategoryFromClassificationCode($classification_code);
-    }
-    else {
-      $classification_code = NULL;
-      $top_category = NULL;
-    }
-
     $node = $case_service->findOrCreateMotion($case_id, $meeting_id, $title, TRUE);
     if (!$node instanceof NodeInterface) {
       $context['results']['failed'][] = $data['title'];
@@ -1819,6 +1809,23 @@ class AhjoProxy implements ContainerInjectionInterface {
     else {
       $context['results']['failed'][] = $data['title'];
       return;
+    }
+
+    if (isset($record_content['Language']) && in_array($record_content['Language'], ['fi', 'sv'])) {
+      $langcode = $record_content['Language'];
+    }
+    else {
+      $langcode = 'fi';
+    }
+
+    // Get top category name.
+    if (isset($ids['classification_code'])) {
+      $classification_code = $ids['classification_code'];
+      $top_category = $case_service->getTopCategoryFromClassificationCode($classification_code, $langcode);
+    }
+    else {
+      $classification_code = NULL;
+      $top_category = NULL;
     }
 
     $attachments_json = [];

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -978,7 +978,7 @@ class AhjoProxy implements ContainerInjectionInterface {
       $ahjo_proxy->updateDecisionHistoryContent($node, $data['decision_endpoint']);
     }
 
-    // If language is set to outdated, refetch organization data
+    // If language is set to outdated, refetch organization data.
     if ($node->hasField('field_record_language_checked') && !$node->get('field_record_language_checked')->value) {
       $recheck_language = TRUE;
     }
@@ -1866,7 +1866,8 @@ class AhjoProxy implements ContainerInjectionInterface {
       return;
     }
 
-    if (isset($record_content['Language']) && in_array($record_content['Language'], ['fi', 'sv'])) {
+    if (isset($record_content['Language'])
+      && in_array($record_content['Language'], ['fi', 'sv'])) {
       $langcode = $record_content['Language'];
     }
     else {

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -687,8 +687,10 @@ class AhjoAggregatorCommands extends DrushCommands {
         $query->notExists('field_decision_record');
       }
       elseif ($logic === 'language') {
-        $query->notExists('field_record_language_checked');
-        $query->condition('field_record_language_checked', 0);
+        $or = $query->orConditionGroup();
+        $or->notExists('field_record_language_checked');
+        $or->condition('field_record_language_checked', 0);
+        $query->condition($or);
       }
       elseif ($logic === 'outdated') {
         $query->condition('field_is_decision', 1);

--- a/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/Block/AnnouncementsBlock.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/Block/AnnouncementsBlock.php
@@ -59,7 +59,6 @@ class AnnouncementsBlock extends BlockBase {
    * Set cache age to zero.
    */
   public function getCacheMaxAge() {
-    // If you need to redefine the Max Age for that block.
     return 0;
   }
 
@@ -74,7 +73,7 @@ class AnnouncementsBlock extends BlockBase {
    * Get cache tags.
    */
   public function getCacheTags() {
-    return ['meeting_video_list'];
+    return ['meeting_video_list', 'node_list:meeting'];
   }
 
   /**
@@ -90,8 +89,7 @@ class AnnouncementsBlock extends BlockBase {
     if (\Drupal::config('paatokset_helsinki_kanava.settings')->get('debug_mode')) {
       return TRUE;
     }
-
-    return strtotime('+1 day') > $time;
+    return strtotime('+1 day') > (int) $time;
   }
 
 }

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -87,8 +87,8 @@ function paatokset_policymakers_preprocess_block__policymaker_calendar(array &$v
   $variables['date'] = t('Date');
   $variables['time'] = t('Time');
   $variables['additional_info'] = t('Additional information');
-  $variables['open_motions'] = t('Open motions');
-  $variables['open_decisions'] = t('Open decisions');
+  $variables['open_motions'] = t('Open agenda');
+  $variables['open_decisions'] = t('Open decision announcement');
   $variables['open_minutes'] = t('Open minutes');
   $variables['meetings'] = $meetingService->query($params);
 

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -11,7 +11,6 @@ use Drupal\node\Entity\Node;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\image\Entity\ImageStyle;
-use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\paatokset_policymakers\Enum\PolicymakerRoutes;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -1202,11 +1202,11 @@ class PolicymakerService {
     /** @var \Drupal\paatokset_ahjo_api\Service\MeetingService $meetingService */
     $meetingService = \Drupal::service('paatokset_ahjo_meetings');
 
-    if ($document = $meetingService->getDocumentFromEntity($meeting, 'pöytäkirja', $currentLanguage)) {
+    if ($document = $meetingService->getDocumentFromEntity($meeting, 'pöytäkirja', 'fi')) {
       $pageTitle = t('Minutes');
       $documentTitle = t('Minutes publication date');
     }
-    elseif ($document = $meetingService->getDocumentFromEntity($meeting, 'esityslista', $currentLanguage)) {
+    elseif ($document = $meetingService->getDocumentFromEntity($meeting, 'esityslista', 'fi')) {
       $pageTitle = t('Agenda');
       $documentTitle = t('Agenda publication date');
     }
@@ -1215,9 +1215,9 @@ class PolicymakerService {
       $documentTitle = NULL;
     }
 
-    if ($document instanceof MediaInterface) {
-      if ($document->hasField('field_document_issued') && !$document->get('field_document_issued')->isEmpty()) {
-        $document_timestamp = strtotime($document->get('field_document_issued')->value);
+    if (!empty($document)) {
+      if (!empty($document['Issued'])) {
+        $document_timestamp = strtotime($document['Issued']);
         $publishDate = date('d.m.Y', $document_timestamp);
       }
       else {

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/TopCategoryCode.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/TopCategoryCode.php
@@ -9,7 +9,7 @@ use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
 
 /**
- * Extracts sector info from source JSON.
+ * Gets top category code from fields.
  *
  * @SearchApiProcessor(
  *   id = "top_category_id",

--- a/public/modules/custom/paatokset_search_form/src/Form/AdvancedSearchForm.php
+++ b/public/modules/custom/paatokset_search_form/src/Form/AdvancedSearchForm.php
@@ -56,7 +56,7 @@ class AdvancedSearchForm extends FormBase {
       '#attributes' => [
         'class' => ['hds-text-input__input'],
       ],
-      '#placeholder' => t('Write a search phrase, eg. park'),
+      '#placeholder' => t('Search with a Finnish keyword, eg. Viikki'),
     ];
 
     $form['container']['search-wrapper']['hds-text-input']['hds-text-input__input-wrapper']['submit'] = [

--- a/public/modules/custom/paatokset_search_form/src/Form/PaatoksetSearchForm.php
+++ b/public/modules/custom/paatokset_search_form/src/Form/PaatoksetSearchForm.php
@@ -56,7 +56,7 @@ class PaatoksetSearchForm extends FormBase {
         'class' => ['hds-text-input__input'],
       ],
       '#title' => t('Search from content'),
-      '#placeholder' => t('Write a search phrase, eg. park'),
+      '#placeholder' => t('Search with a Finnish keyword, eg. Viikki'),
     ];
 
     $form['container']['search-wrapper']['hds-text-input']['hds-text-input__input-wrapper']['submit'] = [

--- a/public/themes/custom/helfi_paatokset/templates/components/decision-voting-results.html.twig
+++ b/public/themes/custom/helfi_paatokset/templates/components/decision-voting-results.html.twig
@@ -66,8 +66,8 @@
               <thead>
                 <tr class="results-table__row">
                   <th>{{ 'Political group'|t }}</th>
-                  <th>{{ 'Jaa'|t }}</th>
-                  <th>{{ 'Ei'|t }}</th>
+                  <th>{{ 'Ayes'|t }}</th>
+                  <th>{{ 'Noes'|t }}</th>
                   <th>{{ 'Blank'|t }}</th>
                   <th>{{ 'Absent'|t }}</th>
                 </tr>


### PR DESCRIPTION
**To test**
- Checkout branch and run `make drush-cr drush-cim` (if this gives you any errors, run `make new`).
- Get data for testing. Login to the container with`make shell` and then run `drush migrate-import ahjo_decisionmakers:all && drush migrate-import ahjo_meetings:latest && drush migrate-import ahjo_decisions:latest && drush ap:update decisions 2160018e-a7a3-c116-8414-832121f00003 -v && drush ahjo-proxy:update-decisions -v && drush queue:run ahjo_api_subscriber_queue -v && drush ahjo-proxy:update-decisions --update -v`
- While the imports are running, read the code changes and make sure there's nothing unclear or things that should be refactored
- Go to https://helsinki-paatokset.docker.so/fi/admin/content/decisions and filter for swedish language decisions
- Edit some of them and check the following fields. They should be have swedish content in them:
  - Decision data -> Top category name
  - Organization data -> Organization Name
  - Organization data -> Organization level above name
  - Organization data -> Organization (JSON data should have `apireqlang=sv` in there somewhere)
- Open this decision: https://helsinki-paatokset.docker.so/en/case/hel-2022-008567?decision=2160018e-a7a3-c116-8414-832121f00003
  - Open the voting results accordion element
  - The vote categories should be in english, such as "Ayes", "Nays", "Blank" and "Absent", also in the "By political group" table
  - All of these should be translatable through UI translation: https://helsinki-paatokset.docker.so/fi/admin/config/regional/translate
  - Translate them to finnish (with whatever labels you want just to test that it works), then load the finnish version to check: https://helsinki-paatokset.docker.so/fi/asia/hel-2022-008567?paatos=2160018e-a7a3-c116-8414-832121f00003
- Open the meeting calendar: https://helsinki-paatokset.docker.so/fi/kokouskalenteri (create a landing page with this URL alias if you don't have it locally)
  - You should find the following link titles in some of the meetings (might have to scroll back to november)
    - Open agenda
    - Open decision announcement
    - Open minutes
  - All of these should be translatable through UI translation: https://helsinki-paatokset.docker.so/fi/admin/config/regional/translate
  - Translate them to finnish, then reload the page to check that it works