### PR TITLE
PP-385: PDF-list component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
         "league/csv": "^9.8",
-        "paatokset/paatokset_search": "1.0.20"
+        "paatokset/paatokset_search": "1.0.21"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -131,9 +131,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "1.0.20",
+                "version": "1.0.21",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.20/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.21/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "713c03895280a3948ebeb290457943e3",
+    "content-hash": "5bb74d905d0cee438a735e19d8122252",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9059,10 +9059,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "1.0.20",
+            "version": "1.0.21",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.20/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.21/paatokset_search.zip"
             },
             "type": "library"
         },
@@ -16592,5 +16592,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/conf/cmi/core.entity_form_display.media.pdf_minutes_of_discussion.default.yml
+++ b/conf/cmi/core.entity_form_display.media.pdf_minutes_of_discussion.default.yml
@@ -11,7 +11,6 @@ dependencies:
     - datetime
     - file
     - path
-    - select2
 id: media.pdf_minutes_of_discussion.default
 targetEntityType: media
 bundle: pdf_minutes_of_discussion
@@ -31,14 +30,10 @@ content:
       progress_indicator: throbber
     third_party_settings: {  }
   field_pdf_category:
-    type: select2_entity_reference
+    type: options_select
     weight: 2
     region: content
-    settings:
-      width: 100%
-      autocomplete: true
-      match_operator: CONTAINS
-      match_limit: 10
+    settings: {  }
     third_party_settings: {  }
   field_pdf_date:
     type: datetime_default

--- a/conf/cmi/core.entity_form_display.media.pdf_minutes_of_discussion.default.yml
+++ b/conf/cmi/core.entity_form_display.media.pdf_minutes_of_discussion.default.yml
@@ -1,0 +1,93 @@
+uuid: 44551ef4-f0ed-44f1-9f4d-a333667f0d38
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.media.pdf_minutes_of_discussion.field_document
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_category
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_date
+    - media.type.pdf_minutes_of_discussion
+  module:
+    - datetime
+    - file
+    - path
+    - select2
+id: media.pdf_minutes_of_discussion.default
+targetEntityType: media
+bundle: pdf_minutes_of_discussion
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_document:
+    type: file_generic
+    weight: 1
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+  field_pdf_category:
+    type: select2_entity_reference
+    weight: 2
+    region: content
+    settings:
+      width: 100%
+      autocomplete: true
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
+  field_pdf_date:
+    type: datetime_default
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 4
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 9
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  translation:
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  replace_file: true

--- a/conf/cmi/core.entity_form_display.media.pdf_minutes_of_discussion.media_library.yml
+++ b/conf/cmi/core.entity_form_display.media.pdf_minutes_of_discussion.media_library.yml
@@ -1,0 +1,38 @@
+uuid: cc647751-df31-4306-98f0-af12a1107523
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.media.media_library
+    - field.field.media.pdf_minutes_of_discussion.field_document
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_category
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_date
+    - media.type.pdf_minutes_of_discussion
+id: media.pdf_minutes_of_discussion.media_library
+targetEntityType: media
+bundle: pdf_minutes_of_discussion
+mode: media_library
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_document: true
+  field_pdf_category: true
+  field_pdf_date: true
+  langcode: true
+  path: true
+  replace_file: true
+  status: true
+  uid: true

--- a/conf/cmi/core.entity_form_display.paragraph.pdf_listing.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.pdf_listing.default.yml
@@ -1,0 +1,27 @@
+uuid: 1e3cdfc9-646a-4850-9a63-be36c91df8e2
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.pdf_listing.field_pdf_category
+    - paragraphs.paragraphs_type.pdf_listing
+  module:
+    - select2
+id: paragraph.pdf_listing.default
+targetEntityType: paragraph
+bundle: pdf_listing
+mode: default
+content:
+  field_pdf_category:
+    type: select2_entity_reference
+    weight: 0
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/conf/cmi/core.entity_view_display.media.pdf_minutes_of_discussion.default.yml
+++ b/conf/cmi/core.entity_view_display.media.pdf_minutes_of_discussion.default.yml
@@ -1,0 +1,49 @@
+uuid: 587f2011-b748-4ded-a3aa-a5d5da0391b9
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.media.pdf_minutes_of_discussion.field_document
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_category
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_date
+    - media.type.pdf_minutes_of_discussion
+  module:
+    - datetime
+    - file
+id: media.pdf_minutes_of_discussion.default
+targetEntityType: media
+bundle: pdf_minutes_of_discussion
+mode: default
+content:
+  field_document:
+    type: file_default
+    label: visually_hidden
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_pdf_category:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_pdf_date:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/conf/cmi/core.entity_view_display.media.pdf_minutes_of_discussion.media_library.yml
+++ b/conf/cmi/core.entity_view_display.media.pdf_minutes_of_discussion.media_library.yml
@@ -1,0 +1,38 @@
+uuid: 8f6b4f50-58b3-4943-a928-bc371d8f0fc4
+langcode: fi
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.media_library
+    - field.field.media.pdf_minutes_of_discussion.field_document
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_category
+    - field.field.media.pdf_minutes_of_discussion.field_pdf_date
+    - image.style.medium
+    - media.type.pdf_minutes_of_discussion
+  module:
+    - image
+id: media.pdf_minutes_of_discussion.media_library
+targetEntityType: media
+bundle: pdf_minutes_of_discussion
+mode: media_library
+content:
+  thumbnail:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_document: true
+  field_pdf_category: true
+  field_pdf_date: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  uid: true

