### PR TITLE
UHF-9027: More visible error handling for broken attachments.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -1162,17 +1162,12 @@ class CaseService {
     foreach ($this->selectedDecision->get('field_decision_attachments') as $field) {
       $data = json_decode($field->value, TRUE);
 
-      // If all relevant info is empty, do not display attachment.
-      if (empty($data['PublicityClass']) && empty($data['Title']) && empty($data['FileURI'])) {
-        continue;
-      }
-
       $number = NULL;
       if (isset($data['AttachmentNumber'])) {
         $number = $data['AttachmentNumber'] . '. ';
       }
 
-      $title = t('Attachment');
+      $title = NULL;
       if (isset($data['Title'])) {
         $title = $data['Title'];
       }
@@ -1182,8 +1177,18 @@ class CaseService {
         $publicity_class = $data['PublicityClass'];
       }
 
+      $file_url = NULL;
+      if (isset($data['FileURI'])) {
+        $file_url = $data['FileURI'];
+      }
+
+      // If all relevant info is empty, do not display attachment.
+      if (empty($data['PublicityClass']) && empty($data['Title']) && empty($data['FileURI'])) {
+        $title = t("There's an error with this attachment. We are resolving the issue as soon as possible.");
+        $publicity_class = 'error';
+      }
       // Override title if attachment is not public.
-      if ($publicity_class !== 'Julkinen') {
+      elseif ($publicity_class !== 'Julkinen') {
         if (!empty($data['SecurityReasons'])) {
           $title = t('Confidential: @reasons', [
             '@reasons' => implode(', ', $data['SecurityReasons']),
@@ -1192,11 +1197,6 @@ class CaseService {
         else {
           $title = t('Confidential');
         }
-      }
-
-      $file_url = NULL;
-      if (isset($data['FileURI'])) {
-        $file_url = $data['FileURI'];
       }
 
       $attachments[] = [

--- a/public/modules/custom/paatokset_ahjo_api/translations/fi.po
+++ b/public/modules/custom/paatokset_ahjo_api/translations/fi.po
@@ -18,3 +18,9 @@ msgstr "kokousta siirretty, alkuperäinen ajankohta: @orig_time"
 
 msgid "There's an error with this attachment. We are resolving the issue as soon as possible."
 msgstr "Liitteen julkaisussa on virhe. Korjaamme virheen mahdollisimman pian."
+
+msgid "Confidential"
+msgstr "Salassa pidettävä"
+
+msgid "Confidential: @reasons"
+msgstr "Salassa pidettävä: @reasons"

--- a/public/modules/custom/paatokset_ahjo_api/translations/fi.po
+++ b/public/modules/custom/paatokset_ahjo_api/translations/fi.po
@@ -15,3 +15,6 @@ msgstr "Kokousta siirretty, alkuperäinen ajankohta: @orig_time"
 msgctxt "Meetings calendar"
 msgid "meeting moved, original time: @orig_time"
 msgstr "kokousta siirretty, alkuperäinen ajankohta: @orig_time"
+
+msgid "There's an error with this attachment. We are resolving the issue as soon as possible."
+msgstr "Liitteen julkaisussa on virhe. Korjaamme virheen mahdollisimman pian."

--- a/public/modules/custom/paatokset_ahjo_api/translations/sv.po
+++ b/public/modules/custom/paatokset_ahjo_api/translations/sv.po
@@ -15,3 +15,6 @@ msgstr "Möte flyttade, gammal tid: @orig_time"
 msgctxt "Meetings calendar"
 msgid "meeting moved, original time: @orig_time"
 msgstr "möte flyttade, gammal tid: @orig_time"
+
+msgid "There's an error with this attachment. We are resolving the issue as soon as possible."
+msgstr "Det finns ett fel i den publicerade bilagan. Vi rättar till felet så fort som möjligt."

--- a/public/themes/custom/hdbt_subtheme/templates/components/case-attachments.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/components/case-attachments.html.twig
@@ -13,7 +13,9 @@
       {% for attachment in attachments.items %}
         {% if attachment.file_url and attachment.publicity_class == 'Julkinen' %}
           {% set icon_class = 'download' %}
-        {% elseif attachment.publicity_class != 'Julkinen'%}
+        {% elseif attachment.publicity_class == 'error' %}
+          {% set icon_class = 'error' %}
+        {% elseif attachment.publicity_class != 'Julkinen' %}
           {% set icon_class = 'eye-crossed' %}
           {% set non_public_attachments = true %}
         {% else %}


### PR DESCRIPTION
# [UHF-9027](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9027)

## What was done
Fixes error handling in cases where we get broken attachments for a decision or a motion.

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9027-better-attachment-error-handling`
  * If you don't have a Drupal installation yet, run `make new`
* Run `make drush-cr`
* Run `drush locale:update;drush locale:check` 
* Fetch data to test with: 
``` 
drush ap:update decisions c90cf8d5-3984-418f-a216-4bd4ec192fbb -v
drush ap:update cases HEL-2022-011203 -v
drush ap:ud -v
```
* Edit the case: https://helsinki-paatokset.docker.so/fi/asia/hel-2022-011203/c90cf8d5-3984-418f-a216-4bd4ec192fbb
* In the Decision Content section, add three new Attachments with the following data:
  * `{"Title": "Oikaisuvaatimus 5.9.2023, saate", "links": [], "PublicityClass": "Julkinen", "SecurityReasons": [], "AttachmentNumber": "2"}`
  * `{"Title": "Salassa pidettävä", "links": [], "PublicityClass": "Salassa pidettävä", "SecurityReasons": ["JulkL (621/1999) 24.1 § 25 k"], "AttachmentNumber": "3"}` 
  * `{"Title": "", "links": [], "PublicityClass": "", "SecurityReasons": [], "AttachmentNumber": "4"}` 

## How to test
* [x] The attachments should be visible on https://helsinki-paatokset.docker.so/fi/asia/hel-2022-011203/c90cf8d5-3984-418f-a216-4bd4ec192fbb
* [x] The public attachment should work normally
* [x] The attachment missing a link should have a cross icon and just the title visible
* [x] The condifential attachment should have an eye icon and just the title visible
* [x] The last attchment should have an error icon and the title should be a message about the error
* [x] The error message should be translated to finnish and swedish
* [ ] Check that code follows our standards


[UHF-9027]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