### PR TITLE
PP-422 & PP-443: Fixes for Ahjo API HYTE integration, Disallow indexing for all pages

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -6,5 +6,5 @@ ignored_config_entities:
   - 'system.site:page.front'
   - paatokset_ahjo_proxy.blacklist
   - 'paatokset_ahjo_api.disallowed_decisions.*'
-  - 'paatokset_ahjo_openid.settings.*'
-  - 'paatokset_ahjo_proxy.settings.*'
+  - paatokset_ahjo_openid.settings
+  - paatokset_ahjo_proxy.settings

--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -7,3 +7,4 @@ ignored_config_entities:
   - paatokset_ahjo_proxy.blacklist
   - 'paatokset_ahjo_api.disallowed_decisions.*'
   - 'paatokset_ahjo_openid.settings.*'
+  - 'paatokset_ahjo_proxy.settings.*'

--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -6,3 +6,4 @@ ignored_config_entities:
   - 'system.site:page.front'
   - paatokset_ahjo_proxy.blacklist
   - 'paatokset_ahjo_api.disallowed_decisions.*'
+  - 'paatokset_ahjo_openid.settings.*'

--- a/conf/cmi/metatag.metatag_defaults.global.yml
+++ b/conf/cmi/metatag.metatag_defaults.global.yml
@@ -8,9 +8,10 @@ id: global
 label: Global
 tags:
   canonical_url: '[current-page:url]'
-  title: '[current-page:title] | [site:name] | [site:page-title-suffix]'
+  og_image: '[site:default-og-image]'
   og_site_name: '[site:page-title-suffix]'
+  robots: 'noindex, nofollow, noarchive, nosnippet, noodp, noydir, noimageindex, notranslate'
+  title: '[current-page:title] | [site:name] | [site:page-title-suffix]'
   twitter_cards_page_url: '[current-page:url]'
   twitter_cards_title: '[current-page:title] | [site:page-title-suffix]'
   twitter_cards_type: summary_large_image
-  og_image: '[site:default-og-image]'

--- a/conf/cmi/paatokset_ahjo_proxy.settings.yml
+++ b/conf/cmi/paatokset_ahjo_proxy.settings.yml
@@ -1,0 +1,2 @@
+api_base_url: 'https://ahjo.hel.fi:9802/ahjorest/v1/'
+api_file_url: 'https://ahjo.hel.fi:9802/ahjorest/v1/content/'

--- a/public/modules/custom/paatokset_ahjo_proxy/config/install/paatokset_ahjo_proxy.settings.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/config/install/paatokset_ahjo_proxy.settings.yml
@@ -1,0 +1,2 @@
+api_base_url: 'https://ahjo.hel.fi:9802/ahjorest/v1/'
+api_file_url: 'https://ahjo.hel.fi:9802/ahjorest/v1/content/'

--- a/public/modules/custom/paatokset_ahjo_proxy/config/schema/paatokset_ahjo_proxy.schema.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/config/schema/paatokset_ahjo_proxy.schema.yml
@@ -1,0 +1,12 @@
+# Schema for the proxy setting configuration files.
+
+paatokset_ahjo_proxy.settings:
+  type: config_object
+  label: 'Default proxy settings'
+  mapping:
+    api_base_url:
+      type: string
+      label: 'API Base URL'
+    api_file_url:
+      type: string
+      label: 'API File URL'

--- a/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.links.menu.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.links.menu.yml
@@ -1,3 +1,8 @@
+paatokset_ahjo_proxy.settings:
+  title: 'Ahjo Proxy settings'
+  parent: system.admin_config_services
+  route_name: paatokset_ahjo_proxy.settings
+
 paatokset_ahjo_proxy.blacklist:
   title: 'Ahjo API entity blacklist'
   parent: system.admin_config_services