--- a/conf/cmi/core.entity_view_display.paragraph.pdf_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.pdf_listing.default.yml
@@ -1,0 +1,15 @@
+uuid: f2ec5e8b-c1d4-4162-a2f3-757924648024
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.pdf_listing.field_pdf_category
+    - paragraphs.paragraphs_type.pdf_listing
+id: paragraph.pdf_listing.default
+targetEntityType: paragraph
+bundle: pdf_listing
+mode: default
+content: {  }
+hidden:
+  field_pdf_category: true
+  search_api_excerpt: true

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -107,6 +107,7 @@ module:
   paatokset_helsinki_kanava: 0
   paatokset_lang_switcher: 0
   paatokset_news_importer: 0
+  paatokset_pdf_listing: 0
   paatokset_policymakers: 0
   paatokset_search: 0
   paatokset_search_form: 0

--- a/conf/cmi/field.field.media.pdf_minutes_of_discussion.field_document.yml
+++ b/conf/cmi/field.field.media.pdf_minutes_of_discussion.field_document.yml
@@ -1,0 +1,27 @@
+uuid: 931d93c0-efd8-4396-b3a7-7d0a67fc3914
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_document
+    - media.type.pdf_minutes_of_discussion
+  module:
+    - file
+id: media.pdf_minutes_of_discussion.field_document
+field_name: field_document
+entity_type: media
+bundle: pdf_minutes_of_discussion
+label: Tiedosto
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: pdf-minutes
+  file_extensions: pdf
+  max_filesize: ''
+  description_field: false
+field_type: file

--- a/conf/cmi/field.field.media.pdf_minutes_of_discussion.field_pdf_category.yml
+++ b/conf/cmi/field.field.media.pdf_minutes_of_discussion.field_pdf_category.yml
@@ -1,0 +1,29 @@
+uuid: 74d3951c-62db-4504-bba0-609fe6e08fa7
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_pdf_category
+    - media.type.pdf_minutes_of_discussion
+    - taxonomy.vocabulary.pdf_minutes_category
+id: media.pdf_minutes_of_discussion.field_pdf_category
+field_name: field_pdf_category
+entity_type: media
+bundle: pdf_minutes_of_discussion
+label: Category
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      pdf_minutes_category: pdf_minutes_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.media.pdf_minutes_of_discussion.field_pdf_date.yml
+++ b/conf/cmi/field.field.media.pdf_minutes_of_discussion.field_pdf_date.yml
@@ -1,0 +1,21 @@
+uuid: 7d113152-b565-4797-a54d-ab8d14a9d4f1
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_pdf_date
+    - media.type.pdf_minutes_of_discussion
+  module:
+    - datetime
+id: media.pdf_minutes_of_discussion.field_pdf_date
+field_name: field_pdf_date
+entity_type: media
+bundle: pdf_minutes_of_discussion
+label: Date
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.node.landing_page.field_content.yml
+++ b/conf/cmi/field.field.node.landing_page.field_content.yml
@@ -20,6 +20,7 @@ dependencies:
     - paragraphs.paragraphs_type.meetings_calendar
     - paragraphs.paragraphs_type.news_liftups
     - paragraphs.paragraphs_type.news_list
+    - paragraphs.paragraphs_type.pdf_listing
     - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.popular_services
     - paragraphs.paragraphs_type.remote_video
