### PR TITLE
PP-453: Decision migration fixes with Series ID field

### DIFF
--- a/conf/cmi/core.entity_form_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_form_display.node.decision.default.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.decision.field_decision_previous
     - field.field.node.decision.field_decision_record
     - field.field.node.decision.field_decision_section
+    - field.field.node.decision.field_decision_series_id
     - field.field.node.decision.field_diary_number
     - field.field.node.decision.field_diary_number_label
     - field.field.node.decision.field_dm_org_above_name
@@ -57,6 +58,7 @@ third_party_settings:
       children:
         - field_full_title
         - field_decision_native_id
+        - field_decision_series_id
         - field_unique_id
         - field_decision_date
         - field_meeting_date
@@ -198,13 +200,13 @@ content:
     third_party_settings: {  }
   field_decision_date:
     type: datetime_default
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   field_decision_history:
     type: text_textarea
-    weight: 27
+    weight: 22
     region: content
     settings:
       rows: 5
@@ -215,7 +217,7 @@ content:
         hide_guidelines: '0'
   field_decision_history_pdf:
     type: json_textarea
-    weight: 26
+    weight: 21
     region: content
     settings:
       rows: 5
@@ -280,6 +282,14 @@ content:
   field_decision_section:
     type: string_textfield
     weight: 9
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_decision_series_id:
+    type: string_textfield
+    weight: 5
     region: content
     settings:
       size: 60
@@ -400,7 +410,7 @@ content:
     third_party_settings: {  }
   field_unique_id:
     type: string_textfield
-    weight: 5
+    weight: 6
     region: content
     settings:
       size: 60

--- a/conf/cmi/core.entity_view_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.default.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.decision.field_decision_previous
     - field.field.node.decision.field_decision_record
     - field.field.node.decision.field_decision_section
+    - field.field.node.decision.field_decision_series_id
     - field.field.node.decision.field_diary_number
     - field.field.node.decision.field_diary_number_label
     - field.field.node.decision.field_dm_org_above_name
@@ -205,6 +206,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 5
+    region: content
+  field_decision_series_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 37
     region: content
   field_diary_number:
     type: string

--- a/conf/cmi/core.entity_view_display.node.decision.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.teaser.yml
@@ -24,6 +24,7 @@ dependencies:
     - field.field.node.decision.field_decision_previous
     - field.field.node.decision.field_decision_record
     - field.field.node.decision.field_decision_section
+    - field.field.node.decision.field_decision_series_id
     - field.field.node.decision.field_diary_number
     - field.field.node.decision.field_diary_number_label
     - field.field.node.decision.field_dm_org_above_name
@@ -75,6 +76,7 @@ hidden:
   field_decision_previous: true
   field_decision_record: true
   field_decision_section: true
+  field_decision_series_id: true
   field_diary_number: true
   field_diary_number_label: true
   field_dm_org_above_name: true

--- a/conf/cmi/field.field.node.decision.field_decision_series_id.yml
+++ b/conf/cmi/field.field.node.decision.field_decision_series_id.yml
@@ -1,0 +1,19 @@
+uuid: a29bbbea-124a-42fb-a0f5-e10afeba4576
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_decision_series_id
+    - node.type.decision
+id: node.decision.field_decision_series_id
+field_name: field_decision_series_id
+entity_type: node
+bundle: decision
+label: 'Series ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_decision_series_id.yml
+++ b/conf/cmi/field.storage.node.field_decision_series_id.yml
@@ -1,0 +1,21 @@
+uuid: d88ed893-b560-484d-8659-b493ab3e795c
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_decision_series_id
+field_name: field_decision_series_id
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/views.view.decisions.yml
+++ b/conf/cmi/views.view.decisions.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_decision_content
     - field.storage.node.field_decision_date
     - field.storage.node.field_decision_motion
+    - field.storage.node.field_decision_series_id
     - field.storage.node.field_diary_number
     - field.storage.node.field_dm_org_name
     - field.storage.node.field_is_decision
@@ -217,6 +218,69 @@ display:
           plugin_id: field
           label: 'Unique ID'
           exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_decision_series_id:
+          id: field_decision_series_id
+          table: node__field_decision_series_id
+          field: field_decision_series_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Series ID'
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -822,19 +886,6 @@ display:
           granularity: second
       arguments: {  }
       filters:
