### PR TITLE
PP-0: Try to fix office holder decision sorting.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -914,6 +914,45 @@ class CaseService {
       }
     }
 
+    // Sort decisions by timestamp and then again by section numbering.
+    // Has to be done here because query sees sections as text, not numbers.
+    usort($results, function ($item1, $item2) {
+      if ($item1->get('field_meeting_date')->isEmpty()) {
+        $item1_timestamp = 0;
+        $item1_date = NULL;
+      }
+      else {
+        $item1_timestamp = strtotime($item1->get('field_meeting_date')->value);
+        $item1_date = date('d.m.Y', $item1_timestamp);
+      }
+      if ($item2->get('field_meeting_date')->isEmpty()) {
+        $item2_timestamp = 0;
+        $item2_date = NULL;
+      }
+      else {
+        $item2_timestamp = strtotime($item2->get('field_meeting_date')->value);
+        $item2_date = date('d.m.Y', $item2_timestamp);
+      }
+      if ($item1->get('field_decision_section')->isEmpty()) {
+        $item1_section = 0;
+      }
+      else {
+        $item1_section = (int) $item1->get('field_decision_section')->value;
+      }
+      if ($item2->get('field_decision_section')->isEmpty()) {
+        $item2_section = 0;
+      }
+      else {
+        $item2_section = (int) $item2->get('field_decision_section')->value;
+      }
+
+      if ($item1_date === $item2_date) {
+        return $item2_section - $item1_section;
+      }
+
+      return $item2_timestamp - $item1_timestamp;
+    });
+
     return $results;
   }
 

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -673,12 +673,12 @@ class PolicymakerService {
       return [];
     }
 
+    // Entityquery. Sorting is handled later for meeting date and section.
     $query = \Drupal::entityQuery('node')
       ->condition('status', 1)
       ->condition('type', 'decision')
       ->condition('field_policymaker_id', $this->policymakerId)
-      ->condition('field_meeting_date', '', '<>')
-      ->condition('field_meeting_date', '2018-04-01', '>=');
+      ->condition('field_meeting_date', '', '<>');
 
     if ($limit) {
       $query->range('0', $limit);
@@ -724,10 +724,10 @@ class PolicymakerService {
     // Sort decisions by timestamp and then again by section numbering.
     // Has to be done here because query sees sections as text, not numbers.
     usort($results, function ($item1, $item2) {
-      return strtotime($item2['timestamp']) - strtotime($item1['timestamp']);
-    });
-    usort($results, function ($item1, $item2) {
-      return (int) $item2['section'] - (int) $item1['section'];
+      if ($item1['date_desktop'] === $item2['date_desktop']) {
+        return (int) $item2['section'] - (int) $item1['section'];
+      }
+      return $item2['timestamp'] - $item1['timestamp'];
     });
 
     foreach ($results as $result) {


### PR DESCRIPTION
This PR fixes decision sorting on multiple pages. Correct logic:
- Decisions should be sorted by date, newest first
- If the date is the same, decisions should be sorted by their section number, largest first. These are added sequentially each year, so larger = newer.

**Replicate issue, get data for testing:**
- Before checking out branch, pull in data for testing:
```
drush ap:update cases hel-2022-008625 -v
drush ap:update organization u511052007020vh1 -v
drush ap:update decisions ca6edb1d-f4cf-42bf-8704-8c70b0ae6f08 -v
drush ap:update decisions 1aa1e916-8f27-4a00-97eb-cdda61fda9cb -v
drush ap:update decisions 94d3906c-5e5c-48e9-b692-5bf5664bd6a6 -v
drush ap:update decisions af277802-02e5-44c1-8eeb-c695525c8515 -v
drush ap:update decisions 3efc18e0-12fd-c3af-883a-822413400001 -v
drush ap:update decisions 0a6f337b-d915-ca26-a90f-822413800000 -v
drush ap:update decisions 4df7ae8b-a12a-443a-815f-8870604e6290 -v
drush ap:update decisions 7366cd45-1730-4baa-9f19-c91108b524be -v
drush ap:update decisions 7bbf8e73-1749-4c02-8f9f-0a098e3c2c18 -v
drush ap:update decisions 10b03b24-8d8b-4e9a-befb-8217052cac44 -v
drush ap:update decisions 78a138e7-bb03-4359-85d8-22ce97bb1869 -v
drush ap:update decisions 585321dc-82f3-4bed-893a-9d4c74edba9e -v
drush ap:update decisions 88aab3af-51a8-4956-a09c-81c8a4390419 -v
drush ap:update decisions 969c900c-c189-4d74-8f34-78399384f023 -v
drush ap:update decisions bfd1cf71-fbcd-42b3-8b28-9e4675332bd5 -v
drush ap:update decisions e6b85ddc-54fc-4be4-a9a9-f5ee1320125d -v
drush ap:update decisions 828ee972-8e5d-4b83-817d-c79c72df1018 -v
drush ap:update decisions 2def220a-6cda-43ae-b93b-5c7fa6c03f7a -v
```
- Open the following pages:
  - https://helsinki-paatokset.docker.so/fi/paattajat/yksikon-paallikko-projektirakennuttaminen-yksikko/ 
  - https://helsinki-paatokset.docker.so/fi/paattajat/yksikon-paallikko-projektirakennuttaminen-yksikko/paatokset
  - https://helsinki-paatokset.docker.so/fi/asia/hel-2022-008625
- The decisions should be correctly sorted by date, but the section numbering (§ 101 etc) are sorted wrong when the date is the same.
  - On the list, the section numbers are handled alphabetically, so 9 comes before 10 (10 is being read as 1).
  - On the decision page, if you use the dropdown you can see that 5 is shown before 6.

**To test:**
- Checkout branch, run `make drush-cr`
- Reload the pages. The sorting should be correct now.