### PR TITLE
UHF-8852: update search app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
         "league/csv": "^9.8",
-        "paatokset/paatokset_search": "1.0.26"
+        "paatokset/paatokset_search": "1.0.27"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -127,9 +127,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "1.0.26",
+                "version": "1.0.27",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.26/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.27/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "911d6f9c6a79adf2e6327c2e29fe008e",
+    "content-hash": "81e47337d80091e69c4e9a71a9e6a18e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8018,7 +8018,8 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/josdejong/jsoneditor/archive/v5.29.1.zip"
+                "url": "https://github.com/josdejong/jsoneditor/archive/v5.29.1.zip",
+                "reference": "v5.29.1"
             },
             "type": "drupal-library"
         },
@@ -8993,10 +8994,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "1.0.26",
+            "version": "1.0.27",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.26/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.0.27/paatokset_search.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
# [UHF-8852](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8852)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updates `paatokset_search` to version [1.0.27](https://github.com/City-of-Helsinki/paatokset-search/releases/tag/1.0.27) with correct assets.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8852-update-search-app`
* Run `composer install`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `md5 public/modules/custom/paatokset_search/assets/paatokset-search-main.js` should be `be2284a1b30229685564a60c8711908e`


[UHF-8852]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