### PR TITLE
UHF-8583: Add cron job for datapumppu integration

### DIFF
--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -21,6 +21,7 @@ exec "/crons/purge-queue.sh" &
 exec "/crons/run-helsinki-integrations.sh" &
 exec "/crons/run-aggregated-ahjo-integrations.sh" &
 exec "/crons/run-immediate-ahjo-integrations.sh" &
+exec "/crons/run-datapumppu-integrations.sh" &
 exec "/crons/search-index.sh" &
 
 while true

--- a/docker/openshift/crons/run-datapumppu-integrations.sh
+++ b/docker/openshift/crons/run-datapumppu-integrations.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Sleep 100 seconds.
+sleep 100
+
+while true
+do
+  echo "Running Datapumppu migration: $(date)"
+  drush migrate:import datapumppu_statements -v --no-progress
+
+  # Sleep for 24 hours.
+  sleep 86400
+
+  echo "Reset datapumppu migration"
+  drush migrate-reset-status datapumppu_statements 2>/dev/null
+done


### PR DESCRIPTION
# [UHF-8583](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8583)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add cron job that runs `drush datapumppu:latest-statements -v` every 24 hours.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8583-datapumppu-cron`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Review changes
* [x] Try running `/app/docker/openshift/crons/run-datapumppu-integrations.sh` (sleeps 100s before starting the migration).

## Relates to
#308 


[UHF-8583]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