### PR TITLE
PP-0: Add internal proxy URL for search.

### DIFF
--- a/public/modules/custom/paatokset_search/paatokset_search.routing.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.routing.yml
@@ -31,3 +31,10 @@ paatokset_search.settings_form:
     _permission: 'access administration pages'
   options:
     _admins_route: TRUE
+
+paatokset_search.proxy:
+  path: '/search-proxy/{index}/{url}'
+  requirements:
+    _permission: 'access content'
+  defaults:
+    _controller: '\Drupal\paatokset_search\Controller\SearchProxyController::searchRequest'

--- a/public/modules/custom/paatokset_search/src/Controller/SearchController.php
+++ b/public/modules/custom/paatokset_search/src/Controller/SearchController.php
@@ -13,8 +13,15 @@ class SearchController extends ControllerBase {
    * Return markup for search page.
    */
   public function decisions() {
+    if (getenv('REACT_APP_PROXY_URL')) {
+      $proxy_url = getenv('REACT_APP_PROXY_URL');
+    }
+    else {
+      $proxy_url = getenv('REACT_APP_ELASTIC_URL');
+    }
+
     $build = [
-      '#markup' => '<div id="paatokset_search" class="paatokset-search--decisions" data-type="decisions" data-url="' . getenv('REACT_APP_ELASTIC_URL') . '"></div>',
+      '#markup' => '<div id="paatokset_search" class="paatokset-search--decisions" data-type="decisions" data-url="' . $proxy_url . '"></div>',
       '#attached' => [
         'library' => [
           'paatokset_search/paatokset-search',

--- a/public/modules/custom/paatokset_search/src/Controller/SearchProxyController.php
+++ b/public/modules/custom/paatokset_search/src/Controller/SearchProxyController.php
@@ -8,7 +8,6 @@ use Drupal\Core\Controller\ControllerBase;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\ClientInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -47,6 +46,10 @@ class SearchProxyController extends ControllerBase {
    *
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   HTTP request.
+   * @param string $index
+   *   Index to search from (paatokset_decisions or paatokset_policymakers).
+   * @param string $url
+   *   URL to search from.
    *
    * @return GuzzleHttp\Psr7\Response
    *   Response from Elastic proxy.
@@ -88,4 +91,5 @@ class SearchProxyController extends ControllerBase {
 
     return $response;
   }
+
 }

--- a/public/modules/custom/paatokset_search/src/Controller/SearchProxyController.php
+++ b/public/modules/custom/paatokset_search/src/Controller/SearchProxyController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_search\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Search proxy controller.
+ *
+ * @package Drupal\paatokset_search\Controller
+ */
+class SearchProxyController extends ControllerBase {
+
+  /**
+   * HTTP Client.
+   *
+   * @var GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(ClientInterface $http_client) {
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * Create and inject.
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('http_client'),
+    );
+  }
+
+  /**
+   * Send request to Elastic proxy.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   HTTP request.
+   *
+   * @return GuzzleHttp\Psr7\Response
+   *   Response from Elastic proxy.
+   */
+  public function searchRequest(Request $request, string $index, string $url): Response {
+    $base_url = getenv('REACT_APP_ELASTIC_URL');
+
+    if (!$base_url) {
+      throw new NotFoundHttpException();
+    }
+
+    $url = $base_url . '/' . $index . '/' . $url;
+
+    $query_string = $request->getQueryString();
+    if ($query_string) {
+      $url .= '?' . $query_string;
+    }
+
+    $method = $request->getMethod();
+    $payload = (string) $request->getContent();
+
+    /** @var \GuzzleHttp\Psr7\Response $response */
+    try {
+      $response = $this->httpClient->request($method, $url,
+      [
+        'headers' => [
+          'Content-type' => 'application/json',
+        ],
+        'http_errors' => FALSE,
+        'body' => $payload,
+      ]);
+    }
+    catch (\Exception $e) {
+    }
+
+    if (!$response) {
+      throw new NotFoundHttpException();
+    }
+
+    return $response;
+  }
+}

--- a/public/modules/custom/paatokset_search/src/Plugin/Block/PolicymakerSearchBlock.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/Block/PolicymakerSearchBlock.php
@@ -19,8 +19,15 @@ class PolicymakerSearchBlock extends BlockBase {
    * Build the attributes.
    */
   public function build() {
+    if (getenv('REACT_APP_PROXY_URL')) {
+      $proxy_url = getenv('REACT_APP_PROXY_URL');
+    }
+    else {
+      $proxy_url = getenv('REACT_APP_ELASTIC_URL');
+    }
+
     $build = [
-      '#markup' => '<div class="paatokset-search-wrapper"><div id="paatokset_search" data-type="policymakers" data-url="' . getenv('REACT_APP_ELASTIC_URL') . '"></div></div>',
+      '#markup' => '<div class="paatokset-search-wrapper"><div id="paatokset_search" data-type="policymakers" data-url="' . $proxy_url . '"></div></div>',
       '#attributes' => [
         'class' => ['policymaker-search'],
       ],

--- a/public/modules/custom/paatokset_search_form/src/Plugin/Block/SearchBlock.php
+++ b/public/modules/custom/paatokset_search_form/src/Plugin/Block/SearchBlock.php
@@ -18,8 +18,15 @@ class SearchBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
+    if (getenv('REACT_APP_PROXY_URL')) {
+      $proxy_url = getenv('REACT_APP_PROXY_URL');
+    }
+    else {
+      $proxy_url = getenv('REACT_APP_ELASTIC_URL');
+    }
+
     $build = [
-      '#markup' => '<div class="paatokset-search-wrapper"><div id="paatokset_search" data-type="frontpage" data-url="' . getenv('REACT_APP_ELASTIC_URL') . '"></div></div>',
+      '#markup' => '<div class="paatokset-search-wrapper"><div id="paatokset_search" data-type="frontpage" data-url="' . $proxy_url . '"></div></div>',
       '#attributes' => [
         'class' => ['paatokset-search--frontpage'],
       ],


### PR DESCRIPTION
Temporary solution because elasticsearch proxy is not public on prod. This passes the requests through Drupal to the proxy.

**To test**
- Checkout branch, run `make composer-install drush-cr`
- Make sure your .env.local file contains these: 
```
REACT_APP_ELASTIC_URL=https://paatokset-proxy-test.agw.arodevtest.hel.fi
REACT_APP_PROXY_URL=https://helsinki-paatokset.docker.so/fi/search-proxy
```
- Run `make up`
- Go to https://helsinki-paatokset.docker.so/fi/etusivu (create the page if it doesn't exist)
  - Make sure the autocomplete suggestions work
- Go to https://helsinki-paatokset.docker.so/fi/asia
  - Try out some searches and make sure the application works as intended
  - Open the network panel in your developer toolbar. All search related requests should go to https://helsinki-paatokset.docker.so/fi/search-proxy instead of the elastic proxy URL.
- Go to https://helsinki-paatokset.docker.so/fi/paattajat
  - Try out some searches and make sure the application works as intended
  - Again, check that the requests to to the local URL instead of the test elastic domain
- Edit your `.env.local` file and remove the `REACT_APP_PROXY_URL` line, then run `make up`.
  - Test the search pages again and make sure they work  
  - Check the network panel. This time the requests should go to  https://paatokset-proxy-test.agw.arodevtest.hel.fi instead of the local URL
- Read code changes, see if there's anything weird that should be fixed