### PR TITLE
PP-492: Decision fallback from redirect

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -7,7 +7,6 @@ use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
-use Drupal\redirect\Entity\Redirect;
 
 /**
  * Service class for retrieving case and decision-related data.
@@ -228,7 +227,6 @@ class CaseService {
     return array_shift($decision_nodes);
   }
 
-
   /**
    * Get decision node from redirect data.
    *
@@ -237,7 +235,7 @@ class CaseService {
    * @param string $decision_id
    *   ID for decision.
    *
-   * @return NodeInterface|null
+   * @return \Drupal\node\NodeInterface|null
    *   Decision node, if one can be found based on a redirect.
    */
   private function getDecisionFromRedirect(string $case_id, string $decision_id): ?NodeInterface {
@@ -263,7 +261,7 @@ class CaseService {
    * @param string $source_path
    *   Source path to check.
    *
-   * @return NodeInterface|null
+   * @return \Drupal\node\NodeInterface|null
    *   Node, if a redirect is found and it points directly to entity.
    */
   private function getNodeFromRedirectSource(string $source_path): ?NodeInterface {

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -863,7 +863,7 @@ class CaseService {
       // Try to get localized route if one exists for current language.
       $localizedRoute = 'paatokset_case.' . $langcode;
       if ($this->routeExists($localizedRoute)) {
-        $case_url = Url::fromRoute($localizedRoute, ['case_id' => strtolower($native_id)]);
+        $case_url = Url::fromRoute($localizedRoute, ['case_id' => strtolower($case_id)]);
       }
       // If langcode is set, we don't want an URL without a localized route.
       elseif ($strict_lang) {

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -479,8 +479,9 @@ class CaseService {
       $langcode === $this->language;
     }
 
-    // Langcode is used for checking if aliases (and nodes) exists.
-    // Decision nodes only exist in finnish and swedish.
+    // Langcode is only used for checking if aliases (and nodes) exists,
+    // because decision nodes only exist in finnish and swedish.
+    // Actual URL is generated with current language with the localized route.
     if ($langcode === 'sv') {
       $prefix = 'arende';
     }

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -771,6 +771,12 @@ class PolicymakerService {
         $section = '';
       }
 
+      // Try to get link without node data first with fi langcode and then sv.
+      $link = $caseService->getDecisionUrlWithoutNode($data->field_decision_native_id_value, $data->field_diary_number_value, 'fi');
+      if (!$link) {
+        $link = $caseService->getDecisionUrlWithoutNode($data->field_decision_native_id_value, $data->field_diary_number_value, 'sv');
+      }
+
       $result = [
         'year' => $year,
         'date_desktop' => date('d.m.Y', $timestamp),
@@ -778,7 +784,7 @@ class PolicymakerService {
         'timestamp' => $timestamp,
         'subject' => $decision_label,
         'section' => $section,
-        'link' => $caseService->getDecisionUrlLight($id, $data->field_decision_native_id_value, $data->field_diary_number_value),
+        'link' => $link,
       ];
 
       $results[] = $result;


### PR DESCRIPTION
Fixes an issue with old motion URLs getting stuck in the Elasticsearch index when they are converted to decisions. This checks redirect data to load the correct entity instead of showing a blank page.

Also adds some minor improvements to office holder decision list handling.

**Replicate issue**
- Before checking out branch, run these commands:
```
drush mim ahjo_decisionmakers:all --update
drush ap:agg decisions --dataset=all --queue --decisionmaker_id=u4804005010vh1 -v
drush ap:update decisions 11b5b467-e4aa-4a08-904f-c6a38d973ec5 -v
drush ap:update cases hel-2023-009076 -v
drush queue:run ahjo_api_aggregation_queue -v
drush ap:ud -v
drush queue:run ahjo_api_retry_queue -v
```
- Go to: https://helsinki-paatokset.docker.so/fi/asia/hel-2023-009076?paatos=11b5b467-e4aa-4a08-904f-c6a38d973ec5
  - The decision should load correctly 
- Go to https://helsinki-paatokset.docker.so/fi/asia/hel-2023-009076/11b5b467-e4aa-4a08-904f-c6a38d973ec5
  - Edit the node. Open the "Decision data" section and change the "Native ID" field to `{123}`
  - Now when you reload the page, you should be redirected to https://helsinki-paatokset.docker.so/fi/asia/hel-2023-009076/123
- When you reload the first URL, the content area should be empty (because the ID has changed)
- Go to: https://helsinki-paatokset.docker.so/fi/paattajat/aluekirjastopalvelujen-johtaja-aluekirjastopalvelut/paatokset
  - The URLs should be slightly malformed, for example: https://helsinki-paatokset.docker.so/fi/asia/7ac57e34-3eed-4d9d-9c2a-537a2f2d2f3e?paatos=7ac57e34-3eed-4d9d-9c2a-537a2f2d2f3e (the ID is there twice)

**To test**
- Checkout branch, run `make drush-cr`
- Reload this URL again: https://helsinki-paatokset.docker.so/fi/asia/hel-2023-009076?paatos=11b5b467-e4aa-4a08-904f-c6a38d973ec5
  - The content should be visible now 
- Reload this URL: https://helsinki-paatokset.docker.so/fi/paattajat/aluekirjastopalvelujen-johtaja-aluekirjastopalvelut/paatokset
  - The URLs should be in the correct format now (for example https://helsinki-paatokset.docker.so/fi/asia/hel-2023-006865?paatos=7ac57e34-3eed-4d9d-9c2a-537a2f2d2f3e , the URL should include both the case ID and the decision ID)
- Read the code changes to check they make sense