### PR TITLE
UHF-9026: Add new method for clearing agenda item URL caches.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
@@ -111,7 +111,10 @@ class AhjoSubscriberController extends ControllerBase {
       ]);
     }
 
-    $this->ahjoProxy->invalideCacheForProxy($id, $entity_id);
+    $this->ahjoProxy->invalidateCacheForProxy($id, $entity_id);
+    if ($id === 'meetings') {
+      $this->ahjoProxy->invalidateAgendaItemsCache($entity_id);
+    }
 
     return new JsonResponse($data);
   }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -2428,8 +2428,11 @@ class AhjoProxy implements ContainerInjectionInterface {
       $endpoint_url .= '?apireqlang=sv';
     }
 
-    // Attempt to fetch content first, because
-    // migration doesn't complain about empty results.
+    // Attempt to fetch content first, because migration
+    // doesn't complain about empty results.
+    // If the command is run with the verbose flag, this will print in the CLI.
+    // The following migrate command uses the same URL, but its logs will be in
+    // syslog or dblog.
     $data = $this->getContent($endpoint_url);
     if (empty(reset($data))) {
       return 0;

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -186,30 +186,16 @@ class AhjoProxy implements ContainerInjectionInterface {
 
     $api_url = $this->getApiBaseUrl() . $url . '/?' . urldecode($query_string);
 
-    // Local adjustments for fetching records through proxy.
-    if (!empty(getenv('AHJO_PROXY_BASE_URL')) && strpos($url, 'records') === 0) {
-      $base_url = getenv('AHJO_PROXY_BASE_URL');
-      $api_url = $base_url . '/ahjo-proxy/' . $url . '?' . urldecode($query_string);
-    }
-
-    // Local adjustments for fetching meetings through proxy.
-    if (!empty(getenv('AHJO_PROXY_BASE_URL')) && strpos($url, 'meetings') === 0) {
-      $base_url = getenv('AHJO_PROXY_BASE_URL');
-      $api_url = $base_url . '/ahjo-proxy/' . $url . '?' . urldecode($query_string);
-    }
-
-    // Local adjustments for fetching cases or decisions through proxy.
+    // Local adjustments for fetching data through proxy.
     if (!empty(getenv('AHJO_PROXY_BASE_URL'))) {
-      if (strpos($url, 'cases') === 0 || strpos($url, 'decisions') === 0 || strpos($url, 'agenda-item') === 0) {
-        $base_url = getenv('AHJO_PROXY_BASE_URL');
-        $api_url = $base_url . '/ahjo-proxy/' . $url . '?' . urldecode($query_string);
-      }
-    }
-
-    // Local adjustments for fetching org data through proxy.
-    if (!empty(getenv('AHJO_PROXY_BASE_URL'))) {
-      if (strpos($url, 'organization') === 0) {
-        $base_url = getenv('AHJO_PROXY_BASE_URL');
+      $base_url = getenv('AHJO_PROXY_BASE_URL');
+      if (
+          str_starts_with($url, 'records')
+          || str_starts_with($url, 'meetings')
+          || str_starts_with($url, 'decisions')
+          || str_starts_with($url, 'agenda-items')
+          || str_starts_with($url, 'organization')
+        ) {
         $api_url = $base_url . '/ahjo-proxy/' . $url . '?' . urldecode($query_string);
       }
     }

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -2813,7 +2813,8 @@ class AhjoProxy implements ContainerInjectionInterface {
       $proxy_url = getenv('AHJO_PROXY_BASE_URL') . '/ahjo-proxy/';
       $urls[] = $proxy_url . $endpoint . '/' . strtoupper($id);
       $urls[] = $proxy_url . $endpoint . '/single/' . strtoupper($id);
-    } elseif (!empty(getenv('DRUPAL_REVERSE_PROXY_ADDRESS'))) {
+    }
+    elseif (!empty(getenv('DRUPAL_REVERSE_PROXY_ADDRESS'))) {
       $proxy_url = 'https://' . getenv('DRUPAL_REVERSE_PROXY_ADDRESS') . '/ahjo-proxy/';
       $urls[] = $proxy_url . $endpoint . '/' . strtoupper($id);
       $urls[] = $proxy_url . $endpoint . '/single/' . strtoupper($id);
@@ -2859,7 +2860,8 @@ class AhjoProxy implements ContainerInjectionInterface {
     $proxy_base_url = '';
     if (!empty(getenv('AHJO_PROXY_BASE_URL'))) {
       $proxy_base_url = getenv('AHJO_PROXY_BASE_URL') . '/ahjo-proxy/';
-    } elseif (!empty(getenv('DRUPAL_REVERSE_PROXY_ADDRESS'))) {
+    }
+    elseif (!empty(getenv('DRUPAL_REVERSE_PROXY_ADDRESS'))) {
       $proxy_base_url = 'https://' . getenv('DRUPAL_REVERSE_PROXY_ADDRESS') . '/ahjo-proxy/';
     }
 


### PR DESCRIPTION
# [UHF-9026](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9026)

## What was done
This PR adds a new method for clearing agenda item URLs that is called when a meeting callback is received.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9026-meeting-agenda-item-cache-fix`
* Run `make drush-cr` (or run `make new` if you don't have your local environment set up yet).
* Make sure you have some decisionmakers available: `drush mim ahjo_decisionmakers:all`
* Pull in a meeting to test with, for example: `drush ap:update meetings 00400202339 -v`
  * The meeting has to be an upcoming meeting with a published agenda, but no minutes yet.
  * If this meeting has already been updated, find another one from https://paatokset.hel.fi and use its ID instead.
* Then import the motions with `drush ap:gm -v` 
* To actually test if datacaches have been cleared, add logger lines to the `getFromCache` method in `public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php` (line 2758).
  * For example: `$this->logger->info('Trying to get from cache: ' . $key);`  , `Found from cache` and `Not found from cache`. 

## How to test
* [x] Verify that the caches work without using the callback yet:
  * Try running this a few times:  `drush ap:update meetings 00400202339 -v`. The meeting should be found from cache
  * Run `drush ap:gm -v` again. The agenda items should be found from the cache. Try running this a few more times after using the previous meeting update command.
* [x] Test that the caches are cleared after a callback is received
  * Send a POST request to `https://helsinki-paatokset.docker.so/fi/ahjo_api/subscriber/meetings` with the following body:  
```
{
    "updatetype": "TESTING",
    "id": "00400202339"
}
```
* [x] Now when you run `drush queue:run ahjo_api_subscriber_queue -v`, the meeting should not be found from cache
* [x] And when you run `drush ap:gm -v`, the agenda items should not be found from cache either
* [x] Repeat the previous steps at least once. Callback should clear the URL caches, but updating the meeting manually should not.
* [ ] Check that code follows our standards

[UHF-9026]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