### PR TITLE
PP-490: Aggregation and queue changes

### DIFF
--- a/conf/cmi/views.view.decision_makers.yml
+++ b/conf/cmi/views.view.decision_makers.yml
@@ -469,7 +469,7 @@ display:
           admin_label: ''
           plugin_id: field
           label: Decisionmaker
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -963,6 +963,96 @@ display:
               editor: '0'
               admin: '0'
             reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_policymaker_existing_value:
+          id: field_policymaker_existing_value
+          table: node__field_policymaker_existing
+          field: field_policymaker_existing_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Active
+            description: ''
+            use_operator: false
+            operator: field_policymaker_existing_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_policymaker_existing_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              read_only: '0'
+              content_producer: '0'
+              editor: '0'
+              admin: '0'
+              api_user: '0'
+              elevated_api_user: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_is_decisionmaker_value:
+          id: field_is_decisionmaker_value
+          table: node__field_is_decisionmaker
+          field: field_is_decisionmaker_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Decisionmaker
+            description: ''
+            use_operator: false
+            operator: field_is_decisionmaker_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_is_decisionmaker_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              read_only: '0'
+              content_producer: '0'
+              editor: '0'
+              admin: '0'
+              api_user: '0'
+              elevated_api_user: '0'
           is_grouped: false
           group_info:
             label: ''

--- a/conf/cmi/views.view.decision_makers.yml
+++ b/conf/cmi/views.view.decision_makers.yml
@@ -3,10 +3,12 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_dm_org_name
     - field.storage.node.field_is_decisionmaker
     - field.storage.node.field_organization_type
     - field.storage.node.field_policymaker_existing
     - field.storage.node.field_policymaker_id
+    - field.storage.node.field_sector_name
     - node.type.policymaker
   module:
     - node
@@ -83,6 +85,132 @@ display:
           admin_label: ''
           plugin_id: field
           label: ID
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_sector_name:
+          id: field_sector_name
+          table: node__field_sector_name
+          field: field_sector_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Sector name'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_dm_org_name:
+          id: field_dm_org_name
+          table: node__field_dm_org_name
+          field: field_dm_org_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Organization name'
           exclude: false
           alter:
             alter_text: false
@@ -712,6 +840,52 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_dm_org_name_value:
+          id: field_dm_org_name_value
+          table: node__field_dm_org_name
+          field: field_dm_org_name_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_dm_org_name_value_op
+            label: 'Organization name'
+            description: ''
+            use_operator: false
+            operator: field_dm_org_name_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_dm_org_name_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              read_only: '0'
+              content_producer: '0'
+              editor: '0'
+              admin: '0'
+              api_user: '0'
+              elevated_api_user: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         field_organization_type_value:
           id: field_organization_type_value
           table: node__field_organization_type
@@ -815,6 +989,8 @@ display:
             title: title
             field_policymaker_id: field_policymaker_id
             field_organization_type: field_organization_type
+            field_sector_name: field_sector_name
+            field_dm_org_name: field_dm_org_name
             changed: changed
             field_policymaker_existing: field_policymaker_existing
             field_is_decisionmaker: field_is_decisionmaker
@@ -837,6 +1013,20 @@ display:
               empty_column: false
               responsive: ''
             field_organization_type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_sector_name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_dm_org_name:
               sortable: true
               default_sort_order: asc
               align: ''
@@ -906,10 +1096,12 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_dm_org_name'
         - 'config:field.storage.node.field_is_decisionmaker'
         - 'config:field.storage.node.field_organization_type'
         - 'config:field.storage.node.field_policymaker_existing'
         - 'config:field.storage.node.field_policymaker_id'
+        - 'config:field.storage.node.field_sector_name'
   page_1:
     id: page_1
     display_title: Page
@@ -940,7 +1132,9 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_dm_org_name'
         - 'config:field.storage.node.field_is_decisionmaker'
         - 'config:field.storage.node.field_organization_type'
         - 'config:field.storage.node.field_policymaker_existing'
         - 'config:field.storage.node.field_policymaker_id'
+        - 'config:field.storage.node.field_sector_name'

--- a/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
@@ -4,43 +4,47 @@ while true
 do
   # Sleep for 1 hour.
   sleep 3600
+
   # Don't run aggregations between 01:00 and 07:00 UTC+3.
   # Ahjo might be offline for maintenance during the night.
   currenttime=$(date +%H:%M)
   if [[ "$currenttime" > "22:00" ]] || [[ "$currenttime" < "04:00" ]]; then
     sleep 3600
