### PR TITLE
UHF-8850: Decision handling improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - 3306
     networks:
       - internal
+    command: --max_allowed_packet=128M
   varnish:
     container_name: "${COMPOSE_PROJECT_NAME}-varnish"
     image: druidfi/varnish:6-drupal

--- a/docker/openshift/crons/run-immediate-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-immediate-ahjo-integrations.sh
@@ -10,6 +10,7 @@ do
   drush queue:run ahjo_api_subscriber_queue --time-limit=240 -v
   echo "Generating motions from meeting data: $(date)"
   drush ahjo-proxy:get-motions -v
+  drush ahjo-proxy:parse-decision-content --limit=100 -v
   if [ ${APP_ENV} = 'production' ]; then
     echo "Updating decision and motion data: $(date)"
     drush ahjo-proxy:update-decisions -v

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -991,7 +991,7 @@ function _paatokset_ahjo_api_get_top_category(array $values): ?string {
 function _paatokset_ahjo_api_parse_decision_content($value): string|null {
   /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
   $caseService = \Drupal::service('paatokset_ahjo_cases');
-  return $caseService->parseContentSectionsFromHtml((string) $value);
+  return $caseService->parseContentSectionsFromHtml((string) $value, TRUE);
 }
 
 /**
@@ -1006,7 +1006,7 @@ function _paatokset_ahjo_api_parse_decision_content($value): string|null {
 function _paatokset_ahjo_api_parse_decision_motion($value): string|null {
   /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
   $caseService = \Drupal::service('paatokset_ahjo_cases');
-  return $caseService->parseContentSectionsFromHtml((string) $value);
+  return $caseService->parseContentSectionsFromHtml((string) $value, TRUE);
 }
 
 /**

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -1546,7 +1546,7 @@ class CaseService {
     // More information.
     $more_info = $content_xpath->query("//*[contains(@class, 'LisatiedotOtsikko')]");
     $more_info_content = NULL;
-    if ($more_info) {
+    if ($more_info->length > 0) {
       $more_info_content = $this->getHtmlContentUntilBreakingElement($more_info);
       $more_info_content = str_replace(': 310', ': 09 310', $more_info_content);
     }
@@ -1561,7 +1561,7 @@ class CaseService {
     // Signature information.
     $signature_info = $content_xpath->query("//*[contains(@class, 'SahkoisestiAllekirjoitettuTeksti')]");
     $signature_info_content = NULL;
-    if ($signature_info) {
+    if ($signature_info->length > 0) {
       $signature_info_content = $this->getHtmlContentUntilBreakingElement($signature_info);
     }
 
@@ -1575,7 +1575,7 @@ class CaseService {
     // Presenter information.
     $presenter_info = $content_xpath->query("//*[contains(@class, 'EsittelijaTiedot')]");
     $presenter_content = NULL;
-    if ($presenter_info) {
+    if ($presenter_info->length > 0) {
       $presenter_content = $this->getHtmlContentUntilBreakingElement($presenter_info);
     }
 
@@ -1589,7 +1589,7 @@ class CaseService {
     // Decision history.
     $decision_history = $history_xpath->query("//*[contains(@class, 'paatoshistoria')]");
     $decision_history_content = NULL;
-    if ($decision_history) {
+    if ($decision_history->length > 0) {
       $decision_history_content = $this->getDecisionHistoryHtmlContent($decision_history);
     }
     if ($decision_history_content) {

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -1681,7 +1681,18 @@ class CaseService {
     }
 
     if ($strip_tags) {
-      $allowed_tags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'p'];
+      $allowed_tags = [
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'ul',
+        'ol',
+        'li',
+        'p',
+      ];
       return strip_tags($content, $allowed_tags);
     }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -1639,17 +1639,19 @@ class CaseService {
    *   Decision node.
    * @param string $field_name
    *   Which field to get raw data from.
+   * @param bool $strip_tags
+   *   Only allow text related tags, strip images etc.
    *
    * @return string|null
    *   Parsed content HTML as string, if found.
    */
-  public function getDecisionContentFromHtml(NodeInterface $node, string $field_name): ?string {
+  public function getDecisionContentFromHtml(NodeInterface $node, string $field_name, bool $strip_tags = FALSE): ?string {
     if (!$node instanceof NodeInterface || !$node->hasField($field_name) || $node->get($field_name)->isEmpty()) {
       return NULL;
     }
 
     $html = $node->get($field_name)->value;
-    return $this->parseContentSectionsFromHtml($html);
+    return $this->parseContentSectionsFromHtml($html, $strip_tags);
   }
 
   /**
@@ -1657,11 +1659,13 @@ class CaseService {
    *
    * @param string $html
    *   Input HTML.
+   * @param bool $strip_tags
+   *   Only allow text related tags, strip images etc.
    *
    * @return string|null
    *   Content sections, if found.
    */
-  public function parseContentSectionsFromHtml(string $html): ?string {
+  public function parseContentSectionsFromHtml(string $html, bool $strip_tags = FALSE): ?string {
     $dom = new \DOMDocument();
     if (!empty($html)) {
       @$dom->loadHTML($html);
@@ -1674,6 +1678,11 @@ class CaseService {
 
     foreach ($sections as $section) {
       $content .= $section->ownerDocument->saveHTML($section);
+    }
+
+    if ($strip_tags) {
+      $allowed_tags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'p'];
+      return strip_tags($content, $allowed_tags);
     }
 
     return $content;

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -1676,6 +1676,11 @@ class CaseService {
     // Main decision content sections.
     $sections = $xpath->query("//*[contains(@class, 'SisaltoSektio')]");
 
+    // If content sections are empty (confidential data), use title instead.
+    if ($sections->length === 0) {
+      $sections = $xpath->query("//*[contains(@class, 'AsiaOtsikko')]");
+    }
+
     foreach ($sections as $section) {
       $content .= $section->ownerDocument->saveHTML($section);
     }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1800,13 +1800,13 @@ class AhjoProxy implements ContainerInjectionInterface {
     $caseService = \Drupal::service('paatokset_ahjo_cases');
     $node = Node::load($data['nid']);
 
-    $decision_content = $caseService->getDecisionContentFromHtml($node, 'field_decision_content');
     if ($node->hasField('field_decision_content_parsed')) {
+      $decision_content = $caseService->getDecisionContentFromHtml($node, 'field_decision_content', TRUE);
       $node->set('field_decision_content_parsed', $decision_content);
     }
 
-    $decision_motion = $caseService->getDecisionContentFromHtml($node, 'field_decision_motion');
     if ($node->hasField('field_decision_motion_parsed')) {
+      $decision_motion = $caseService->getDecisionContentFromHtml($node, 'field_decision_motion', TRUE);
       $node->set('field_decision_motion_parsed', $decision_motion);
     }
 

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -1440,11 +1440,17 @@ class AhjoAggregatorCommands extends DrushCommands {
       ->latestRevision();
 
     if (isset($options['logic']) && $options['logic'] === 'motion') {
-      $query->notExists('field_decision_motion_parsed');
+      $or = $query->orConditionGroup();
+      $or->notExists('field_decision_motion_parsed');
+      $or->condition('field_decision_motion_parsed', '');
+      $query->condition($or);
       $query->condition('field_decision_motion', '', '<>');
     }
     else {
-      $query->notExists('field_decision_content_parsed');
+      $or = $query->orConditionGroup();
+      $or->notExists('field_decision_content_parsed');
+      $or->condition('field_decision_content_parsed', '');
+      $query->condition($or);
       $query->condition('field_decision_content', '', '<>');
     }
 


### PR DESCRIPTION
# [UHF-8850](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8850)

## What was done
* Fixes decision content parsing to strip embedded images (and other irrelevant tags). This prevents base64 encoded images from ending up in the ElasticSearch index

## Replicate issue
* Enable dblog and pull in test data:
```
drush en dblog;
drush ap:agg decisions --dataset=latest --decisionmaker_id=U511053004070VH1 --queue --start=2023-01-01T00:00:00 -v;
drush queue:run ahjo_api_aggregation_queue -v;
```
* Now when you go to https://helsinki-paatokset.docker.so/fi/admin/content/decisions you should get a WSOD or an error page
* Check out the error in the logs, there should be a message about "packets out of order" / "packet size"
* Try to index the decisions you pulled in: `drush sapi-rt decisions;drush sapi-i decisions`
  * You should get the same SQL connection errors  
* Try to edit this node: https://helsinki-paatokset.docker.so/fi/asia/hel-2023-006949/6414d562-0d06-c715-a639-8938cff00001
  * You might get an error. If not, check the "Decision Content" field. This should include base64 encoded image data. 

## How to install and test
* Checkout branch, run `make up` and `make drush-cr`
* This page should load properly now: https://helsinki-paatokset.docker.so/fi/admin/content/decisions
* Run this command to reimport one of the decisions: `drush ap:update decisions 6414d562-0d06-c715-a639-8938cff00001 -v`
  * Reload the node you tried to edit earlier. The "Decision Content" field should now only basic text content and the images should be missing.
  * When you view the node, the images should still be visible (because they are parsed from the raw HTML data field)
* Get rid of all the parsed content field data from the db:
  * `drush sql:cli`
  * And then: 
```
truncate node__field_decision_content_parsed;
truncate node_revision__field_decision_content_parsed;
```
* Run `drush ahjo-proxy:parse-decision-content -v` to reparse the content
* Now the indexing should work again: `drush sapi-c decisions;drush sapi-rt decisions;drush sapi-i decisions`
  * You might have to detroy the ES container and run `make up` again if the errors persist. 
* Pull in one more decision: `drush ap:update decisions {0D5E9CB4-A5F7-4F3E-90B5-D9AB0C92A04A} -v`
  * This is a confidential decision with empty content sections 
  * Run `drush ahjo-proxy:parse-decision-content -v`. You should get a "Nothing to import" message. When you edit the node the heading should be in the parsed content section. (This is to check that the parsing script doesn't get stuck looping through empty content).

## How to test
* [x] Check that code follows our standards
* [x] The decisions content list loads properly
* [x] Embedded images are removed from the decisions node's parsed content fields
* [x] Decisions with empty content sections don't get stuck in the parsing queue.

[UHF-8850]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