@@ -54,15 +55,16 @@ settings:
       image: image
       text: text
       custom_content_links: custom_content_links
+      target_group_links: target_group_links
       chart: chart
       meetings_calendar: meetings_calendar
-      news_liftups: news_liftups
-      remote_video: remote_video
-      phasing: phasing
-      popular_services: popular_services
-      target_group_links: target_group_links
       event_list: event_list
+      news_liftups: news_liftups
       news_list: news_list
+      remote_video: remote_video
+      popular_services: popular_services
+      phasing: phasing
+      pdf_listing: pdf_listing
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -80,9 +82,18 @@ settings:
       columns:
         weight: -27
         enabled: true
+      contact_card:
+        weight: 39
+        enabled: false
+      contact_card_listing:
+        weight: 40
+        enabled: false
       content_cards:
         weight: -23
         enabled: true
+      content_liftup:
+        weight: 42
+        enabled: false
       custom_content_links:
         weight: 21
         enabled: true
@@ -122,11 +133,17 @@ settings:
       news_list:
         weight: 30
         enabled: true
+      pdf_listing:
+        weight: 56
+        enabled: true
       phasing:
         weight: 50
         enabled: true
       phasing_item:
         weight: 30
+        enabled: false
+      popular_service_item:
+        weight: 60
         enabled: false
       popular_services:
         weight: 42
@@ -134,6 +151,12 @@ settings:
       remote_video:
         weight: 37
         enabled: true
+      sidebar_text:
+        weight: 62
+        enabled: false
+      social_media_link:
+        weight: 63
+        enabled: false
       target_group_link_item:
         weight: 45
         enabled: false

--- a/conf/cmi/field.field.node.page.field_content.yml
+++ b/conf/cmi/field.field.node.page.field_content.yml
@@ -21,6 +21,7 @@ dependencies:
     - paragraphs.paragraphs_type.meetings_calendar
     - paragraphs.paragraphs_type.news_liftups
     - paragraphs.paragraphs_type.news_list
+    - paragraphs.paragraphs_type.pdf_listing
     - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
@@ -54,13 +55,14 @@ settings:
       chart: chart
       custom_content_links: custom_content_links
       content_liftup: content_liftup
+      event_list: event_list
+      news_list: news_list
+      contact_card_listing: contact_card_listing
       meetings_calendar: meetings_calendar
       news_liftups: news_liftups
       remote_video: remote_video
-      contact_card_listing: contact_card_listing
       phasing: phasing
-      event_list: event_list
-      news_list: news_list
+      pdf_listing: pdf_listing
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -129,11 +131,20 @@ settings:
       news_list:
         weight: 30
         enabled: true
+      pdf_listing:
+        weight: 56
+        enabled: true
       phasing:
         weight: 50
         enabled: true
       phasing_item:
         weight: 30
+        enabled: false
+      popular_service_item:
+        weight: 60
+        enabled: false
+      popular_services:
+        weight: 59
         enabled: false
       remote_video:
         weight: 37
@@ -143,6 +154,12 @@ settings:
         enabled: false
       social_media_link:
         weight: 46
+        enabled: false
+      target_group_link_item:
+        weight: 65
+        enabled: false
+      target_group_links:
+        weight: 64
         enabled: false
       text:
         weight: -27

--- a/conf/cmi/field.field.node.page.field_lower_content.yml
+++ b/conf/cmi/field.field.node.page.field_lower_content.yml
@@ -21,6 +21,7 @@ dependencies:
     - paragraphs.paragraphs_type.meetings_calendar
     - paragraphs.paragraphs_type.news_liftups
     - paragraphs.paragraphs_type.news_list
+    - paragraphs.paragraphs_type.pdf_listing
     - paragraphs.paragraphs_type.phasing
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
@@ -51,14 +52,15 @@ settings:
       liftup_with_image: liftup_with_image
       chart: chart
       custom_content_links: custom_content_links
+      event_list: event_list
+      news_list: news_list
+      contact_card_listing: contact_card_listing
       remote_video: remote_video
       map: map
       meetings_calendar: meetings_calendar
       news_liftups: news_liftups
-      contact_card_listing: contact_card_listing
       phasing: phasing
-      event_list: event_list
-      news_list: news_list
+      pdf_listing: pdf_listing
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -127,11 +129,20 @@ settings:
       news_list:
         weight: 30
         enabled: true