+  else
+
+    if [ ${APP_ENV} = 'production' ]; then
+      echo "Aggregating data for meetings: $(date)"
+      drush ahjo-proxy:aggregate meetings --dataset=latest --queue -v
+      echo "Aggregating data for cancelled meetings: $(date)"
+      drush ahjo-proxy:aggregate meetings --dataset=cancelled --cancelledonly --queue -v
+      echo "Aggregating data for decisions: $(date)"
+      drush ahjo-proxy:aggregate decisions --dataset=latest --queue -v
+      echo "Aggregating data for cases: $(date)"
+      drush ahjo-proxy:aggregate cases --dataset=latest --queue -v
+    fi
+    echo "Aggregating council org data: $(date)"
+    drush ahjo-proxy:get-council-positionsoftrust -v
+    echo "Aggregating data for council members: $(date)"
+    drush ahjo-proxy:get-trustees positionsoftrust_council.json -v
+    echo "Aggregating latest decisionmaker changes: $(date)"
+    drush ap:get decisionmakers --dataset=latest --filename=decisionmakers_latest.json -v
+    drush ap:get decisionmakers --dataset=latest --langcode=sv --filename=decisionmakers_latest_sv.json -v
+    if [ ${APP_ENV} = 'production' ]; then
+      drush queue:run ahjo_api_aggregation_queue --time-limit=1800 -v
+      drush queue:run ahjo_api_retry_queue --time-limit=1800 -v
+    fi
+    echo "Migrating data for council members: $(date)"
+    drush migrate-reset-status ahjo_trustees:council
+    drush migrate-import ahjo_trustees:council --update
+    echo "Migrating data for decisionmakers: $(date)"
+    drush migrate-reset-status ahjo_decisionmakers:latest
+    drush migrate-reset-status ahjo_decisionmakers:latest_sv
+    drush migrate-import ahjo_decisionmakers:latest --update
+    drush migrate-import ahjo_decisionmakers:latest_sv --update
+    echo "Checking for inactive decisionmakers: $(date)"
+    drush ahjo-proxy:check-dm-status -v
+    # Sleep for 23 hours.
+    sleep 82800
+
   fi
-  if [ ${APP_ENV} = 'production' ]; then
-    echo "Aggregating data for meetings: $(date)"
-    drush ahjo-proxy:aggregate meetings --dataset=latest --queue -v
-    echo "Aggregating data for cancelled meetings: $(date)"
-    drush ahjo-proxy:aggregate meetings --dataset=cancelled --cancelledonly --queue -v
-    echo "Aggregating data for decisions: $(date)"
-    drush ahjo-proxy:aggregate decisions --dataset=latest --queue -v
-    echo "Aggregating data for cases: $(date)"
-    drush ahjo-proxy:aggregate cases --dataset=latest --queue -v
-  fi
-  echo "Aggregating council org data: $(date)"
-  drush ahjo-proxy:get-council-positionsoftrust -v
-  echo "Aggregating data for council members: $(date)"
-  drush ahjo-proxy:get-trustees positionsoftrust_council.json -v
-  echo "Aggregating latest decisionmaker changes: $(date)"
-  drush ap:get decisionmakers --dataset=latest --filename=decisionmakers_latest.json -v
-  drush ap:get decisionmakers --dataset=latest --langcode=sv --filename=decisionmakers_latest_sv.json -v
-  if [ ${APP_ENV} = 'production' ]; then
-    drush queue:run ahjo_api_aggregation_queue --time-limit=1800 -v
-    drush queue:run ahjo_api_retry_queue --time-limit=1800 -v
-  fi
-  echo "Migrating data for council members: $(date)"
-  drush migrate-reset-status ahjo_trustees:council
-  drush migrate-import ahjo_trustees:council --update
-  echo "Migrating data for decisionmakers: $(date)"
-  drush migrate-reset-status ahjo_decisionmakers:latest
-  drush migrate-reset-status ahjo_decisionmakers:latest_sv
-  drush migrate-import ahjo_decisionmakers:latest --update
-  drush migrate-import ahjo_decisionmakers:latest_sv --update
-  echo "Checking for inactive decisionmakers: $(date)"
-  drush ahjo-proxy:check-dm-status -v
-  # Sleep for 23 hours.
-  sleep 82800
 done

--- a/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
@@ -4,6 +4,12 @@ while true
 do
   # Sleep for 1 hour.
   sleep 3600