--- a/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.routing.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.routing.yml
@@ -1,3 +1,11 @@
+paatokset_ahjo_proxy.settings:
+  path: '/admin/config/services/ahjo-settings'
+  defaults:
+    _form: \Drupal\paatokset_ahjo_proxy\Form\AhjoProxySettingsForm
+    _title: 'Ahjo Proxy settings'
+  requirements:
+    _permission: 'administer site configuration'
+
 paatokset_ahjo_proxy.blacklist:
   path: '/admin/config/services/ahjo-blacklist'
   defaults:

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -2537,6 +2537,12 @@ class AhjoProxy implements ContainerInjectionInterface {
     ]);
   }
 
+  /**
+   * Get API Base URL.
+   *
+   * @return string
+   *   API Base URL from config or default (prod).
+   */
   public function getApiBaseUrl(): string {
     $config = $this->config->get('paatokset_ahjo_proxy.settings');
 
@@ -2547,6 +2553,12 @@ class AhjoProxy implements ContainerInjectionInterface {
     return 'https://ahjo.hel.fi:9802/ahjorest/v1/';
   }
 
+  /**
+   * Get API File URL.
+   *
+   * @return string
+   *   API File URL from config or default (prod).
+   */
   public function getApiFileUrl(): string {
     $config = $this->config->get('paatokset_ahjo_proxy.settings');
 

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -1813,7 +1813,7 @@ class AhjoAggregatorCommands extends DrushCommands {
           if ($data['Type'] !== 'pöytäkirja') {
             continue;
           }
-          if (strpos($data['FileURI'], 'https://ahjo.hel.fi') !== FALSE) {
+          if (strpos($data['FileURI'], 'https://ahjo.') !== FALSE) {
             $minutes_document = '⚠';
           }
           else {

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxySettingsForm.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Form/AhjoProxySettingsForm.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\paatokset_ahjo_proxy\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for AHJO Proxy.
+ *
+ * @package Drupal\paatokset_ahjo_proxy\Form
+ */
+class AhjoProxySettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    // Instantiates this form class.
+    $instance = parent::create($container);
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'paatokset_ahjo_proxy_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditableConfigNames() {
+    return [
+      'paatokset_ahjo_proxy.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('paatokset_ahjo_proxy.settings');
+
+    $form['api_base_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('API base URL'),
+      '#default_value' => $config->get('api_base_url'),
+    ];
+
+    $form['api_file_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('API file URL'),
+      '#default_value' => $config->get('api_file_url'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('paatokset_ahjo_proxy.settings')
+      ->set('api_base_url', $form_state->getValue('api_base_url'))
+      ->set('api_file_url', $form_state->getValue('api_file_url'))
+      ->save();
+  }
+
+}


### PR DESCRIPTION
**Setup**
- Checkout branch, run `make drush-cim drush-cr` (Run `make new` if you run into any issues)

**Testing robots metatag:**
- Create a few test pages. Also create a frontpage node if you don't have it locally (`/etusivu`)
- Check the pages HTML source for metatags. You should find `<meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noodp, noydir, noimageindex, notranslate" />` in the source.
- Also check that the same metatag is found on the 404 page
- Check that the search page (which is not a node) has the same metatags: https://helsinki-paatokset.docker.so/fi/asia
- Log into the container with `make shell` and import some content with `drush migrate-import ahjo_decisionmakers:all && drush migrate-import ahjo_trustees:council && drush migrate-import ahjo_meetings:latest && drush migrate-import ahjo_decisions:latest`
- Make sure the migrated content has the same robots metatag:
  - Open a few decisionmakers from the content list: https://helsinki-paatokset.docker.so/fi/admin/content/decisionmakers
  - Open a few meetings from: https://helsinki-paatokset.docker.so/admin/content/meetings (view the node then click the "Meeting minutes" link).
  - Open a few council member profiles from: https://helsinki-paatokset.docker.so/fi/admin/content/trustees
  - Open a few decisions from: https://helsinki-paatokset.docker.so/fi/admin/content/decisions

**Testing HYTE settings**
- These can't really be tested locally, but read the code changes and check that they make sense
- Edit some of these settings:
  - https://helsinki-paatokset.docker.so/fi/admin/ahjo-open-id/settings
  - https://helsinki-paatokset.docker.so/fi/admin/config/services/ahjo-settings
    - This should have some URL values already filled in instead of being blank 
  - Run `make drush-cim`. The changes you made should still be there