+      pdf_listing:
+        weight: 56
+        enabled: true
       phasing:
         weight: 50
         enabled: true
       phasing_item:
         weight: 30
+        enabled: false
+      popular_service_item:
+        weight: 60
+        enabled: false
+      popular_services:
+        weight: 59
         enabled: false
       remote_video:
         weight: 32
@@ -141,6 +152,12 @@ settings:
         enabled: false
       social_media_link:
         weight: 46
+        enabled: false
+      target_group_link_item:
+        weight: 65
+        enabled: false
+      target_group_links:
+        weight: 64
         enabled: false
       text:
         weight: -29

--- a/conf/cmi/field.field.paragraph.pdf_listing.field_pdf_category.yml
+++ b/conf/cmi/field.field.paragraph.pdf_listing.field_pdf_category.yml
@@ -1,0 +1,29 @@
+uuid: a0535615-85a8-4541-bfbb-e9b6c17f7284
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_pdf_category
+    - paragraphs.paragraphs_type.pdf_listing
+    - taxonomy.vocabulary.pdf_minutes_category
+id: paragraph.pdf_listing.field_pdf_category
+field_name: field_pdf_category
+entity_type: paragraph
+bundle: pdf_listing
+label: 'PDF Minutes of Discussion'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      pdf_minutes_category: pdf_minutes_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.storage.media.field_pdf_category.yml
+++ b/conf/cmi/field.storage.media.field_pdf_category.yml
@@ -1,0 +1,20 @@
+uuid: 749dddd5-d55a-42d6-ac39-4e86a109379f
+langcode: fi
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: media.field_pdf_category
+field_name: field_pdf_category
+entity_type: media
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.media.field_pdf_date.yml
+++ b/conf/cmi/field.storage.media.field_pdf_date.yml
@@ -1,0 +1,20 @@
+uuid: b05b9d49-2104-44fd-8506-ae7316ea6e90
+langcode: fi
+status: true
+dependencies:
+  module:
+    - datetime
+    - media
+id: media.field_pdf_date
+field_name: field_pdf_date
+entity_type: media
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.paragraph.field_pdf_category.yml
+++ b/conf/cmi/field.storage.paragraph.field_pdf_category.yml
@@ -1,0 +1,20 @@
+uuid: 6bcda2cc-3ed8-45db-9ed0-21d6623c369d
+langcode: fi
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_pdf_category
+field_name: field_pdf_category
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.media.pdf_minutes_of_discussion.yml
+++ b/conf/cmi/language.content_settings.media.pdf_minutes_of_discussion.yml
@@ -1,0 +1,16 @@
+uuid: bcc70323-8935-4f53-bf9c-ac9d6e959d11
+langcode: fi
+status: true
+dependencies:
+  config:
+    - media.type.pdf_minutes_of_discussion
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: media.pdf_minutes_of_discussion
+target_entity_type_id: media
+target_bundle: pdf_minutes_of_discussion
+default_langcode: current_interface
+language_alterable: true

--- a/conf/cmi/language.content_settings.taxonomy_term.pdf_minutes_category.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.pdf_minutes_category.yml
@@ -1,0 +1,16 @@
+uuid: 09251383-da6e-4e3f-97e7-b6c7fdb033a3
+langcode: fi
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.pdf_minutes_category
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.pdf_minutes_category
+target_entity_type_id: taxonomy_term
+target_bundle: pdf_minutes_category
+default_langcode: fi
+language_alterable: false

--- a/conf/cmi/language/fi/taxonomy.vocabulary.pdf_minutes_category.yml
+++ b/conf/cmi/language/fi/taxonomy.vocabulary.pdf_minutes_category.yml
@@ -1,0 +1,1 @@
+name: PDF-pöytäkirjalistat

--- a/conf/cmi/media.type.minutes_of_the_discussion.yml
+++ b/conf/cmi/media.type.minutes_of_the_discussion.yml
@@ -1,10 +1,15 @@
 uuid: 4514dfa4-055e-4e0b-8b4e-5f926f2f6790
 langcode: fi
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - crop
+third_party_settings:
+  crop:
+    image_field: _none
 id: minutes_of_the_discussion
 label: 'Minutes of the discussion'
-description: ''
+description: 'Minutes of discussion for City council meetings'
 source: file
 queue_thumbnail_downloads: false
 new_revision: true

