### PR TITLE
UHF-8852 search language handling

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
@@ -3,5 +3,6 @@ services:
     class: Drupal\paatokset_ahjo_api\Service\MeetingService
   paatokset_ahjo_cases:
     class: Drupal\paatokset_ahjo_api\Service\CaseService
+    arguments: ['@language_manager']
   paatokset_ahjo_trustees:
     class: Drupal\paatokset_ahjo_api\Service\TrusteeService

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -746,9 +746,6 @@ class CaseService {
       return $decision->toUrl();
     }
 
-    $decision_id = $decision->get('field_decision_native_id')->getString();
-    $decision_id = $this->normalizeNativeId($decision_id);
-
     try {
       $decision = $this->getDecisionTranslation($decision, $langcode);
     }
@@ -758,6 +755,9 @@ class CaseService {
       // decisions in invalid languages if for example a Swedish translation is
       // requested and the translation does not exist.
     }
+
+    $decision_id = $decision->get('field_decision_native_id')->getString();
+    $decision_id = $this->normalizeNativeId($decision_id);
 
     // Special fallback for decisions without diary numbers.
     if (!$decision->hasField('field_diary_number') || $decision->get('field_diary_number')->isEmpty()) {

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -126,7 +126,7 @@ class CaseService {
    * @param string $decision_id
    *   Decision native ID.
    */
-  public function setEntitiesById(?string $case_id = NULL, string $decision_id): void {
+  public function setEntitiesById(?string $case_id, string $decision_id): void {
     if ($case_id !== NULL) {
       $case_nodes = $this->caseQuery([
         'case_id' => $case_id,

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/DecisionUrl.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/DecisionUrl.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\paatokset_search\Plugin\search_api\processor;
 
 use Drupal\Core\Url;
+use Drupal\paatokset_ahjo_api\Service\CaseService;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Computes the decision URL for the indexed decision.
@@ -23,6 +27,24 @@ use Drupal\search_api\Processor\ProcessorProperty;
  * )
  */
 class DecisionUrl extends ProcessorPluginBase {
+
+  /**
+   * Case service.
+   *
+   * @var \Drupal\paatokset_ahjo_api\Service\CaseService
+   */
+  private CaseService $caseService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $instance */
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->caseService = $container->get('paatokset_ahjo_cases');
+
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
@@ -49,10 +71,8 @@ class DecisionUrl extends ProcessorPluginBase {
   public function addFieldValues(ItemInterface $item) {
     $datasourceId = $item->getDatasourceId();
     if ($datasourceId === 'entity:node' && $decision = $item->getOriginalObject()->getValue()) {
-      $langcode = $decision->get('langcode');
-      /** @var \Drupal\paatokset_ahjo_api\Service\CaseService */
-      $caseService = \Drupal::service('paatokset_ahjo_cases', $langcode);
-      $decisionUrl = $caseService->getDecisionUrlFromNode($decision);
+      $language = $decision->language();
+      $decisionUrl = $this->caseService->getDecisionUrlFromNode($decision, $language->getId());
       $fields = $this->getFieldsHelper()->filterForPropertyPath($item->getFields(), 'entity:node', 'decision_url');
       if ($decisionUrl instanceof Url && isset($fields['decision_url'])) {
         $fields['decision_url']->addValue($decisionUrl->toString());

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/HasTranslation.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/HasTranslation.php
@@ -4,7 +4,6 @@ namespace Drupal\paatokset_search\Plugin\search_api\processor;
 
 use Drupal\node\NodeInterface;
 use Drupal\paatokset_ahjo_api\Service\CaseService;
-use Drupal\paatokset_policymakers\Service\PolicymakerService;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/HasTranslation.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/HasTranslation.php
@@ -3,10 +3,13 @@
 namespace Drupal\paatokset_search\Plugin\search_api\processor;
 
 use Drupal\node\NodeInterface;
+use Drupal\paatokset_ahjo_api\Service\CaseService;
+use Drupal\paatokset_policymakers\Service\PolicymakerService;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Checks if node has translations, with special cases for decisions.
@@ -23,6 +26,24 @@ use Drupal\search_api\Processor\ProcessorProperty;
  * )
  */
 class HasTranslation extends ProcessorPluginBase {
+
+  /**
+   * Case service.
+   *
+   * @var \Drupal\paatokset_ahjo_api\Service\CaseService
+   */
+  private CaseService $caseService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $processor */
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->caseService = $container->get('paatokset_ahjo_cases');
+
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
@@ -73,33 +94,17 @@ class HasTranslation extends ProcessorPluginBase {
    *   Node to check translations for.
    *
    * @return bool
-   *   If node has translations.
+   *   True if node has translations.
    */
   private function checkNodeTranslation(NodeInterface $node): bool {
-    // Not including default language.
     $translations = $node->getTranslationLanguages(FALSE);
     if (count($translations) >= 1) {
       return TRUE;
     }
 
-    // Special cases for decisions.
-    if ($node->getType() !== 'decision') {
-      return FALSE;
-    }
-
-    if (!$node->hasField('field_unique_id') || $node->get('field_unique_id')->isEmpty()) {
-      return FALSE;
-    }
-
-    /** @var \Drupal\paatokset_ahjo_api\Service\CaseService */
-    $caseService = \Drupal::service('paatokset_ahjo_cases');
-    $nids = $caseService->decisionQuery([
-      'unique_id' => $node->get('field_unique_id')->value,
-    ], FALSE);
-
-    // If we get more than one result, we can assume the node has translations.
-    if (count($nids) >= 2) {
-      return TRUE;
+    // Decisions don't use built-in translations.
+    if ($node->getType() === 'decision') {
+      return $this->caseService->decisionHasTranslations($node);
     }
 
     return FALSE;


### PR DESCRIPTION
# [UHF-8852](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8852)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Attempt to index Swedish decision urls correctly. Attempts to clean the code a bit.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8852-search-language-handling`
* Have a working paatokset database

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check with debugger that decision_url SearchApiProcessor generates correct urls.
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* City-of-Helsinki/paatokset-search#28

[UHF-8852]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