+  # Don't run aggregations between 01:00 and 07:00 UTC+3.
+  # Ahjo might be offline for maintenance during the night.
+  currenttime=$(date +%H:%M)
+  if [[ "$currenttime" > "22:00" ]] || [[ "$currenttime" < "04:00" ]]; then
+    sleep 3600
+  fi
   if [ ${APP_ENV} = 'production' ]; then
     echo "Aggregating data for meetings: $(date)"
     drush ahjo-proxy:aggregate meetings --dataset=latest --queue -v

--- a/docker/openshift/crons/run-immediate-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-immediate-ahjo-integrations.sh
@@ -10,14 +10,16 @@ do
   drush queue:run ahjo_api_subscriber_queue --time-limit=240 -v
   echo "Generating motions from meeting data: $(date)"
   drush ahjo-proxy:get-motions -v
-  echo "Updating decision and motion data: $(date)"
-  drush ahjo-proxy:update-decisions -v
-  drush ahjo-proxy:update-decisions --logic=seriesid --limit=200 -v
-  drush ahjo-proxy:update-decisions --logic=uniqueid --limit=100 -v
-  drush ahjo-proxy:update-decisions --logic=case --limit=100 -v
-  drush ahjo-proxy:update-decisions --logic=language --limit=100 -v
-  drush ahjo-proxy:update-decision-attachments --limit=100 -v
-  drush ahjo-proxy:check-decision-status --limit=100 -v
-  # Sleep for 10 minutes.
-  sleep 600
+  if [ ${APP_ENV} = 'production' ]; then
+    echo "Updating decision and motion data: $(date)"
+    drush ahjo-proxy:update-decisions -v
+    drush ahjo-proxy:update-decisions --logic=seriesid --limit=200 -v
+    drush ahjo-proxy:update-decisions --logic=uniqueid --limit=100 -v
+    drush ahjo-proxy:update-decisions --logic=case --limit=100 -v
+    drush ahjo-proxy:update-decisions --logic=language --limit=100 -v
+    drush ahjo-proxy:update-decision-attachments --limit=100 -v
+    drush ahjo-proxy:check-decision-status --limit=100 -v
+  fi
+  # Sleep for 5 minutes.
+  sleep 300
 done

--- a/public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php
@@ -157,6 +157,12 @@ class AhjoQueueWorkerBase extends QueueWorkerBase implements ContainerFactoryPlu
       return FALSE;
     }
 
+    // Check if item is already in next queue.
+    // If it is, return TRUE here so the duplicate can be removed here too.
+    if ($this->ahjoProxy->checkIfItemIsAlreadyInQueue($item['id'], $item['content']->id, $move_to)) {
+      return TRUE;
+    }
+
     // Add old queue to update type label.
     if (isset($item['content']->updatetype)) {
       $operation = $item['content']->updatetype;

--- a/public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php
@@ -141,7 +141,7 @@ class AhjoQueueWorkerBase extends QueueWorkerBase implements ContainerFactoryPlu
       $move_to = 'ahjo_api_retry_queue';
     }
 
-    // Allow 3 hours or retries for callbacks, 3 days for other queues.
+    // Allow 3 hours of retries for callbacks, 3 days for other queues.
     if ($this->queueName === 'ahjo_api_callback_queue') {
       $max_time = (int) (new \DateTime('NOW - 3 HOURS'))->format('U');
     }

