### PR TITLE
UHF-8581: statements for city council members

### DIFF
--- a/public/modules/custom/paatokset_datapumppu/drush.services.yml
+++ b/public/modules/custom/paatokset_datapumppu/drush.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\paatokset_datapumppu\Commands\DatapumppuCommands
     tags:
       - { name: drush.command }
-    arguments: ['@logger.factory', '@entity_type.manager', '@entity.memory_cache', '@paatokset_datapumppu']
+    arguments: ['@logger.factory', '@entity_type.manager', '@entity.memory_cache', '@paatokset_policymakers', '@paatokset_datapumppu']

--- a/public/modules/custom/paatokset_datapumppu/src/Service/Datapumppu.php
+++ b/public/modules/custom/paatokset_datapumppu/src/Service/Datapumppu.php
@@ -86,9 +86,14 @@ class Datapumppu {
 
     $this->logger->info("Fetching from $endpoint");
 
+    /** @var \Drupal\migrate\Plugin\MigrationInterface|false $migration */
     $migration = $this->migrationManager->createInstance(static::STATEMENTS_MIGRATION_ID, $configuration);
     if ($migration === FALSE) {
       return MigrationInterface::RESULT_DISABLED;
+    }
+
+    if ($migration->getStatus() !== MigrationInterface::STATUS_IDLE) {
+      $this->logger->warning("Migration is running. If the problem persists, consider: drush migrate-reset-status " . static::STATEMENTS_MIGRATION_ID);
     }
 
     // Execute the migration.

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerLazyBuilder.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerLazyBuilder.php
@@ -80,7 +80,7 @@ class PolicymakerLazyBuilder implements TrustedCallbackInterface {
    *   The render array.
    */
   public function policymakersCards(): array {
-    $council = $this->policymakerService->getPolicyMaker('02900');
+    $council = $this->policymakerService->getPolicyMaker(PolicymakerService::CITY_COUNCIL_DM_ID);
     $board = $this->policymakerService->getPolicyMaker('00400');
 
     $cache_tags = [];
@@ -357,7 +357,7 @@ class PolicymakerLazyBuilder implements TrustedCallbackInterface {
    */
   protected function getCouncilMembersAccordion(): ?array {
     // City council nodes.
-    $nodes = $this->policymakerService->getComposition('02900');
+    $nodes = $this->policymakerService->getComposition(PolicymakerService::CITY_COUNCIL_DM_ID);
 
     $filter = 'Jäsen';
     $members = array_filter($nodes, function ($var) use ($filter) {


### PR DESCRIPTION
# [UHF-8581](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8581)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

 * Add drush command `datapumppu:latest-statements` that fetches trustee statements only from city council memebers

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8581-statements-for-city-council-members`
* Run `make drush-cr`
* Import all trustees (around 400): 
  ```
  drush mim ahjo_trustees:all
  ```

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Run `drush datapumppu:latest-statements -v`. It should not query datapumppu for all 400 trustee nodes.
* [x] Existing functionality on https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto should still work.


[UHF-8581]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