### PR TITLE
Draft: PP-499: Enable elasticsearch agenda lists

### DIFF
--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -168,7 +168,7 @@ function paatokset_policymakers_preprocess_node__policymaker(&$variables) {
     }
     else {
       // Get the two most recent decisions.
-      $recentDecisions = $policymakerService->getAgendasList(2, FALSE);
+      $recentDecisions = $policymakerService->getAgendasListFromElasticSearch(2, FALSE);
       if (!empty($recentDecisions)) {
         $variables['recent_decisions'] = $recentDecisions;
         $variables['all_decisions_link'] = $policymakerService->getDecisionsRoute();

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/AgendasSubmenuBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/AgendasSubmenuBlock.php
@@ -35,7 +35,7 @@ class AgendasSubmenuBlock extends BlockBase {
    * Build the attributes.
    */
   public function build() {
-    $list = $this->policymakerService->getAgendasList(NULL, TRUE);
+    $list = $this->policymakerService->getAgendasListFromElasticSearch(NULL, TRUE);
     $years = array_keys($list);
 
     return [


### PR DESCRIPTION
This should only be merged after !294 has been deployed to production and all decision content has been reindexed.