-        status:
-          id: status
-          table: node_field_data
-          field: status
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
-          value: '1'
-          group: 1
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
         type:
           id: type
           table: node_field_data
@@ -992,6 +1043,52 @@ display:
               anonymous: '0'
               admin: '0'
               content_producer: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_decision_series_id_value:
+          id: field_decision_series_id_value
+          table: node__field_decision_series_id
+          field: field_decision_series_id_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_decision_series_id_value_op
+            label: 'Series ID'
+            description: ''
+            use_operator: false
+            operator: field_decision_series_id_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_decision_series_id_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              read_only: '0'
+              content_producer: '0'
+              editor: '0'
+              admin: '0'
+              api_user: '0'
+              elevated_api_user: '0'
             placeholder: ''
           is_grouped: false
           group_info:
@@ -1240,6 +1337,54 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Julkaisutila
+            description: null
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: Julkaistu
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: '1'
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'True'
+                operator: '='
+                value: '1'
+              2:
+                title: 'False'
+                operator: '='
+                value: '0'
       filter_groups:
         operator: AND
         groups:
@@ -1380,6 +1525,7 @@ display:
         - 'config:field.storage.node.field_decision_content'
         - 'config:field.storage.node.field_decision_date'
         - 'config:field.storage.node.field_decision_motion'
+        - 'config:field.storage.node.field_decision_series_id'
         - 'config:field.storage.node.field_diary_number'
         - 'config:field.storage.node.field_dm_org_name'
         - 'config:field.storage.node.field_is_decision'
@@ -1419,6 +1565,7 @@ display:
         - 'config:field.storage.node.field_decision_content'
         - 'config:field.storage.node.field_decision_date'
         - 'config:field.storage.node.field_decision_motion'
+        - 'config:field.storage.node.field_decision_series_id'
         - 'config:field.storage.node.field_diary_number'
         - 'config:field.storage.node.field_dm_org_name'
         - 'config:field.storage.node.field_is_decision'

--- a/docker/openshift/crons/run-immediate-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-immediate-ahjo-integrations.sh
@@ -12,12 +12,14 @@ do
   drush ahjo-proxy:get-motions -v
   echo "Updating decision and motion data: $(date)"
   drush ahjo-proxy:update-decisions -v
+  drush ahjo-proxy:update-decisions --logic=seriesid --limit=200 -v
   drush ahjo-proxy:update-decisions --logic=uniqueid --limit=100 -v
   drush ahjo-proxy:update-decisions --logic=outdated --limit=100 -v
   drush ahjo-proxy:update-decisions --logic=history --limit=100 -v
   drush ahjo-proxy:update-decisions --logic=case --limit=100 -v
   drush ahjo-proxy:update-decisions --logic=language --limit=100 -v
   drush ahjo-proxy:update-decision-attachments --limit=100 -v
+  drush ahjo-proxy:update-decision-dates --limit=100 -v
   # Sleep for 10 minutes.
   sleep 600
 done

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml
@@ -32,6 +32,10 @@ source:
       label: Native ID
       selector: NativeId
     -
+      name: series_id
+      label: Series ID
+      selector: PDF/VersionSeriesId
+    -
       name: language
       label: Language
       selector: PDF/Language
@@ -133,6 +137,11 @@ process:
       - organization_id
       - decision_date
       - section
+  _skip_if_series_id_is_empty:
+    plugin: skip_on_empty
+    method: row
+    source: series_id
+    message: 'Series ID missing for decision.'
   type:
     plugin: default_value
     default_value: decision
@@ -141,11 +150,13 @@ process:
     source: language
     default_value: fi
   field_decision_native_id: native_id
+  field_decision_series_id: series_id
   nid:
     plugin: callback
     callable: _paatokset_ahjo_api_lookup_decision_nid
     source:
       - native_id
+      - series_id
       - case_id
       - meeting_id
       - title

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -515,34 +515,40 @@ function _paatokset_ahjo_api_lookup_case_nid(string $case_id): ?string {
  *   Existing nid, if found.
  */
 function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
-  // First attempt to find node with native ID.
   $native_id = $values[0];
   if (!empty($values[1])) {
-    $case_id = $values[1];
+    $series_id = $values[1];
+  }
+  else {
+    $series_id = NULL;
+  }
+
+  if (!empty($values[2])) {
+    $case_id = $values[2];
   }
   else {
     $case_id = NULL;
   }
-  if (!empty($values[2])) {
-    $meeting_id = $values[2];
+  if (!empty($values[3])) {
+    $meeting_id = $values[3];
   }
   else {
     $meeting_id = NULL;
   }
-  if (!empty($values[3])) {
-    $title = $values[3];
+  if (!empty($values[4])) {
+    $title = $values[4];
   }
   else {
     $title = NULL;
   }
-
-  if (!empty($values[4])) {
-    $language = $values[4];
+  if (!empty($values[5])) {
+    $language = $values[5];
   }
   else {
     $language = NULL;
   }
 
+  // First search for native ID (unique for document).
   $query = Drupal::entityQuery('node')
     ->condition('type', 'decision')
     ->condition('field_decision_native_id', $native_id)
@@ -554,6 +560,21 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
     return reset($ids);
   }
 
+  // If native ID is not found, search for series ID (shared by doc versions).
+  if ($series_id) {
+    $query = Drupal::entityQuery('node')
+      ->condition('type', 'decision')
+      ->condition('field_decision_series_id', $series_id)
+      ->range(0, 1)
+      ->latestRevision();
+
+    $ids = $query->execute();
+    if (!empty($ids)) {
+      return reset($ids);
+    }
+  }
+
+  // If nothing is found with series ID, try other IDs and fields.
   if (!$meeting_id) {
     return NULL;
   }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1145,6 +1145,11 @@ class AhjoProxy implements ContainerInjectionInterface {
       $node->set('field_outdated_document', 0);
     }
 
+    // Set record Series ID, if found.
+    if (!empty($record_content['VersionSeriesId'])) {
+      $node->set('field_decision_series_id', $record_content['VersionSeriesId']);
+    }
+
     if (isset($record_content['Issued'])) {
       $date = new \DateTime($record_content['Issued'], new \DateTimeZone('Europe/Helsinki'));
       $date->setTimezone(new \DateTimeZone('UTC'));

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -717,6 +717,13 @@ class AhjoAggregatorCommands extends DrushCommands {
       elseif ($logic === 'uniqueid') {
         $query->notExists('field_unique_id');
       }
+      elseif ($logic === 'seriesid') {
+        $query->condition('field_is_decision', 1);
+        $or = $query->orConditionGroup();
+        $or->notExists('field_decision_series_id');
+        $or->condition('field_decision_series_id', '');
+        $query->condition($or);
+      }
     }
 
     if ($limit) {


### PR DESCRIPTION
**To test**
* Checkout branch
* Run `make new`
* Go to `public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml` and remove the lines 140 - 144 ( the `_skip_if_series_id_is_empty` step). Run `make drush-cr`
* Login to the container and import decisions:
  * `drush ap:update decisions {167D3993-E3AE-4E53-AF12-6431179EF3E2} -v`
  * `drush ap:update decisions {56763595-69AB-CC78-85C4-831B42900000} -v`
* Go to https://helsinki-paatokset.docker.so/fi/admin/content/decisions?status=All
  * You should see two decisions with the same title
* Rollback and import decisions again, but this time fetch missing data to the first one:
  * `drush migrate-rollback ahjo_decisions:single`
  * `drush ap:update decisions {167D3993-E3AE-4E53-AF12-6431179EF3E2} -v`
  * `drush ap:ud -v`
  * `drush ap:update decisions {56763595-69AB-CC78-85C4-831B42900000} -v`
* Reload the listing page. This time you should only see one decision, because the first one was replaced by a newer decision with the same Series ID
* Add the removed lines back to `ahjo_decisions.yml` and run `drush cr`
* Run `drush migrate-messages ahjo_decisions:single`. The output should be empty.
* Try migrating this decision again:
  * `drush ap:update decisions {167D3993-E3AE-4E53-AF12-6431179EF3E2} -v`
  * Run `drush migrate-messages ahjo_decisions:single` again. This time you should get a message about the migration being skipped because of a missing series_id value
* Read code changes