--- a/conf/cmi/media.type.pdf_minutes_of_discussion.yml
+++ b/conf/cmi/media.type.pdf_minutes_of_discussion.yml
@@ -1,0 +1,13 @@
+uuid: 11232e2a-496b-4a57-a5ff-e5db1ce74388
+langcode: fi
+status: true
+dependencies: {  }
+id: pdf_minutes_of_discussion
+label: 'PDF Minutes of Discussion'
+description: 'Minutes of discussion document stored outside of Ahjo'
+source: file
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_document
+field_map: {  }

--- a/conf/cmi/paragraphs.paragraphs_type.pdf_listing.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.pdf_listing.yml
@@ -1,0 +1,10 @@
+uuid: d33efc3e-fc29-4b9a-820c-a0bf313f083a
+langcode: fi
+status: true
+dependencies: {  }
+id: pdf_listing
+label: 'PDF listing'
+icon_uuid: null
+icon_default: null
+description: 'List PDF minutes of discussion based on category.'
+behavior_plugins: {  }

--- a/conf/cmi/taxonomy.vocabulary.pdf_categories.yml
+++ b/conf/cmi/taxonomy.vocabulary.pdf_categories.yml
@@ -2,7 +2,7 @@ uuid: 7f7c132d-2e7d-4b50-b9de-ee8695404056
 langcode: fi
 status: true
 dependencies: {  }
-name: 'Pdf kategoriat'
+name: 'Interest statement category'
 vid: pdf_categories
 description: ''
 weight: 0

--- a/conf/cmi/taxonomy.vocabulary.pdf_minutes_category.yml
+++ b/conf/cmi/taxonomy.vocabulary.pdf_minutes_category.yml
@@ -1,0 +1,8 @@
+uuid: 9a3ece14-def5-4e5c-91ab-2af6b6bd03d6
+langcode: fi
+status: true
+dependencies: {  }
+name: 'PDF minutes category'
+vid: pdf_minutes_category
+description: ''
+weight: 0

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -28,6 +28,7 @@ dependencies:
     - node.type.trustee
     - taxonomy.vocabulary.keywords
     - taxonomy.vocabulary.pdf_categories
+    - taxonomy.vocabulary.pdf_minutes_category
   module:
     - block
     - config_translation
@@ -127,6 +128,7 @@ permissions:
   - 'create soundcloud media'
   - 'create terms in keywords'
   - 'create terms in pdf_categories'
+  - 'create terms in pdf_minutes_category'
   - 'create trustee content'
   - 'create url aliases'
   - 'delete all revisions'
@@ -175,6 +177,7 @@ permissions:
   - 'delete remote entities'
   - 'delete terms in keywords'
   - 'delete terms in pdf_categories'
+  - 'delete terms in pdf_minutes_category'
   - 'delete trustee revisions'
   - 'edit any article content'
   - 'edit any case content'
@@ -218,6 +221,7 @@ permissions:
   - 'edit remote entities'
   - 'edit terms in keywords'
   - 'edit terms in pdf_categories'
+  - 'edit terms in pdf_minutes_category'
   - 'revert all revisions'
   - 'revert article revisions'
   - 'revert case revisions'
@@ -251,6 +255,7 @@ permissions:
   - 'translate menu_link_content'
   - 'translate page node'
   - 'translate pdf_categories taxonomy_term'
+  - 'translate pdf_minutes_category taxonomy_term'
   - 'translate policymaker node'
   - 'translate remote_video media'
   - 'translate soundcloud media'

--- a/conf/cmi/user.role.editor.yml
+++ b/conf/cmi/user.role.editor.yml
@@ -25,6 +25,7 @@ dependencies:
     - node.type.trustee
     - taxonomy.vocabulary.keywords
     - taxonomy.vocabulary.pdf_categories
+    - taxonomy.vocabulary.pdf_minutes_category
   module:
     - content_translation
     - editoria11y
@@ -87,6 +88,7 @@ permissions:
   - 'create soundcloud media'
   - 'create terms in keywords'
   - 'create terms in pdf_categories'
+  - 'create terms in pdf_minutes_category'
   - 'create url aliases'
   - 'delete any article content'
   - 'delete any file media'
@@ -127,6 +129,7 @@ permissions:
   - 'delete remote entities'
   - 'delete terms in keywords'
   - 'delete terms in pdf_categories'
+  - 'delete terms in pdf_minutes_category'
   - 'edit any article content'
   - 'edit any declaration_of_affiliation media'
   - 'edit any file media'
