### PR TITLE
PP-491: Improve decisionmaker title field override

### DIFF
--- a/conf/cmi/core.entity_form_display.node.policymaker.default.yml
+++ b/conf/cmi/core.entity_form_display.node.policymaker.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.policymaker.field_organization_color_code
     - field.field.node.policymaker.field_organization_type
     - field.field.node.policymaker.field_organization_type_id
+    - field.field.node.policymaker.field_override_title
     - field.field.node.policymaker.field_policymaker_dissolved
     - field.field.node.policymaker.field_policymaker_existing
     - field.field.node.policymaker.field_policymaker_formed
@@ -40,6 +41,7 @@ dependencies:
     - media_library
     - paragraphs
     - path
+    - publication_date
     - readonly_field_widget
     - scheduler
     - text
@@ -64,7 +66,7 @@ third_party_settings:
       label: 'Integration data'
       region: content
       parent_name: ''
-      weight: 1
+      weight: 3
       format_type: details
       format_settings:
         classes: ''
@@ -83,7 +85,7 @@ third_party_settings:
       label: 'Basic information'
       region: content
       parent_name: ''
-      weight: 2
+      weight: 4
       format_type: details
       format_settings:
         classes: ''
@@ -101,7 +103,7 @@ third_party_settings:
       label: 'Section descriptions'
       region: content
       parent_name: ''
-      weight: 3
+      weight: 5
       format_type: details
       format_settings:
         classes: ''
@@ -112,13 +114,13 @@ third_party_settings:
         required_fields: false
     group_organization_label:
       children:
-        - field_custom_organization_type
         - field_city_council_division
+        - field_custom_organization_type
         - field_organization_color_code
       label: 'Organization label'
       region: content
       parent_name: ''
-      weight: 0
+      weight: 2
       format_type: details
       format_settings:
         classes: ''
@@ -134,7 +136,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 11
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -183,7 +185,7 @@ content:
     third_party_settings: {  }
   field_contacts:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS
@@ -193,7 +195,7 @@ content:
     third_party_settings: {  }
   field_custom_menu_links:
     type: entity_reference_paragraphs
-    weight: 4
+    weight: 6
     region: content
     settings:
       title: Paragraph
@@ -312,6 +314,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_override_title:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_policymaker_dissolved:
     type: datetime_default
     weight: 12
@@ -381,30 +390,30 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 8
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 10
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 10
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -419,7 +428,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 16
     region: content
     settings:
       match_operator: CONTAINS
@@ -429,12 +438,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 7
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 9
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.policymaker.default.yml
+++ b/conf/cmi/core.entity_view_display.node.policymaker.default.yml
@@ -22,6 +22,7 @@ dependencies:
     - field.field.node.policymaker.field_organization_color_code
     - field.field.node.policymaker.field_organization_type
     - field.field.node.policymaker.field_organization_type_id
+    - field.field.node.policymaker.field_override_title
     - field.field.node.policymaker.field_policymaker_dissolved
     - field.field.node.policymaker.field_policymaker_existing
     - field.field.node.policymaker.field_policymaker_formed
@@ -117,6 +118,16 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_override_title:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 14
     region: content
   field_policymaker_image:
     type: entity_reference_entity_view

--- a/conf/cmi/field.field.node.policymaker.field_override_title.yml
+++ b/conf/cmi/field.field.node.policymaker.field_override_title.yml
@@ -1,0 +1,23 @@
+uuid: b9bbbbe1-38de-4e22-925a-69fcfc19789b
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_override_title
+    - node.type.policymaker
+id: node.policymaker.field_override_title
+field_name: field_override_title
+entity_type: node
+bundle: policymaker
+label: 'Override title'
+description: 'Customize organization title instead of using value from AHJO.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Käytössä
+  off_label: 'Pois päältä'
+field_type: boolean

--- a/conf/cmi/field.storage.node.field_override_title.yml
+++ b/conf/cmi/field.storage.node.field_override_title.yml
@@ -1,0 +1,18 @@
+uuid: 610c92b2-f812-4fda-bbfa-78525b29c0ee
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_override_title
+field_name: field_override_title
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisionmakers.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_decisionmakers.yml
@@ -72,6 +72,7 @@ source:
       type: string
   constants:
     title_field: title
+    title_override_field: field_override_title
 process:
   type:
     plugin: default_value
@@ -85,10 +86,11 @@ process:
     source: decisionmaker_id
   title:
     plugin: callback
-    callable: _paatokset_ahjo_api_get_existing_value
+    callable: _paatokset_ahjo_api_get_existing_value_with_override
     source:
       - '@nid'
       - 'constants/title_field'
+      - 'constants/title_override_field'
       - 'title'
       - '@langcode'
   field_ahjo_title:
@@ -104,14 +106,14 @@ process:
     source: existing
   field_policymaker_formed:
     plugin: format_date
-    from_format: 'Y-m-d\TH:i:s.000'
+    from_format: 'Y-m-d\TH:i:s.v'
     to_format: 'Y-m-d\TH:i:s'
     from_timezone: Europe/Helsinki
     to_timezone: UTC
     source: formed
   field_policymaker_dissolved:
     plugin: format_date
-    from_format: 'Y-m-d\TH:i:s.000'
+    from_format: 'Y-m-d\TH:i:s.v'
     to_format: 'Y-m-d\TH:i:s'
     from_timezone: Europe/Helsinki
     to_timezone: UTC

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -920,6 +920,40 @@ function _paatokset_ahjo_api_get_existing_value(array $values) {
 }
 
 /**
+ * Get existing value, if node already exists and title field is overridden.
+ */
+function _paatokset_ahjo_api_get_existing_value_with_override(array $values) {
+  $nid = $values[0];
+  $field = $values[1];
+  $override_field = $values[2];
+  $default = $values[3];
+  $langcode = $values[4];
+
+  if (!$nid) {
+    return $default;
+  }
+
+  $node = Node::load($nid);
+  if ($node->hasTranslation($langcode)) {
+    $node = $node->getTranslation($langcode);
+  }
+  else {
+    return $default;
+  }
+
+  if (!$node instanceof NodeInterface) {
+    return $default;
+  }
+
+  // Return existing value if override field is value is not empty.
+  if ($node->hasField($override_field) && $node->get($override_field)->value && $node->hasField($field) && !$node->get($field)->isEmpty()) {
+    return $node->get($field)->value;
+  }
+
+  return $default;
+}
+
+/**
  * Get top category name from classifiction code.
  *
  * @param mixed $values


### PR DESCRIPTION
Fixes issue with overriding decisionmaker titles. Previously the migration wouldn't import titles from the API if they had been changed in Drupal, but this overlooked cases where the title was actually updated in the API.

**To test**
- Checkout branch
- Run `make drush-cim drush-cr shell`
- Run `drush mim ahjo_decisionmakers:all;drush mim ahjo_decisionmakers:all_sv`
- Open https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto and https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus
- Edit the finnish and swedish titles to:
  - "Helsingin kaupunginvaltuusto" and "Helsingfors stadsfullmäktige"
  - "Helsingin kaupunginhallitus" and "Helsingfors stadsstyrelsen"
- When editing the nodes, there should be a new "Override title" toggle below the title. Turn this on for Kaupunginvaltuusto but not Kaupunginhallitus
- Run `drush mim ahjo_decisionmakers:all --update;drush mim ahjo_decisionmakers:all_sv --update`
- The Kaupunginvaltuusto titles should remain in the form you edited them to, but the Kaupunginhallitus titles should be reverted
- Read code changes