### PR TITLE
PP-0: Add missing libraries for tabbed navigation and dropdown components

### DIFF
--- a/public/modules/custom/paatokset_lang_switcher/paatokset_lang_switcher.module
+++ b/public/modules/custom/paatokset_lang_switcher/paatokset_lang_switcher.module
@@ -145,7 +145,10 @@ function _paatokset_lang_switcher_get_alt_urls_for_routes(RouteMatchInterface $r
   foreach ($route->getParameters() as $key => $value) {
     // Special case for translating policymaker organization parameter.
     if ($key === 'organization') {
+      // Policymaker gets lost when returning page from cache, so set it again.
+      $policymakerService->setPolicyMakerByPath();
       $organization = $policymakerService->getPolicymakerOrganizationFromUrl(NULL, $langCode);
+
       if ($organization) {
         $parameters[$key] = $organization;
       }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.libraries.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.libraries.yml
@@ -4,6 +4,15 @@ global-styling:
     theme:
       dist/css/styles.min.css: {}
 
+global-scripting:
+  version: 1.x
+  js:
+    dist/js/paatokset_submenus.min.js: {}
+    dist/js/paatoksetDropdown.min.js: {}
+  dependencies:
+    - core/drupal
+
+
 accordion_inner:
   version: 1.x
   js:
@@ -23,6 +32,11 @@ accordion_lazy:
     - core/drupal
     - core/jquery
     - hdbt/handorgel
+
+paatokset_submenu:
+  version: 1.x
+  js:
+    dist/js/paatokset_submenus.min.js: {}
 
 cookie_compliance_block:
   version: 1.x


### PR DESCRIPTION
This PR adds two missing JS files to the global-scripting library in order to fix tabbed navigation components and decision dropdowns.

**To test**
- Checkout branch, run `make new` 
- Get content to test with:
```
drush mim ahjo_decisionmakers:all
drush mim ahjo_trustees:council
drush ap:update meetings 02900202221 -v
drush ap:update meetings 02900202123 -v
drush ap:update meetings 02900202310 -v
drush ap:update decisions 8c3e5164-930e-4a90-b980-457be86b6792 -v
drush ap:update decisions a2612b7e-331b-cb2c-a118-87758d600004 -v
drush ap:update decisions 3f3c90b5-65c3-480b-b937-5bb91a7c142e -v
drush ap:update decisions 49c80948-6d89-4664-842a-3886e91ab9a2 -v
drush ap:update decisions 6f652461-02e4-40fc-b856-c7267dcfca15 -v
drush ap:update cases hel-2023-001306 -v
drush ap:cdp --queue -v
drush queue:run ahjo_api_subscriber_queue -v
```
- Open these pages:
  - https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat
  - https://paatokset.hel.fi/fi/paattajat/yksikon-paallikko-alueellinen-rakennuttaminen-yksikko/paatokset
  - Create a page with this URL: `/paattajat/kaupunginvaltuusto/aloitteet`
  - On each of those pages should be a list of content divided by year. The year selection should work on desktop and mobile
- Go to: https://helsinki-paatokset.docker.so/fi/asia/hel-2023-001306
  - There should be a dropdown selector on this page to switch between different decisions. It should work on both desktop and mobile
  - Also test that the "previous handling / next handling" links work
 - Open this page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat
   - Check the language switcher links. They should have "02900" instead of "kaupunginvaltuusto"
   - Reload the page (so it's returned from cache). The language switcher links should still work and have "02900" and not "kaupunginvaltuusto". 