@@ -163,6 +166,7 @@ permissions:
   - 'edit remote entities'
   - 'edit terms in keywords'
   - 'edit terms in pdf_categories'
+  - 'edit terms in pdf_minutes_category'
   - 'revert article revisions'
   - 'revert imported_article revisions'
   - 'revert landing_page revisions'
@@ -188,6 +192,7 @@ permissions:
   - 'translate menu_link_content'
   - 'translate page node'
   - 'translate pdf_categories taxonomy_term'
+  - 'translate pdf_minutes_category taxonomy_term'
   - 'translate policymaker node'
   - 'translate remote_video media'
   - 'translate soundcloud media'

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1903,7 +1903,7 @@ class AhjoProxy implements ContainerInjectionInterface {
       $top_category = NULL;
     }
 
-    // Get attachments from agenda item endpoint.
+    // Get data from agenda item endpoint.
     $attachments_json = [];
     $agenda_content = [];
     if ($data['agenda_endpoint']) {
@@ -1915,9 +1915,20 @@ class AhjoProxy implements ContainerInjectionInterface {
       $agenda_content = $agenda_content['agenda_item'];
     }
 
-    if (!empty($agenda_content) && !empty($agenda_content['Attachments'])) {
-      foreach ($agenda_content['Attachments'] as $attachment) {
-        $attachments_json[] = json_encode($attachment);
+    if (!empty($agenda_content)) {
+      if (!empty($agenda_content['Attachments'])) {
+        foreach ($agenda_content['Attachments'] as $attachment) {
+          $attachments_json[] = json_encode($attachment);
+        }
+      }
+      if (!empty($agenda_content['DecisionHistoryHTML'])) {
+        $node->set('field_decision_history', [
+          'value' => $agenda_content['DecisionHistoryHTML'],
+          'format' => 'plain_text',
+        ]);
+      }
+      if (!empty($agenda_content['DecisionHistoryPDF'])) {
+        $node->set('field_decision_history_pdf', json_encode($agenda_content['DecisionHistoryPDF']));
       }
     }
 

--- a/public/modules/custom/paatokset_pdf_listing/paatokset_pdf_listing.info.yml
+++ b/public/modules/custom/paatokset_pdf_listing/paatokset_pdf_listing.info.yml
@@ -1,0 +1,4 @@
+name: Paatokset PDF listing component
+type: module
+package: custom
+core_version_requirement: ^9

--- a/public/modules/custom/paatokset_pdf_listing/paatokset_pdf_listing.module
+++ b/public/modules/custom/paatokset_pdf_listing/paatokset_pdf_listing.module
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for PDF listing module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\media\Entity\Media;
+use Drupal\file\Entity\File;
+
+/**
+ * Implements hook_theme().
+ */
+function paatokset_pdf_listing_theme($existing, $type, $theme, $path) {
+  return [
+    'paragraph__pdf_listing' => [
+      'variables' => [
+        'years' => [],
+        'documents' => [],
+      ],
+      'render element' => 'elements',
+      'template' => 'paragraph--pdf-listing',
+      'path' => $path . '/templates/paragraph',
+      'base hook' => 'paragraph',
+    ],
+  ];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function paatokset_pdf_listing_preprocess_paragraph__pdf_listing(&$variables) {
+  if (empty($variables['paragraph']) || !$variables['paragraph'] instanceof Paragraph) {
+    return;
+  }
+  $paragraph = $variables['paragraph'];
+
+  if (!$paragraph->hasField('field_pdf_category')) {
+    return;
+  }
+
+  $tids = [];
+  foreach ($paragraph->get('field_pdf_category') as $field) {
+    $tids[] = $field->target_id;
+  }
+
+  $query = \Drupal::entityQuery('media')
+    ->condition('bundle', 'pdf_minutes_of_discussion')
+    ->condition('status', 1)
+    ->sort('field_pdf_date', 'DESC')
+    ->sort('name', 'ASC')
+    ->latestRevision();
+
+  if (!empty($tids)) {
+    $query->condition('field_pdf_category', $tids, 'IN');
+  }
+
+  $ids = $query->execute();
+
+  $entities = Media::loadMultiple($ids);
+  $documents = [];
+  foreach ($entities as $entity) {
+    if (!$entity->hasField('field_pdf_date') || $entity->get('field_pdf_date')->isEmpty()) {
+      continue;
+    }
+
+    $timestamp = $entity->get('field_pdf_date')->date->getTimeStamp();
+    $year = date('Y', $timestamp);
+    $title = $entity->label();
+    $date = date('d.m.Y', $timestamp);
+    $download_link = NULL;
+    if ($entity->get('field_document')->target_id) {
+      $file_id = $entity->get('field_document')->target_id;
+      $download_link = \Drupal::service('file_url_generator')->generateAbsoluteString(File::load($file_id)->getFileUri());
+    }
+
+    if (!$download_link) {
+      continue;
+    }
+
+    $documents[$year][] = [
+      'title' => $title,
+      'date' => $date,
+      'year' => $year,
+      'link' => $download_link,
+    ];
+  }
+
+  $variables['elements']['#cache']['tags'][] = 'media_list:pdf_minutes_of_discussion';
+  $variables['years'] = array_keys($documents);
+  $variables['documents'] = $documents;
+}

--- a/public/modules/custom/paatokset_pdf_listing/templates/paragraph/paragraph--pdf-listing.html.twig
+++ b/public/modules/custom/paatokset_pdf_listing/templates/paragraph/paragraph--pdf-listing.html.twig
@@ -1,0 +1,112 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{%
+  set classes = [
+    'pdf-listing',
+  ]
+%}
+
+{% block paragraph %}
+{% if documents %}
+<div{{ attributes.addClass(classes) }}>
+  {% if (years is not empty ) %}
+    <div class="paatokset__decision-tree-container">
+      <div class="decision-tree__title">
+        <span>{{ 'Select year' |trans }}</span>
+      </div>
+      {% embed "@hdbt/misc/container.twig" with {container_element: 'accordion'} %}
+        {% block container_content %}
+          <div class="accordion__wrapper handorgel">
+            <div class="accordion-item__content handorgel__content">
+              <div class="accordion-item__content__inner handorgel__content__inner">
+                <ul class="menu">
+                  {% for year in years %}
+                    {% set item_attributes = create_attribute() %}
+                    {%
+                      set item_classes = [
+                        'item',
+                        loop.index == 1 ? 'selected'
+                      ]
+                    %}
+                    <li{{ item_attributes.addClass(item_classes) }}>
+                      {% if loop.index == 1 %}
+                        <input type="button" id="yearSelection_{{ year }}" value="{{ year }}" aria-pressed="true"/>
+                      {% else %}
+                        <input type="button" id="yearSelection_{{ year }}" value="{{ year }}" aria-pressed="false"/>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </div>
+          </div>
+        {% endblock %}
+      {% endembed %}
+      {% for year, files in documents %}
+        {% set document_container_attributes = create_attribute() %}
+        {%
+          set document_container_classes = [
+            'policymakers-documents',
+            loop.index == 1 ? 'selected-year'
+          ]
+        %}
+
+        <div{{ document_container_attributes.addClass(document_container_classes).setAttribute('value', year) }}>
+          {% for file in files %}
+            <a href="{{ file.link }}" class="policymaker-list-item policymaker-list-item--document" role="region" aria-label="{{ 'Document'|t }}">
+              <div class="list-item__date">
+                <span>{{ file.date }}</span>
+              </div>
+              <div class="list-item__subject">
+                <span>
+                  {{ file.title }}
+                </span>
+              </div>
+            </a>
+          {% endfor %}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>
+{% endif %}
+{% endblock paragraph %}


### PR DESCRIPTION
**To test**
- Checkout branch
- Run `make drush-cim drush-cr`
- Create some PDF categories: https://helsinki-paatokset.docker.so/fi/admin/structure/taxonomy/manage/pdf_minutes_category/add
- Create some PDF minutes of discussion: https://helsinki-paatokset.docker.so/fi/media/add/pdf_minutes_of_discussion (this is a new media type and is not related to meetings like the other minutes of discussion documents).
  - Create about 10 or so of these, make sure to vary the dates so you have different years in different categories
  - Create a few with the same date
- Create a new basic page: https://helsinki-paatokset.docker.so/fi/node/add/page
  - Add a new "PDF listing" component to the content area
  - Select a PDF category and save the page
- The PDF media entities you created should be listed on this page, filtered by the category you selected
- The Media entities should be ordered by newest first. If the documents have the same date, they should be in alphabetical order
- Edit the listing component settings and make sure that:
  - If you select more than one category, the list should contain all entities from the selected categories
  - If you leave the category selection empty, the list should contain all of the PDF media entities you created