--- a/public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Queue\SuspendQueueException;
+
+/**
+ * Processes cron queue.
+ */
+class AhjoQueueWorkerBase extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected LoggerChannelInterface $logger;
+
+  /**
+   * Ahjo proxy service.
+   *
+   * @var \Drupal\paatokset_ahjo_proxy\AhjoProxy
+   */
+  protected $ahjoProxy;
+
+  private const VERBOSE_LOGGING = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
+    $instance->logger = $container->get('logger.factory')->get('ahjo_api_subscriber_queue');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($item) {
+    if (isset($item['content']->updatetype)) {
+      $operation = $item['content']->updatetype;
+    }
+    else {
+      $operation = NULL;
+    }
+
+    if (isset($item['content']->id)) {
+      $entity = $item['content']->id;
+    }
+    else {
+      $entity = NULL;
+    }
+
+    if (!$entity || !$operation) {
+      if (self::VERBOSE_LOGGING) {
+        $this->logger->info('Empty callback from @queue queue, deleting.', [
+          '@queue' => $item['id'],
+        ]);
+      }
+      return;
+    }
+
+    if (!$this->ahjoProxy->isOperational()) {
+      $this->logger->error('Ahjo Proxy is not operational, suspending.');
+      throw new SuspendQueueException('Ahjo Proxy is not operational, suspending.');
+    }
+
+    $status = $this->ahjoProxy->migrateSingleEntity($item['id'], $entity);
+
+    if ($status !== 1) {
+      if (self::VERBOSE_LOGGING) {
+        $this->logger->warning('Could not process entity @id from @queue, migration returned with status: @status.', [
+          '@id' => $entity,
+          '@queue' => $item['id'],
+          '@status' => $status,
+        ]);
+      }
+
+      throw new \Exception(sprintf(
+        'Could not process entity %s from %s, migration returned with status: %s.',
+        $entity,
+        $item['id'],
+        $status,
+      ));
+    }
+
+    // Mark meeting motions to be regenerated after updates.
+    if ($item['id'] === 'meetings' && $operation === 'Updated') {
+      $this->ahjoProxy->markMeetingMotionsAsUnprocessed($entity);
+    }
+
+    $this->logger->info('Migrated @id from @queue as @operation.', [
+      '@queue' => $item['id'],
+      '@operation' => $operation,
+      '@id' => $entity,
+    ]);
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
@@ -163,6 +163,13 @@ class AhjoCallbackCommands extends DrushCommands {
         $entity = NULL;
       }
 
+      if (isset($item->data['created'])) {
+        $created = date('Y-m-d H:i:s', (int) $item->data['created']);
+      }
+      else {
+        $created = date('Y-m-d H:i:s', (int) $item->created) . ' (no timestamp)';
+      }
+
       if ($entity && !in_array($entity, $ids[$item->data['id']])) {
         $ids[$item->data['id']][] = $entity;
       }
@@ -170,7 +177,7 @@ class AhjoCallbackCommands extends DrushCommands {
       $table->addRow([
         $item->data['id'],
         $item->item_id,
-        date('Y-m-d H:i:s', (int) $item->created),
+        $created,
         $operation,
         $entity,
       ]);

--- a/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
@@ -105,7 +105,7 @@ class AhjoCallbackCommands extends DrushCommands {
     $this->queue = $this->queueFactory->get(self::QUEUE_NAME);
     $this->retryQueue = $this->queueFactory->get(self::RETRY_QUEUE_NAME);
     $this->aggregationQueue = $this->queueFactory->get(self::AGGREGATION_QUEUE_NAME);
-    $this->errorQueue = $this->queueFactory->get(SELF::ERROR_QUEUE_NAME);
+    $this->errorQueue = $this->queueFactory->get(self::ERROR_QUEUE_NAME);
     $this->orgQueue = $this->queueFactory->get(self::ORG_QUEUE_NAME);
     $this->logger = $logger_factory->get('ahjo_api_subscriber');
     $this->database = $database;

--- a/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Commands/AhjoCallbackCommands.php
@@ -108,6 +108,8 @@ class AhjoCallbackCommands extends DrushCommands {
    *
    * @param \Drupal\Core\Queue\QueueInterface $queue
    *   Queue to list items for.
+   * @param string $queue_name
+   *   Queue name, used for printing command after items.
    * @param string|null $name
    *   Sub-queue name (ahjo entity).
    */

--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
@@ -77,10 +77,12 @@ class AhjoSubscriberController extends ControllerBase {
     $queue = $this->queueFactory->get(self::QUEUE_NAME);
 
     $content = json_decode($request->getContent());
+    $created = (int) (new \DateTime('NOW'))->format('U');
 
     $data = [
       'id' => $id,
       'content' => $content,
+      'created' => $created,
       'request' => $request->request->all(),
     ];
 
@@ -101,10 +103,11 @@ class AhjoSubscriberController extends ControllerBase {
     }
 
     if ($item_id) {
-      $this->logger->info('Added item to @id queue: @entity_id (@update_type).', [
+      $this->logger->info('Added item to @id queue: @entity_id (@update_type) on @created.', [
         '@id' => $id,
         '@entity_id' => $entity_id,
         '@update_type' => $update_type,
+        '@created' => $created,
       ]);
     }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoAggregationQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoAggregationQueueWorker.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\paatokset_ahjo_api\Plugin\QueueWorker;
 
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
@@ -20,28 +19,13 @@ use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
 class AhjoAggregationQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
-   * The logger.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  protected LoggerChannelInterface $logger;
-
-  /**
-   * Ahjo proxy service.
-   *
-   * @var \Drupal\paatokset_ahjo_proxy\AhjoProxy
-   */
-  protected $ahjoProxy;
-
-  private const VERBOSE_LOGGING = TRUE;
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
     $instance->logger = $container->get('logger.factory')->get('ahjo_api_aggregation_queue');
+    $instance->queueName = 'ahjo_api_aggregation_queue';
     return $instance;
   }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoAggregationQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoAggregationQueueWorker.php
@@ -44,4 +44,5 @@ class AhjoAggregationQueueWorker extends AhjoQueueWorkerBase implements Containe
     $instance->logger = $container->get('logger.factory')->get('ahjo_api_aggregation_queue');
     return $instance;
   }
+
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoAggregationQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoAggregationQueueWorker.php
@@ -13,11 +13,11 @@ use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
  * Processes cron queue.
  *
  * @QueueWorker(
- *   id = "ahjo_api_subscriber_queue",
- *   title = @Translation("Ahjo Callback Queue Worker"),
+ *   id = "ahjo_api_aggregation_queue",
+ *   title = @Translation("Ahjo Retry Queue Worker"),
  * )
  */
-class AhjoCallbackQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
+class AhjoAggregationQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
    * The logger.
@@ -41,7 +41,7 @@ class AhjoCallbackQueueWorker extends AhjoQueueWorkerBase implements ContainerFa
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
-    $instance->logger = $container->get('logger.factory')->get('ahjo_api_subscriber_queue');
+    $instance->logger = $container->get('logger.factory')->get('ahjo_api_aggregation_queue');
     return $instance;
   }
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoCallbackQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoCallbackQueueWorker.php
@@ -44,4 +44,5 @@ class AhjoCallbackQueueWorker extends AhjoQueueWorkerBase implements ContainerFa
     $instance->logger = $container->get('logger.factory')->get('ahjo_api_subscriber_queue');
     return $instance;
   }
+
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoCallbackQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoCallbackQueueWorker.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\paatokset_ahjo_api\Plugin\QueueWorker;
 
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
@@ -20,28 +19,13 @@ use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
 class AhjoCallbackQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
-   * The logger.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  protected LoggerChannelInterface $logger;
-
-  /**
-   * Ahjo proxy service.
-   *
-   * @var \Drupal\paatokset_ahjo_proxy\AhjoProxy
-   */
-  protected $ahjoProxy;
-
-  private const VERBOSE_LOGGING = TRUE;
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
     $instance->logger = $container->get('logger.factory')->get('ahjo_api_subscriber_queue');
+    $instance->queueName = 'ahjo_api_subscriber_queue';
     return $instance;
   }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoErrorQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoErrorQueueWorker.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\paatokset_ahjo_api\Plugin\QueueWorker;
 
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
@@ -20,28 +19,13 @@ use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
 class AhjoErrorQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
-   * The logger.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  protected LoggerChannelInterface $logger;
-
-  /**
-   * Ahjo proxy service.
-   *
-   * @var \Drupal\paatokset_ahjo_proxy\AhjoProxy
-   */
-  protected $ahjoProxy;
-
-  private const VERBOSE_LOGGING = TRUE;
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
     $instance->logger = $container->get('logger.factory')->get('ahjo_api_error_queue');
+    $instance->queueName = 'ahjo_api_error_queue';
     return $instance;
   }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoErrorQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoErrorQueueWorker.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\paatokset_ahjo_api\Plugin\QueueWorker;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
+
+/**
+ * Processes cron queue.
+ *
+ * @QueueWorker(
+ *   id = "ahjo_api_error_queue",
+ *   title = @Translation("Ahjo Error Queue Worker"),
+ * )
+ */
+class AhjoErrorQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected LoggerChannelInterface $logger;
+
+  /**
+   * Ahjo proxy service.
+   *
+   * @var \Drupal\paatokset_ahjo_proxy\AhjoProxy
+   */
+  protected $ahjoProxy;
+
+  private const VERBOSE_LOGGING = TRUE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
+    $instance->logger = $container->get('logger.factory')->get('ahjo_api_error_queue');
+    return $instance;
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoOrgChartQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoOrgChartQueueWorker.php
@@ -50,7 +50,7 @@ class AhjoOrgChartQueueWorker extends QueueWorkerBase implements ContainerFactor
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
-    $instance->logger = $container->get('logger.factory')->get('ahjo_api_subscriber_queue');
+    $instance->logger = $container->get('logger.factory')->get('ahjo_api_org_queue');
     $queue_factory = $container->get('queue');
     $instance->queue = $queue_factory->get('ahjo_api_org_queue');
     return $instance;

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoRetryQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoRetryQueueWorker.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\paatokset_ahjo_api\Plugin\QueueWorker;
 
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
@@ -20,28 +19,13 @@ use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
 class AhjoRetryQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
-   * The logger.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  protected LoggerChannelInterface $logger;
-
-  /**
-   * Ahjo proxy service.
-   *
-   * @var \Drupal\paatokset_ahjo_proxy\AhjoProxy
-   */
-  protected $ahjoProxy;
-
-  private const VERBOSE_LOGGING = TRUE;
-
-  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
     $instance->logger = $container->get('logger.factory')->get('ahjo_api_retry_queue');
+    $instance->queueName = 'ahjo_api_retry_queue';
     return $instance;
   }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoRetryQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoRetryQueueWorker.php
