### PR TITLE
PLATTA-4694: serach-index with cron

### DIFF
--- a/conf/cmi/search_api.index.decisions.yml
+++ b/conf/cmi/search_api.index.decisions.yml
@@ -225,7 +225,7 @@ tracker_settings:
   default:
     indexing_order: fifo
 options:
-  cron_limit: 50
+  cron_limit: 0
   index_directly: false
   track_changes_in_references: true
 server: elasticsearch

--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -157,7 +157,7 @@ tracker_settings:
   default:
     indexing_order: fifo
 options:
-  cron_limit: 50
+  cron_limit: 0
   index_directly: false
   track_changes_in_references: true
 server: elasticsearch

--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -21,6 +21,7 @@ exec "/crons/purge-queue.sh" &
 exec "/crons/run-helsinki-integrations.sh" &
 exec "/crons/run-aggregated-ahjo-integrations.sh" &
 exec "/crons/run-immediate-ahjo-integrations.sh" &
+exec "/crons/search-index.sh" &
 
 while true
 do

--- a/docker/openshift/crons/search-index.sh
+++ b/docker/openshift/crons/search-index.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while true
+do
+  sleep 120
+  drush sapi-i --limit=1000 --batch-size=50
+  sleep 60
+done


### PR DESCRIPTION
- switching indexation via drush command to be faster and not wait from general cron to run