### PR TITLE
UHF-8853: store all trustees in Drupal

### DIFF
--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -3,12 +3,12 @@ langcode: fi
 status: true
 dependencies:
   config:
+    - field.storage.node.field_dm_org_name
     - field.storage.node.field_first_name
     - field.storage.node.field_last_name
-    - field.storage.node.field_dm_org_name
     - field.storage.node.field_organization_type
-    - field.storage.node.field_ahjo_title
     - field.storage.node.field_sector_name
+    - field.storage.node.field_ahjo_title
     - search_api.server.elasticsearch
   module:
     - node
@@ -151,6 +151,7 @@ processor_settings:
   decisionmaker_combined_title: {  }
   entity_status: {  }
   entity_type: {  }
+  exclude_trustees: {  }
   has_translation: {  }
   inactive_decisionmakers: {  }
   language_with_fallback: {  }

--- a/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
+++ b/docker/openshift/crons/run-aggregated-ahjo-integrations.sh
@@ -26,10 +26,10 @@ do
       drush ahjo-proxy:aggregate cases --dataset=latest --queue -v
     fi
     echo "Aggregating council org data: $(date)"
-    drush ahjo-proxy:get-council-positionsoftrust -v
+    drush ahjo-proxy:get-positionsoftrust -v
     echo "Aggregating data for council members: $(date)"
-    drush ahjo-proxy:get-trustees positionsoftrust_council.json fi -v
-    drush ahjo-proxy:get-trustees positionsoftrust_council.json sv -v
+    drush ahjo-proxy:get-trustees positionsoftrust.json fi -v
+    drush ahjo-proxy:get-trustees positionsoftrust.json sv -v
     echo "Aggregating latest decisionmaker changes: $(date)"
     drush ap:get decisionmakers --dataset=latest --filename=decisionmakers_latest.json -v
     drush ap:get decisionmakers --dataset=latest --langcode=sv --filename=decisionmakers_latest_sv.json -v
@@ -44,10 +44,10 @@ do
       drush ahjo-proxy:update-decision-attachments --limit=100 -v
     fi
     echo "Migrating data for council members: $(date)"
-    drush migrate-reset-status ahjo_trustees:council
-    drush migrate-import ahjo_trustees:council --update
-    drush migrate-reset-status ahjo_trustees:council_sv
-    drush migrate-import ahjo_trustees:council_sv --update
+    drush migrate-reset-status ahjo_trustees:all
+    drush migrate-import ahjo_trustees:all --update
+    drush migrate-reset-status ahjo_trustees:all_sv
+    drush migrate-import ahjo_trustees:all_sv --update
     echo "Migrating data for decisionmakers: $(date)"
     drush migrate-reset-status ahjo_decisionmakers:latest
     drush migrate-reset-status ahjo_decisionmakers:latest_sv

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/Deriver/AhjoApiMigrationDeriver.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/Deriver/AhjoApiMigrationDeriver.php
@@ -52,8 +52,6 @@ class AhjoApiMigrationDeriver extends DeriverBase implements ContainerDeriverInt
       $derivatives = [
         'all',
         'all_sv',
-        'council',
-        'council_sv',
         'single',
         'single_sv',
       ];
