### PR TITLE
PP-462: Trigger meeting motion regeneration after update

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoCallbackQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoCallbackQueueWorker.php
@@ -97,6 +97,11 @@ class AhjoCallbackQueueWorker extends QueueWorkerBase implements ContainerFactor
       ));
     }
 
+    // Mark meeting motions to be regenerated after updates.
+    if ($item['id'] === 'meetings' && $operation === 'Updated') {
+      $this->ahjoProxy->markMeetingMotionsAsUnprocessed($entity);
+    }
+
     $this->logger->info('Migrated @id from @queue as @operation.', [
       '@queue' => $item['id'],
       '@operation' => $operation,

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1821,12 +1821,6 @@ class AhjoProxy implements ContainerInjectionInterface {
       return;
     }
 
-    // If node is not new and we're not updating everything, skip item.
-    if (!$data['update_all'] && !$node->isNew()) {
-      $context['results']['skipped'][] = $data['title'];
-      return;
-    }
-
     // Get record from endpoint, unless we're only using local data.
     $record_content = [];
     if ($data['endpoint']) {


### PR DESCRIPTION
**To test**
- Checkout branch, run `make drush-cim drush-cr` (if you get errors, just run `make new`)
- Go to https://paatokset.hel.fi/fi/kokouskalenteri and find an upcoming meeting with a published agenda (has a "Avaa esityslista" link).
  - Open the meeting and copy its ID: paatokset.hel.fi/fi/paattajat/kaupunginvaltuusto/asiakirjat/**0290020231**
- SSH into the container with `make shell`
- Import the meeting locally: `drush ap:update meetings 0290020231 -v` (replace the meeting ID with the one you found).
- Run `drush ap:gm -v` to process the motions. The message should say that at least one node was found and it should process multiple items
- Check https://helsinki-paatokset.docker.so/fi/admin/content/decisions?field_is_decision_value=0 to see that the motions were actually created
- Run `drush ap:gm -v` again. This should end with "Nothing to import".
- Send a post request to https://helsinki-paatokset.docker.so/fi/ahjo_api/subscriber/meetings with the following body. Again, replace the ID with your meeting ID.
```
{
    "updatetype": "Updated",
    "id": "0290020231"
}
```
- You should get a 200 OK response with additional information such as the "item_id".
- Run `drush ac:l` to confirm that the callback was  added to the queue
- Run the queue with `drush queue:run ahjo_api_subscriber_queue -v`
- Now run `drush ap:gm -v` again. It should re-import all the motions
- Check https://helsinki-paatokset.docker.so/fi/admin/content/decisions?field_is_decision_value=0 again to make sure the existing motions were updated and that the script didn't create any duplicates (note that language versions of the same motion have the same unique ID, so it's fine even if the unique ID field is the same but the language is different).
- Run `drush ap:gm -v` a final time, which should just output "Nothign to import". This is just to check that the meeting was correctly marked as processed again.
