### PR TITLE
PP-501: Enable Swedish trustee translation migration.

### DIFF
--- a/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
@@ -46,8 +46,8 @@ do
     echo "Migrating data for council members: $(date)"
     drush migrate-reset-status ahjo_trustees:council
     drush migrate-import ahjo_trustees:council --update
-    #drush migrate-reset-status ahjo_trustees:council_sv
-    #drush migrate-import ahjo_trustees:council_sv --update
+    drush migrate-reset-status ahjo_trustees:council_sv
+    drush migrate-import ahjo_trustees:council_sv --update
     echo "Migrating data for decisionmakers: $(date)"
     drush migrate-reset-status ahjo_decisionmakers:latest
     drush migrate-reset-status ahjo_decisionmakers:latest_sv


### PR DESCRIPTION
This enables automatic fetching of Swedish trustee translations. Should be merged after a few manual migrations to see that it works without issue.

Or if https://helsinkisolutionoffice.atlassian.net/browse/PP-502 is completed before this is ready to be enabled, this PR should be closed.