### PR TITLE
PP-458: Misc fixes

### DIFF
--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerLazyBuilder.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerLazyBuilder.php
@@ -196,7 +196,7 @@ class PolicymakerLazyBuilder implements TrustedCallbackInterface {
 
     // Sort by titles.
     usort($accordion_contents['viranhaltijat']['items'], function ($a, $b) {
-      return strnatcmp($a['title'], $b['title']);
+      return strnatcmp($a['sort_title'], $b['sort_title']);
     });
     usort($accordion_contents['trustee']['items'], function ($a, $b) {
       return strnatcmp($a['title'], $b['title']);
@@ -333,6 +333,7 @@ class PolicymakerLazyBuilder implements TrustedCallbackInterface {
 
       $filtered[] = [
         'title' => $node->get('title')->value,
+        'sort_title' => $node->get('field_dm_org_name')->value . ' ' . $node->get('title')->value,
         'ahjo_title' => $node->get('field_ahjo_title')->value,
         'link' => $this->policymakerService->getPolicymakerRoute($node, $this->currentLanguage),
         'organization_type' => $node->get('field_organization_type')->value,

--- a/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
+++ b/public/themes/custom/helfi_paatokset/helfi_paatokset.theme
@@ -491,4 +491,7 @@ function helfi_paatokset_preprocess_page(&$variables) {
 function helfi_paatokset_preprocess_node__article(&$variables) {
   $node = $variables['node'];
   $variables['published_at'] = $node->get('created')->value;
+  if ($node->hasField('unpublish_on') && !$node->get('unpublish_on')->isEmpty()) {
+    $variables['scheduled_unpublish_date'] = $node->get('unpublish_on')->value;
+  }
 }

--- a/public/themes/custom/helfi_paatokset/templates/content/node--article--full.html.twig
+++ b/public/themes/custom/helfi_paatokset/templates/content/node--article--full.html.twig
@@ -20,11 +20,18 @@
     {# Created date and modified date #}
     {% if published_at %}
       <div class="content-date">
-        {% set html_published_at = published_at|format_date('custom', 'Y-m-d') ~ 'T' ~ published_at|format_date('custom', 'H:i') %}
         <time datetime="{{ html_published_at }}" class="content-date__datetime content-date__datetime--published">
           <span class="visually-hidden">{{ 'Published'|t({}, {'context': 'The helper text before the node published timestamp'}) }}</span>
           {{ published_at|format_date('publication_date_format') }}
         </time>
+      </div>
+    {% endif %}
+    {% if scheduled_unpublish_date %}
+      <div class="warning-label">
+        <div class="warning-label__container">
+          {% include '@hdbt/misc/icon.twig' with {icon: 'alert-circle', label: 'This publication is public until @scheduled_unpublish_date'|t({'@scheduled_unpublish_date': scheduled_unpublish_date|format_date('publication_date_format')}) } %}
+          <span>{{ 'This publication is public until @scheduled_unpublish_date'|t({'@scheduled_unpublish_date': scheduled_unpublish_date|format_date('publication_date_format') }) }}</span>
+        </div>
       </div>
     {% endif %}
 


### PR DESCRIPTION
This MR fixes some content sorting and adds a scheduled unpublish message to articles.

**To test**
- Checkout branch, run `make drush-cr` (or `make new').
- Run the following commands to import content for testing:
```
drush mim ahjo_decisionmakers:all --update
drush ap:update meetings 02900202021 -v
drush ap:update meetings 02900202122 -v
drush ap:update meetings 02900202221 -v
drush ap:update meetings 02900202212 -v
```
- Add some minutes of discussion PDF files: https://helsinki-paatokset.docker.so/fi/media/add/minutes_of_the_discussion
  - Add one for each of the Kaupunginvaltuusto meetings that were imported above
  - Add them in a random order (for example: 2018, 2022, 2021) so we can test that the sorting works
- Go to: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/keskustelupoytakirjat
  - The years documents should be sorted in a descending order (compare to https://paatokset.hel.fi/fi/paattajat/kaupunginvaltuusto/keskustelupöytäkirjat to see how it is sorted wrong on production)
- Check the decisionmakers list: https://helsinki-paatokset.docker.so/fi/paattajat
  - The office holder lists inside the accordions should be sorted by the organisation name and not just the title. For example, not all "Apulaisylilääkäri" office holders are in a row. Compare to https://paatokset.hel.fi/fi/paattajat
- Add a few articles: https://helsinki-paatokset.docker.so/fi/node/add/article
  - Add a scheduled unpublish date to some of them. After saving the node, the date should be visible in a yellow info box below the publication date
  - The info box should not be visible on articles that are not scheduled for unpublication, or for articles where the scheduling was added and then removed