@@ -13,11 +13,11 @@ use Drupal\paatokset_ahjo_api\AhjoQueueWorkerBase;
  * Processes cron queue.
  *
  * @QueueWorker(
- *   id = "ahjo_api_subscriber_queue",
- *   title = @Translation("Ahjo Callback Queue Worker"),
+ *   id = "ahjo_api_retry_queue",
+ *   title = @Translation("Ahjo Retry Queue Worker"),
  * )
  */
-class AhjoCallbackQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
+class AhjoRetryQueueWorker extends AhjoQueueWorkerBase implements ContainerFactoryPluginInterface {
 
   /**
    * The logger.
@@ -41,7 +41,7 @@ class AhjoCallbackQueueWorker extends AhjoQueueWorkerBase implements ContainerFa
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
     $instance->ahjoProxy = $container->get('paatokset_ahjo_proxy');
-    $instance->logger = $container->get('logger.factory')->get('ahjo_api_subscriber_queue');
+    $instance->logger = $container->get('logger.factory')->get('ahjo_api_retry_queue');
     return $instance;
   }
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoRetryQueueWorker.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker/AhjoRetryQueueWorker.php
@@ -44,4 +44,5 @@ class AhjoRetryQueueWorker extends AhjoQueueWorkerBase implements ContainerFacto
     $instance->logger = $container->get('logger.factory')->get('ahjo_api_retry_queue');
     return $instance;
   }
+
 }

--- a/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.services.yml
+++ b/public/modules/custom/paatokset_ahjo_proxy/paatokset_ahjo_proxy.services.yml
@@ -1,4 +1,4 @@
 services:
   paatokset_ahjo_proxy:
     class: Drupal\paatokset_ahjo_proxy\AhjoProxy
-    arguments: ['@http_client', '@cache.default', '@entity_type.manager', '@plugin.manager.migration', '@logger.factory', '@file.repository', '@config.factory', '@paatokset_ahjo_openid']
+    arguments: ['@http_client', '@cache.default', '@entity_type.manager', '@plugin.manager.migration', '@logger.factory', '@file.repository', '@config.factory', '@database', '@paatokset_ahjo_openid']

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1653,7 +1653,7 @@ class AhjoProxy implements ContainerInjectionInterface {
    *   Case diary number, meeting or decision ID.
    */
   public function addItemToAhjoQueue(string $endpoint, string $id): void {
-    $queue = \Drupal::service('queue')->get('ahjo_api_subscriber_queue');
+    $queue = \Drupal::service('queue')->get('ahjo_api_retry_queue');
     $queue->createItem([
       'id' => $endpoint,
       'content' => (object) [

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1682,7 +1682,7 @@ class AhjoProxy implements ContainerInjectionInterface {
     if ($this->checkIfItemIsAlreadyInQueue($endpoint, $id, $queue_name)) {
       return NULL;
     }
-
+    $created = (int) (new \DateTime('NOW'))->format('U');
     $queue = \Drupal::service('queue')->get($queue_name);
     $item_id = $queue->createItem([
       'id' => $endpoint,
@@ -1690,6 +1690,7 @@ class AhjoProxy implements ContainerInjectionInterface {
         'updatetype' => $update_type,
         'id' => $id,
       ],
+      'created' => $created,
       'request' => [],
     ]);
 

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Url;
+use Drupal\Core\Database\Connection;
 use Drupal\file\FileRepositoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\file\FileInterface;
@@ -88,6 +89,13 @@ class AhjoProxy implements ContainerInjectionInterface {
   protected CacheBackendInterface $dataCache;
 
   /**
+   * The database.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
    * {@inheritdoc}
    */
   public function getCacheMaxAge() : int {
@@ -118,13 +126,15 @@ class AhjoProxy implements ContainerInjectionInterface {
    *   File repository.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   Config factory.
+   * @param \Drupal\Core\Database\Connection $database
+   *   The database connection.
    * @param \Drupal\paatokset_ahjo_openid\AhjoOpenId $ahjo_open_id
    *   Ahjo Open ID service.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function __construct(ClientInterface $http_client, CacheBackendInterface $data_cache, EntityTypeManagerInterface $entity_type_manager, MigrationPluginManager $migration_manager, LoggerChannelFactoryInterface $logger_factory, FileRepositoryInterface $file_repository, ConfigFactoryInterface $config_factory, AhjoOpenId $ahjo_open_id) {
+  public function __construct(ClientInterface $http_client, CacheBackendInterface $data_cache, EntityTypeManagerInterface $entity_type_manager, MigrationPluginManager $migration_manager, LoggerChannelFactoryInterface $logger_factory, FileRepositoryInterface $file_repository, ConfigFactoryInterface $config_factory, Connection $database, AhjoOpenId $ahjo_open_id) {
     $this->httpClient = $http_client;
     $this->dataCache = $data_cache;
     $this->ahjoOpenId = $ahjo_open_id;
@@ -133,6 +143,7 @@ class AhjoProxy implements ContainerInjectionInterface {
     $this->fileRepository = $file_repository;
     $this->logger = $logger_factory->get('paatokset_ahjo_proxy');
     $this->config = $config_factory;
+    $this->database = $database;
   }
 
   /**
@@ -147,6 +158,7 @@ class AhjoProxy implements ContainerInjectionInterface {
       $container->get('logger.factory'),
       $container->get('file.repository'),
       $container->get('config.factory'),
+      $container->get('database'),
       $container->get('paatokset_ahjo_openid')
     );
   }
@@ -176,6 +188,12 @@ class AhjoProxy implements ContainerInjectionInterface {
 
     // Local adjustments for fetching records through proxy.
     if (!empty(getenv('AHJO_PROXY_BASE_URL')) && strpos($url, 'records') === 0) {
+      $base_url = getenv('AHJO_PROXY_BASE_URL');
+      $api_url = $base_url . 'fi/ahjo-proxy/' . $url . '?' . urldecode($query_string);
+    }
+
+    // Local adjustments for fetching meetings through proxy.
+    if (!empty(getenv('AHJO_PROXY_BASE_URL')) && strpos($url, 'meetings') === 0) {
       $base_url = getenv('AHJO_PROXY_BASE_URL');
       $api_url = $base_url . 'fi/ahjo-proxy/' . $url . '?' . urldecode($query_string);
     }
@@ -1651,17 +1669,60 @@ class AhjoProxy implements ContainerInjectionInterface {
    *   Endpoint to use (cases, meetings, decisions).
    * @param string $id
    *   Case diary number, meeting or decision ID.
+   * @param string $queue_name
+   *   Queue to add entity to. Defaults to 'ahjo_api_retry_queue'.
+   * @param string $update_type
+   *   Update type (for debugging purposes). Defaults to 'AddedFromDrush'.
+   *
+   * @return string|null
+   *   Item ID if it was successfully added to queue, otherwise NULL.
    */
-  public function addItemToAhjoQueue(string $endpoint, string $id): void {
-    $queue = \Drupal::service('queue')->get('ahjo_api_retry_queue');
-    $queue->createItem([
+  public function addItemToAhjoQueue(string $endpoint, string $id, string $queue_name = 'ahjo_api_retry_queue', $update_type = 'AddedFromDrush'): ?string {
+    // Attempt to reduce duplicates.
+    if ($this->checkIfItemIsAlreadyInQueue($endpoint, $id, $queue_name)) {
+      return NULL;
+    }
+
+    $queue = \Drupal::service('queue')->get($queue_name);
+    $item_id = $queue->createItem([
       'id' => $endpoint,
       'content' => (object) [
-        'updatetype' => 'AddedFromDrush',
+        'updatetype' => $update_type,
         'id' => $id,
       ],
       'request' => [],
     ]);
+
+    return $item_id;
+  }
+
+  /**
+   * Check if item has already been added to queue. Used to reduce duplicates.
+   *
+   * @param string $endpoint
+   *   Entity type / endpoint for item.
+   * @param string $id
+   *   Item's ID in Ahjo API.
+   * @param string $queue_name
+   *   Queue name to check.
+   *
+   * @return bool
+   *   Returns TRUE if item is found in queue.
+   */
+  public function checkIfItemIsAlreadyInQueue(string $endpoint, string $id, string $queue_name): bool {
+    // Load the specified queue item from the queue table.
+    $query = $this->database->select('queue', 'q')
+      ->fields('q', ['item_id'])
+      ->condition('q.name', $queue_name)
+      ->condition('q.data', '%' . $this->database->escapeLike($id) . '%', 'LIKE')
+      ->condition('q.data', '%' . $this->database->escapeLike($endpoint) . '%', 'LIKE')
+      // Item id should be unique.
+      ->range(0, 1);
+
+    if ($query->execute()->fetchObject()) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
   /**

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -1458,6 +1458,11 @@ class PolicymakerService {
         $agenda_link = $caseService->getDecisionUrlWithoutNode($native_id, $data['CaseIDLabel'], $langcode);
       }
 
+      // Next, try with native ID.
+      if (!$agenda_link && !empty($data['PDF']) && !empty($data['PDF']['NativeId'])) {
+        $agenda_link = $caseService->getDecisionUrlByNativeId($data['PDF']['NativeId']);
+      }
+
       // Next, try with version series ID.
       if (!$agenda_link && !empty($data['PDF']) && !empty($data['PDF']['VersionSeriesId'])) {
         $agenda_link = $caseService->getDecisionUrlByVersionSeriesId($data['PDF']['VersionSeriesId']);


### PR DESCRIPTION
This PR improves data aggregation, moving decisions and meeting integrations from JSON files into a Drupal queue.

Error and duplication handling is also improved:
* Items that are added to the queue are checked for duplicates, which should reduce changes of the same failed items and large datasets from clogging up the more important queues.
* Cases where data fetching fails are eventually moved to an error queue instead of being retried forever.

**To test**
* Checkout branch, run `make new`
* Login to the container with `make shell` and pull in test data with `drush mim ahjo_decisionmakers:all`
* Read code changes to make sure there's nothing weird there

**Improvements to decisionmakers list**
* Login with `drush uli` and go to https://helsinki-paatokset.docker.so/en/admin/content/decisionmakers
* The "Sector" and "Organization Name" columns should be visible in the table
* There should be a filter for "Organization name"

**Aggregation changes**
* Run the following commands inside the container to add aggregation data into the processing queue:
  * `drush ap:agg meetings --dataset=latest --start=2023-06-16T00:00:00 --queue -v`
  * `drush ap:agg decisions --dataset=latest --queue -v`
  * `drush ahjo-proxy:aggregate meetings --dataset=cancelled --cancelledonly --queue -v`
* Verify that items were added to the queue: `drush ac:la`
* Process the queue with: `drush queue:run ahjo_api_aggregation_queue -v` (this will take a long time)
* Confirm content was created via aggreation:
  * https://helsinki-paatokset.docker.so/en/admin/content/meetings
  * https://helsinki-paatokset.docker.so/en/admin/content/decisions

**Aggregation duplicate handling**
* Add data to the queues again with:
  * `drush cron` (this will add failed items back to the queue) 
  * `drush ap:agg meetings --dataset=latest --start=2023-06-16T00:00:00 --queue -v`
  * `drush ap:agg decisions --dataset=latest --queue -v`
  * You might get some errors already about not being able to add data to the queues. This is fine.
* Run these commands again:
  * `drush ap:agg meetings --dataset=latest --start=2023-06-16T00:00:00 --queue -v`
  * `drush ap:agg decisions --dataset=latest --queue -v`
  * You should get a lot of errors this time, because the system should not allow you to add duplicates to the queue
  * Verify this by running: `drush ac:la`. The unique item amount should match the amount of total items (or should at least be very close)

**Aggregation error handling**
* Edit this file: `/public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php`
* Replace line 84 with `$status = 999;`
  * This will cause all data migrations to fail 
* Replace lines 147 and 150 with `$max_time = (int) (new \DateTime('NOW - 3 SECONDS'))->format('U');`
  * This will cause all items to be immediately moved to the retry and error queues (so you don't have to wait 3 days) 
* Run `drush cr`
* Check that the retry and error queues are actually empty:
  * `drush ac:lr`
  * `drush ac:le` 
* Run `drush queue:run ahjo_api_aggregation_queue -v`
  * All the items should fail with a warning and a note  about them being moved
  * Confirm that the items are now in the retry queue: `drush ac:lr`
* Run the retry queue with: `drush queue:run ahjo_api_retry_queue -v`
  * Confirm that the items are now in the error queue: `drush ac:le`
* Run the error queue with `drush queue:run ahjo_api_error_queue -v`
  * This should fail with an error instead of a warning
* Return the failed items back into the queue with `drush cron`
* Add data back to the aggregation queue:
  * `drush ap:agg meetings --dataset=latest --start=2023-06-16T00:00:00 --queue -v`
  * `drush ap:agg decisions --dataset=latest --queue -v`
* Run the queues again:
  * `drush queue:run ahjo_api_aggregation_queue -v
  * `drush queue:run ahjo_api_retry_queue -v
* Check the error queue with `drush ac:le`. There should be no duplicates in this list.