### PR TITLE
PP-453: Add scripts for checking decision publication status.

### DIFF
--- a/conf/cmi/core.entity_form_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_form_display.node.decision.default.yml
@@ -38,6 +38,7 @@ dependencies:
     - field.field.node.decision.field_outdated_document
     - field.field.node.decision.field_policymaker_id
     - field.field.node.decision.field_record_language_checked
+    - field.field.node.decision.field_status_checked
     - field.field.node.decision.field_top_category_name
     - field.field.node.decision.field_unique_id
     - field.field.node.decision.field_voting_results
@@ -394,6 +395,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_record_language_checked:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_status_checked:
     type: boolean_checkbox
     weight: 7
     region: content

--- a/conf/cmi/core.entity_view_display.node.decision.default.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.default.yml
@@ -38,6 +38,7 @@ dependencies:
     - field.field.node.decision.field_outdated_document
     - field.field.node.decision.field_policymaker_id
     - field.field.node.decision.field_record_language_checked
+    - field.field.node.decision.field_status_checked
     - field.field.node.decision.field_top_category_name
     - field.field.node.decision.field_unique_id
     - field.field.node.decision.field_voting_results
@@ -336,6 +337,16 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     weight: 33
+    region: content
+  field_status_checked:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 38
     region: content
   field_top_category_name:
     type: string

--- a/conf/cmi/core.entity_view_display.node.decision.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.decision.teaser.yml
@@ -39,6 +39,7 @@ dependencies:
     - field.field.node.decision.field_outdated_document
     - field.field.node.decision.field_policymaker_id
     - field.field.node.decision.field_record_language_checked
+    - field.field.node.decision.field_status_checked
     - field.field.node.decision.field_top_category_name
     - field.field.node.decision.field_unique_id
     - field.field.node.decision.field_voting_results
@@ -91,6 +92,7 @@ hidden:
   field_outdated_document: true
   field_policymaker_id: true
   field_record_language_checked: true
+  field_status_checked: true
   field_top_category_name: true
   field_unique_id: true
   field_voting_results: true

--- a/conf/cmi/field.field.node.decision.field_status_checked.yml
+++ b/conf/cmi/field.field.node.decision.field_status_checked.yml
@@ -1,0 +1,23 @@
+uuid: 3dfa4a8b-4aba-4a90-a67d-9c30c7ad90b0
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_status_checked
+    - node.type.decision
+id: node.decision.field_status_checked
+field_name: field_status_checked
+entity_type: node
+bundle: decision
+label: 'Status checked'
+description: 'Decision PDF publication status checked.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.storage.node.field_status_checked.yml
+++ b/conf/cmi/field.storage.node.field_status_checked.yml
@@ -1,0 +1,18 @@
+uuid: 6bd7c845-5f60-4a62-b94e-058d7adfc68a
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_status_checked
+field_name: field_status_checked
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -549,6 +549,7 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
   }
 
   // First search for native ID (unique for document).
+  // Allow for unpublished nodes to prevent conflicts.
   $query = Drupal::entityQuery('node')
     ->condition('type', 'decision')
     ->condition('field_decision_native_id', $native_id)
@@ -561,10 +562,13 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
   }
 
   // If native ID is not found, search for series ID (shared by doc versions).
+  // For this, do not allow unpublished nodes.
+  // If a previous version is unpublished, create a new one.
   if ($series_id) {
     $query = Drupal::entityQuery('node')
       ->condition('type', 'decision')
       ->condition('field_decision_series_id', $series_id)
+      ->condition('status', 1)
       ->range(0, 1)
       ->latestRevision();
 


### PR DESCRIPTION
**To test**
- Checkout branch, run `make new`
- Go to `public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisions.yml` and remove the lines 140 - 144 ( the _skip_if_series_id_is_empty step). Run `make drush-cr`
- Migrate the following decisions:
```
drush ap:update {167D3993-E3AE-4E53-AF12-6431179EF3E2} -v
drush ap:update {80A6CFE9-F663-455B-B771-E06C7FCCED57} -v
drush ap:update {29150CA1-2059-C4E7-90DC-830CC2300003} -v
drush ap:update {56763595-69AB-CC78-85C4-831B42900000} -v
drush ap:update {F1302096-A870-4849-BBB1-AC52ACF6C554} -v
drush ap:update {586328F4-A901-CD54-99E4-82C3B6500000} -v
```
- Run `drush migrate-messages ahjo_decisions:single` to make sure none of the duplicates were skipped yet
- Go to: https://helsinki-paatokset.docker.so/fi/admin/content/decisions
- There should be 3 decisions with 1 duplicate for each (6 total)
- Run `drush ahjo-proxy:check-decision-status -v`. This should output messages about three nodes being unpublished.
- Reload the decisions listing page: https://helsinki-paatokset.docker.so/fi/admin/content/decisions
- The duplicates should be gone now
- Read code changes