### PR TITLE
UHF-9024 meetings files language

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -382,20 +382,18 @@ class MeetingService {
       return NULL;
     }
 
-    $document = NULL;
     foreach ($entity->get('field_meeting_documents') as $field) {
       $json = json_decode($field->value, TRUE);
-      if ($langcode && isset($json['Language']) && strpos($json['Language'], $langcode) === FALSE) {
+      if ($langcode && isset($json['Language']) && !str_contains($json['Language'], $langcode)) {
         continue;
       }
 
       if (isset($json['Type']) && isset($json['NativeId']) && $json['Type'] === $document_type) {
-        $document = $json;
-        break;
+        return $json;
       }
     }
 
-    return $document;
+    return NULL;
   }
 
   /**

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.services.yml
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.services.yml
@@ -1,6 +1,7 @@
 services:
   paatokset_policymakers:
     class: Drupal\paatokset_policymakers\Service\PolicymakerService
+    arguments: ['@language_manager', '@entity_type.manager', '@current_route_match', '@path_alias.manager']
   policymakers_lazy_builder:
     class: Drupal\paatokset_policymakers\Service\PolicymakerLazyBuilder
     arguments: ['@language_manager', '@entity_type.manager', '@paatokset_policymakers']

--- a/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerController.php
+++ b/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerController.php
@@ -5,6 +5,8 @@ namespace Drupal\paatokset_policymakers\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\node\NodeInterface;
+use Drupal\paatokset_policymakers\Service\PolicymakerService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -13,18 +15,24 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class PolicymakerController extends ControllerBase {
 
   /**
-   * Policymaker service.
+   * Controller for policymaker subpages.
    *
-   * @var \Drupal\paatokset_policymakers\Service\PolicymakerService
+   * @param \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService
+   *   Policymaker service.
    */
-  private $policymakerService;
+  public function __construct(
+    private PolicymakerService $policymakerService
+  ) {
+    $this->policymakerService->setPolicyMakerByPath();
+  }
 
   /**
-   * Controller for policymaker subpages.
+   * {@inheritdoc}
    */
-  public function __construct() {
-    $this->policymakerService = \Drupal::service('paatokset_policymakers');
-    $this->policymakerService->setPolicyMakerByPath();
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('paatokset_policymakers')
+    );
   }
 
   /**

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -1499,7 +1499,7 @@ class PolicymakerService {
    */
   public function getMeetingAgenda(string $meetingId): ?array {
     if (!$this->policymaker instanceof NodeInterface || !$this->policymakerId) {
-      return [];
+      throw new \InvalidArgumentException("Missing policymaker");
     }
 
     $meeting = $this->getMeetingNode($meetingId);

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -5,14 +5,20 @@ declare(strict_types = 1);
 namespace Drupal\paatokset_policymakers\Service;
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
+use Drupal\paatokset_ahjo_api\Service\MeetingService;
 use Drupal\paatokset_policymakers\Enum\PolicymakerRoutes;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\search_api\Entity\Index;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -52,6 +58,45 @@ class PolicymakerService {
   private $policymakerId;
 
   /**
+   * Node storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  private EntityStorageInterface $nodeStorage;
+
+  /**
+   * Meeting service.
+   *
+   * @var \Drupal\paatokset_ahjo_api\Service\MeetingService
+   */
+  private MeetingService $meetingService;
+
+  /**
+   * Constructs policymaker service.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   Language manager service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   *   Route match service.
+   * @param \Drupal\path_alias\AliasManagerInterface $pathAliasManager
+   *   Path alias manager.
+   */
+  public function __construct(
+    private LanguageManagerInterface $languageManager,
+    EntityTypeManagerInterface $entityTypeManager,
+    private RouteMatchInterface $routeMatch,
+    private AliasManagerInterface $pathAliasManager,
+  ) {
+    $this->nodeStorage = $entityTypeManager->getStorage('node');
+
+    // Using dependency injection here fails on `make new` due to cyclical
+    // dependency with paatokset_ahjo_api module.
+    $this->meetingService = \Drupal::service('paatokset_ahjo_meetings');
+  }
+
+  /**
    * Query policymakers from database.
    *
    * @param array $params
@@ -73,7 +118,9 @@ class PolicymakerService {
       $sort = 'ASC';
     }
 
-    $query = \Drupal::entityQuery('node')
+    $query = $this->nodeStorage
+      ->getQuery()
+      ->accessCheck(TRUE)
       ->condition('status', 1)
       ->condition('type', self::NODE_TYPE)
       ->sort('created', $sort);
@@ -92,7 +139,7 @@ class PolicymakerService {
       return [];
     }
 
-    return Node::loadMultiple($ids);
+    return $this->nodeStorage->loadMultiple($ids);
   }
 
   /**
@@ -122,7 +169,7 @@ class PolicymakerService {
     }
 
     if ($langcode === NULL) {
-      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+      $langcode = $this->languageManager->getCurrentLanguage()->getId();
     }
 
     if ($result->hasTranslation($langcode)) {
@@ -152,7 +199,7 @@ class PolicymakerService {
    *   Policy maker ID.
    */
   public function setPolicyMakerNode(NodeInterface $node): void {
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     if ($node->hasTranslation($currentLanguage)) {
       $node = $node->getTranslation($currentLanguage);
     }
@@ -167,41 +214,34 @@ class PolicymakerService {
   }
 
   /**
-   * Set policy maker by current path.
+   * Set policymaker from current path.
    *
    * @return bool
    *   TRUE if setting pm was succesful.
    */
   public function setPolicyMakerByPath(): bool {
-    $node = \Drupal::routeMatch()->getParameter('node');
-    $routeParams = \Drupal::routeMatch()->getParameters();
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $node = $this->routeMatch->getParameter('node');
+    $routeParams = $this->routeMatch->getParameters();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
 
     // Determine policymaker in custom routes.
-    if (!$node instanceof NodeInterface && $routeParams->get('organization')) {
-      $fallback_prefix = '/paattajat';
-      $fallback_lang = 'fi';
-      if ($currentLanguage === 'sv') {
-        $path_prefix = '/beslutsfattare';
-      }
-      elseif ($currentLanguage === 'en') {
-        $path_prefix = '/decisionmakers';
-      }
-      else {
-        $path_prefix = '/paattajat';
-      }
+    if (!$node instanceof NodeInterface && $routeParams->has('organization')) {
+      $path_prefix = match ($currentLanguage) {
+        'sv' => '/beslutsfattare',
+        'en' => '/decisionmakers',
+        default => '/paattajat',
+      };
 
       // Attempt to load path either by current language path or fallback.
       $organization = $routeParams->get('organization');
 
-      $path = \Drupal::service('path_alias.manager')->getPathByAlias($path_prefix . '/' . $organization, $currentLanguage);
+      $path = $this->pathAliasManager->getPathByAlias($path_prefix . '/' . $organization, $currentLanguage);
       if (preg_match('/node\/(\d+)/', $path, $matches)) {
-        $node = Node::load($matches[1]);
+        $node = $this->nodeStorage->load($matches[1]);
       }
       elseif ($this->getPolicyMaker($organization) !== NULL) {
         $node = $this->getPolicyMaker($organization);
       }
-
     }
 
     // Determine policymaker on subpages.
@@ -213,9 +253,9 @@ class PolicymakerService {
         // Alias check fails with langcode - slice only the part we need
         // Ie. '/paattajat/kaupunginvaltuusto'.
         $alias_parts = array_slice($url_parts, 2, 2);
-        $path = \Drupal::service('path_alias.manager')->getPathByAlias('/' . implode('/', $alias_parts));
+        $path = $this->pathAliasManager->getPathByAlias('/' . implode('/', $alias_parts));
         if (preg_match('/node\/(\d+)/', $path, $matches)) {
-          $node = Node::load($matches[1]);
+          $node = $this->nodeStorage->load($matches[1]);
         }
       }
     }
@@ -301,7 +341,7 @@ class PolicymakerService {
    */
   public function getPolicymakerRoute(?NodeInterface $policymaker = NULL, ?string $langcode = NULL): ?Url {
     if ($langcode === NULL) {
-      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+      $langcode = $this->languageManager->getCurrentLanguage()->getId();
     }
     if ($policymaker === NULL) {
       $policymaker = $this->getPolicyMaker();
@@ -336,7 +376,7 @@ class PolicymakerService {
 
     $routes = PolicymakerRoutes::getOrganizationRoutes();
     $baseRoute = $routes['documents'];
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     $localizedRoute = "$baseRoute.$currentLanguage";
 
     $policymaker_org = $this->getPolicymakerOrganizationFromUrl($this->policymaker, $currentLanguage);
@@ -377,7 +417,7 @@ class PolicymakerService {
 
     $routes = PolicymakerRoutes::getTrusteeRoutes();
     $baseRoute = $routes['decisions'];
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     $localizedRoute = "$baseRoute.$currentLanguage";
     $policymaker_org = $this->getPolicymakerOrganizationFromUrl($this->policymaker, $currentLanguage);
 
@@ -421,7 +461,7 @@ class PolicymakerService {
     }
 
     $route = PolicymakerRoutes::getSubroutes()['minutes'];
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     $localizedRoute = "$route.$currentLanguage";
     $policymaker_org = $this->getPolicymakerOrganizationFromUrl($policymaker, $currentLanguage);
 
@@ -632,7 +672,7 @@ class PolicymakerService {
    *   Element ID or URL fragment.
    */
   public function getDecisionAnnouncementAnchor(): string {
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     if ($currentLanguage === 'sv') {
       return 'beslutsmeddelanden';
     }
@@ -652,7 +692,7 @@ class PolicymakerService {
    */
   public function getLocalizedUrl(?string $id = NULL, ?string $langcode = NULL): ?Url {
     if ($langcode === NULL) {
-      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+      $langcode = $this->languageManager->getCurrentLanguage()->getId();
     }
 
     if ($id === NULL && $this->policymaker->get('langcode')->value === $langcode) {
@@ -847,7 +887,7 @@ class PolicymakerService {
       $limit = 10000;
     }
 
-    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $langcode = $this->languageManager->getCurrentLanguage()->getId();
 
     $index = Index::load('decisions');
     $query = $index->query();
@@ -1060,7 +1100,7 @@ class PolicymakerService {
     $names = array_keys($composition);
     $results = [];
     $person_nodes = $this->getTrusteeNodesByName($names);
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     foreach ($person_nodes as $node) {
       if ($node->hasTranslation($currentLanguage)) {
         $node = $node->getTranslation($currentLanguage);
@@ -1186,7 +1226,7 @@ class PolicymakerService {
    */
   public function getTrusteeUrl(NodeInterface $node, ?string $langcode = NULL): ?Url {
     if ($langcode === NULL) {
-      $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+      $langcode = $this->languageManager->getCurrentLanguage()->getId();
     }
 
     if ($node->get('langcode')->value === $langcode) {
@@ -1244,7 +1284,7 @@ class PolicymakerService {
    *   Trustee node, if found.
    */
   public function getTrusteeByPath(string $agent_id): ?NodeInterface {
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     $fallback_prefix = '/paattajat';
     $fallback_lang = 'fi';
     if ($currentLanguage === 'sv') {
@@ -1353,8 +1393,6 @@ class PolicymakerService {
     }
 
     $nodes = Node::loadMultiple($ids);
-    /** @var \Drupal\paatokset_ahjo_api\Service\MeetingService $meetingService */
-    $meetingService = \Drupal::service('paatokset_ahjo_meetings');
 
     $transformedResults = [];
     foreach ($nodes as $node) {
@@ -1363,10 +1401,10 @@ class PolicymakerService {
       $meeting_id = $node->get('field_meeting_id')->value;
       $decision_link = NULL;
 
-      if ($document = $meetingService->getDocumentFromEntity($node, 'pöytäkirja')) {
+      if ($document = $this->meetingService->getDocumentFromEntity($node, 'pöytäkirja')) {
         $document_title = t('Minutes');
       }
-      elseif ($document = $meetingService->getDocumentFromEntity($node, 'esityslista')) {
+      elseif ($document = $this->meetingService->getDocumentFromEntity($node, 'esityslista')) {
         $document_title = t('Agenda');
         if (!$node->get('field_meeting_decision')->isEmpty()) {
           $decision_link = $this->getMinutesRoute($meeting_id);
@@ -1381,7 +1419,7 @@ class PolicymakerService {
         'publish_date_short' => date('m - Y', $meeting_timestamp),
         'title' => $document_title,
         'meeting_number' => $node->get('field_meeting_sequence_number')->value . ' - ' . $meeting_year,
-        'origin_url' => $meetingService->getUrlFromAhjoDocument($document),
+        'origin_url' => $this->meetingService->getUrlFromAhjoDocument($document),
         'decision_link' => $decision_link,
       ];
 
@@ -1411,7 +1449,9 @@ class PolicymakerService {
    *   Meeting node or NULL if one can't be loaded.
    */
   public function getMeetingNode(string $meetingId): ?NodeInterface {
-    $query = \Drupal::entityQuery('node')
+    $query = $this->nodeStorage
+      ->getQuery()
+      ->accessCheck(TRUE)
       ->condition('status', 1)
       ->condition('type', 'meeting')
       ->condition('field_meeting_dm_id', $this->policymakerId)
@@ -1478,7 +1518,7 @@ class PolicymakerService {
     $fileUrl = NULL;
 
     // Use either current language or fallback language for agenda items.
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
     if ($currentLanguage === 'fi') {
       $fallbackLanguage = 'sv';
     }
@@ -1486,22 +1526,19 @@ class PolicymakerService {
       $fallbackLanguage = 'fi';
     }
 
-    /** @var \Drupal\paatokset_ahjo_api\Service\MeetingService $meetingService */
-    $meetingService = \Drupal::service('paatokset_ahjo_meetings');
-
-    if ($document = $meetingService->getDocumentFromEntity($meeting, 'pöytäkirja', 'fi')) {
+    if ($document = $this->meetingService->getDocumentFromEntity($meeting, 'pöytäkirja', 'fi')) {
       $pageTitle = t('Minutes');
       $documentTitle = t('Minutes publication date');
     }
-    elseif ($document = $meetingService->getDocumentFromEntity($meeting, 'pöytäkirja', 'sv')) {
+    elseif ($document = $this->meetingService->getDocumentFromEntity($meeting, 'pöytäkirja', 'sv')) {
       $pageTitle = t('Minutes');
       $documentTitle = t('Minutes publication date');
     }
-    elseif ($document = $meetingService->getDocumentFromEntity($meeting, 'esityslista', 'fi')) {
+    elseif ($document = $this->meetingService->getDocumentFromEntity($meeting, 'esityslista', 'fi')) {
       $pageTitle = t('Agenda');
       $documentTitle = t('Agenda publication date');
     }
-    elseif ($document = $meetingService->getDocumentFromEntity($meeting, 'esityslista', 'sv')) {
+    elseif ($document = $this->meetingService->getDocumentFromEntity($meeting, 'esityslista', 'sv')) {
       $pageTitle = t('Agenda');
       $documentTitle = t('Agenda publication date');
     }
@@ -1519,7 +1556,7 @@ class PolicymakerService {
         $publishDate = NULL;
       }
 
-      $fileUrl = $meetingService->getUrlFromAhjoDocument($document);
+      $fileUrl = $this->meetingService->getUrlFromAhjoDocument($document);
     }
 
     // Get items in both languages because all aren't translated.
@@ -1843,7 +1880,7 @@ class PolicymakerService {
    *   Overridden, default or NULL if node can't be found.
    */
   public function getPolicymakerTypeFromNode(?NodeInterface $node = NULL): ?string {
-    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentLanguage = $this->languageManager->getCurrentLanguage()->getId();
 
     if ($node === NULL) {
       $node = $this->getPolicyMaker();


### PR DESCRIPTION
# [UHF-9024](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9024)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Prefer currently selected language for meeting PDF files.

This change has a possible issue: Ahjo does not seem to contain minutes of the city council meetings in swedish, only the meeting agenda seems to be translated.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9024-meetings-files-language`
  * `make new shell`
* Install content:
  * `drush migrate-import ahjo_decisionmakers:all && drush migrate-import ahjo_decisionmakers:all_sv`
  * `drush migrate-import ahjo_meetings:latest`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Test meeting PDF documents with different languages
  * [/fi/paattajat/kaupunginvaltuusto/asiakirjat/02900202316](https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat/02900202316) File should be pöytäkirja in Finnish and Swedish.
  * [/sv/beslutsfattare/stadsfullmaktige/dokumenter/02900202316](https://helsinki-paatokset.docker.so/sv/beslutsfattare/stadsfullmaktige/dokumenter/02900202316) File should be pöytäkirja in Finnish and Swedish.
  * [/en/decisionmakers/02900/documents/02900202316](https://helsinki-paatokset.docker.so/en/decisionmakers/02900/documents/02900202316) No translation, file should be pöytäkirja in Finnish and Swedish.
* [x] Edit the meeting node with id 02900202316, remove pöytäkirja from meeting documents and try again.
  * [/fi/paattajat/kaupunginvaltuusto/asiakirjat/02900202316](https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat/02900202316) File should be esityslista in Finnish.
  * [/sv/beslutsfattare/stadsfullmaktige/dokumenter/02900202316](https://helsinki-paatokset.docker.so/sv/beslutsfattare/stadsfullmaktige/dokumenter/02900202316) File should be esityslista in Swedish.
  * [/en/decisionmakers/02900/documents/02900202316](https://helsinki-paatokset.docker.so/en/decisionmakers/02900/documents/02900202316) No translation, file should be esityslista in Finnish.
* [x] Check that code follows our standards


[UHF-9024]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