@@ -149,8 +147,6 @@ class AhjoApiMigrationDeriver extends DeriverBase implements ContainerDeriverInt
       'ahjo_trustees' => [
         'all' => '/ahjo-proxy/aggregated/trustees_fi',
         'all_sv' => '/ahjo-proxy/aggregated/trustees_sv',
-        'council' => '/ahjo-proxy/aggregated/trustees_council_fi',
-        'council_sv' => '/ahjo-proxy/aggregated/trustees_council_sv',
         'single' => '/ahjo-proxy/trustees/single',
         'single_sv' => '/ahjo-proxy/trustees/single',
       ],

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -661,10 +661,6 @@ class AhjoProxy implements ContainerInjectionInterface {
         $filename = 'positionsoftrust.json';
         break;
 
-      case 'positionsoftrust_council':
-        $filename = 'positionsoftrust_council.json';
-        break;
-
       case 'trustees':
         $filename = 'trustees.json';
         break;
@@ -675,18 +671,6 @@ class AhjoProxy implements ContainerInjectionInterface {
 
       case 'trustees_sv':
         $filename = 'trustees_sv.json';
-        break;
-
-      case 'trustees_council':
-        $filename = 'trustees_council.json';
-        break;
-
-      case 'trustees_council_fi':
-        $filename = 'trustees_council_fi.json';
-        break;
-
-      case 'trustees_council_sv':
-        $filename = 'trustees_council_sv.json';
         break;
 
       case 'decisionmakers':

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -429,52 +429,6 @@ class AhjoAggregatorCommands extends DrushCommands {
   }
 
   /**
-   * Aggregates city council position of trust data from Ahjo API.
-   *
-   * @command ahjo-proxy:get-council-positionsoftrust
-   *
-   * @usage ahjo-proxy:get-council-positionsoftrust
-   *   Stores all positions of trust into a file.
-   *
-   * @aliases ap:cpt
-   */
-  public function councilPositionsOfTrust(): void {
-    $council_groups = [
-      '02900',
-      '00400',
-    ];
-
-    $count = 0;
-    foreach ($council_groups as $id) {
-      $count++;
-      $data = [
-        'endpoint' => 'agents/positionoftrust',
-        'count' => $count,
-        'filename' => 'positionsoftrust_council.json',
-        'query_string' => 'org=' . $id,
-      ];
-
-      $operations[] = [
-        '\Drupal\paatokset_ahjo_proxy\AhjoProxy::processGroupItem',
-        [$data],
-      ];
-    }
-
-    if (empty($operations)) {
-      $this->logger->info('Nothing to import.');
-      return;
-    }
-
-    batch_set([
-      'title' => 'Aggregating council groups and organizations.',
-      'operations' => $operations,
-      'finished' => '\Drupal\paatokset_ahjo_proxy\AhjoProxy::finishGroups',
-    ]);
-
-    drush_backend_batch_process();
-  }
-
-  /**
    * Aggregates trustees from Ahjo API. Requires positions to be aggregated.
    *
    * @param string $filename
@@ -509,9 +463,6 @@ class AhjoAggregatorCommands extends DrushCommands {
             'count' => $count,
             'langcode' => $langcode,
           ];
-          if ($filename === 'positionsoftrust_council.json') {
-            $data['filename'] = 'trustees_council_' . $langcode . '.json';
-          }
           $operations[] = [
             '\Drupal\paatokset_ahjo_proxy\AhjoProxy::processTrusteeItem',
             [$data],
@@ -3039,9 +2990,7 @@ class AhjoAggregatorCommands extends DrushCommands {
       'decisionmakers_latest.json',
       'decisionmakers_latest_sv.json',
       'positionsoftrust.json',
-      'positionsoftrust_council.json',
       'trustees.json',
-      'trustees_council.json',
       'callback_test.json',
     ];
 

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -33,6 +33,11 @@ class PolicymakerService {
   public const CITY_COUNCIL_DM_ID = '02900';
 
   /**
+   * City board id in Ahjo.
+   */
+  public const CITY_BOARD_DM_ID = '00400';
+
+  /**
    * Policymaker node.
    *
    * @var \Drupal\node\Entity\Node

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/ExcludePositionsOfTrust.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/ExcludePositionsOfTrust.php
@@ -45,7 +45,7 @@ final class ExcludePositionsOfTrust extends ProcessorPluginBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     /** @var static $processor */
     $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $processor->policymakerService = $container->get('paatokset_policymakers');
@@ -55,7 +55,7 @@ final class ExcludePositionsOfTrust extends ProcessorPluginBase {
   /**
    * {@inheritdoc}
    */
-  public static function supportsIndex(IndexInterface $index) {
+  public static function supportsIndex(IndexInterface $index): bool {
     foreach ($index->getDatasources() as $datasource) {
       $entity_type_id = $datasource->getEntityTypeId();
       if (!$entity_type_id) {
@@ -75,7 +75,7 @@ final class ExcludePositionsOfTrust extends ProcessorPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function alterIndexedItems(array &$items) {
+  public function alterIndexedItems(array &$items): void {
     /** @var \Drupal\search_api\Item\ItemInterface $item */
     foreach ($items as $item_id => $item) {
       $object = $item->getOriginalObject()->getValue();

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/ExcludePositionsOfTrust.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/ExcludePositionsOfTrust.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\paatokset_search\Plugin\search_api\processor;
+
+use Drupal\node\NodeInterface;
+use Drupal\paatokset_policymakers\Service\PolicymakerService;
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * This processor exclude certain trustees from search index.
+ *
+ * Trustees are excluded if:
+ *  - Trustee is not a member of city council.
+ *
+ * @SearchApiProcessor(
+ *    id = "exclude_trustees",
+ *    label = @Translation("Exclude positions of trust"),
+ *    description = @Translation("Exclude non-city-council members from being indexed."),
+ *    stages = {
+ *      "alter_items" = -50
+ *    }
+ * )
+ */
+final class ExcludePositionsOfTrust extends ProcessorPluginBase {
+
+  /**
+   * The policymaker service.
+   *
+   * @var \Drupal\paatokset_policymakers\Service\PolicymakerService
+   */
+  private PolicymakerService $policymakerService;
+
+  /**
+   * Ids of trustee nodes that should be indexed.
+   *
+   * @var \Drupal\node\NodeInterface[]|null
+   */
+  private ?array $indexedTrusteeIds = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $processor */
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $processor->policymakerService = $container->get('paatokset_policymakers');
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function supportsIndex(IndexInterface $index) {
+    foreach ($index->getDatasources() as $datasource) {
+      $entity_type_id = $datasource->getEntityTypeId();
+      if (!$entity_type_id) {
+        continue;
+      }
+
+      // Only active on trustee nodes.
+      $bundles = $datasource->getBundles();
+      if ($entity_type_id === 'node' && in_array('trustee', array_keys($bundles))) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterIndexedItems(array &$items) {
+    /** @var \Drupal\search_api\Item\ItemInterface $item */
+    foreach ($items as $item_id => $item) {
+      $object = $item->getOriginalObject()->getValue();
+
+      // The index contains policymakers as well.
+      // This processor should skip all policymaker nodes.
+      if (!$object instanceof NodeInterface || $object->getType() !== 'trustee') {
+        continue;
+      }
+
+      // Remove from index if trustee is not part of the city council or city
+      // board.
+      if (!$this->shouldIndexTrustee($object)) {
+        unset($items[$item_id]);
+      }
+    }
+
+  }
+
+  /**
+   * Returns TRUE if given trustee node should be indexed.
+   *
+   * @return bool
+   *   True if the node should be indexed.
+   */
+  private function shouldIndexTrustee(NodeInterface $trustee): bool {
+    Assert::eq($trustee->getType(), 'trustee');
+
+    return array_key_exists($trustee->id(), $this->getAllIndexedTrustees());
+  }
+
+  /**
+   * Get list of all trustee nodes that should be indexed.
+   *
+   * If a trustee node is not in this list, it should be excluded.
+   *
+   * @return \Drupal\node\NodeInterface[]
+   *   All trustee nodes that should be indexed.
+   */
+  private function getAllIndexedTrustees(): array {
+    // Build indexedTrusteeIds when first called.
+    if (empty($this->indexedTrusteeIds)) {
+      $this->indexedTrusteeIds = [];
+      $this->addPolicymakerTrustees($this->indexedTrusteeIds, PolicymakerService::CITY_COUNCIL_DM_ID);
+      $this->addPolicymakerTrustees($this->indexedTrusteeIds, PolicymakerService::CITY_BOARD_DM_ID);
+    }
+
+    return $this->indexedTrusteeIds;
+  }
+
+  /**
+   * Add composition of given policymaker to given &$allowedIds array.
+   *
+   * @param array $allowedIds
+   *   Reference to allowed policymaker ids array.
+   * @param string $policymakerId
+   *   Policymaker id.
+   */
+  private function addPolicymakerTrustees(array &$allowedIds, string $policymakerId): void {
+    $composition = $this->policymakerService->getTrustees($policymakerId);
+
+    // On failure, `getTrustees` returns [].
+    if (empty($composition)) {
+      throw new \RuntimeException("Failed to fetch decision-maker composition");
+    }
+
+    foreach ($composition as $trustee) {
+      $allowedIds[$trustee->id()] = $trustee->id();
+    }
+  }
+
+}


### PR DESCRIPTION
# [UHF-8853](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8853)
<!-- What problem does this solve? -->

## What was done
* Import all trustees in a cron job
* Exclude non city council or board members from elastic search index

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8853-fetch-all-trustees`
  * `make new shell`
* Install test content `drush en -y paatokset_test_content`
* Import required data (or use existing database):
  * Meetings
    * `drush ahjo-proxy:aggregate meetings --dataset=latest --queue -v`
    * `drush queue:run ahjo_api_aggregation_queue -v`
  * Decisionmakers
    * `drush migrate-import ahjo_decisionmakers:all`
    * `drush migrate-import ahjo_decisionmakers:all_sv`
  * **All** Trustees
    * `drush migrate-import ahjo_trustees:all`
    * ~`drush migrate-import ahjo_trustees:all_sv` (This does not work for me. Maybe requires running `drush ahjo-proxy:get-trustees positionsoftrust.json sv -v` on prod first?)~

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Re-index policymakers `drush sapi-rt policymakers; drush sapi-i policymakers`. Should complete without errors.
* [x] Search on page [/fi/paattajat](https://helsinki-paatokset.docker.so/fi/paattajat) should not include trustees without city council or board seat.
* [x] Read changes to `./docker/openshift/crons/run-aggregated-ahjo-integrations.sh`
* [x] Check that code follows our standards


[UHF-8853]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