### PR TITLE
Draft: UHF-0: City council livestream fixes

### DIFF
--- a/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
+++ b/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
@@ -101,7 +101,9 @@ function paatokset_helsinki_kanava_preprocess_node__policymaker(array &$variable
 
   if ($liveStream instanceof MeetingVideo) {
     if (!$liveStream->get('start_time')->isEmpty() && _paatokset_helsinki_kanava_should_show_label($liveStream->get('start_time')->value)) {
-      $variables['next_meeting_time'] = date('j.n.Y G:i', (int) $liveStream->get('start_time')->value);
+      $meeting_datetime = new DateTime('now', new DateTimeZone('Europe/Helsinki'));
+      $meeting_datetime->setTimestamp((int) $liveStream->get('start_time')->value);
+      $variables['next_meeting_time'] = $meeting_datetime->format('j.n.y G:i');
     }
     if (!$liveStream->get('start_time')->isEmpty() && _paatokset_helsinki_kanava_should_show_stream($liveStream->get('start_time')->value)) {
       $view_builder = \Drupal::entityTypeManager()->getViewBuilder($liveStream->getEntityTypeId());

--- a/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
+++ b/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
@@ -79,7 +79,6 @@ function paatokset_helsinki_kanava_preprocess_node__policymaker(array &$variable
 
   if ($video instanceof MeetingVideo) {
     $view_builder = \Drupal::entityTypeManager()->getViewBuilder($video->getEntityTypeId());
-
     $variables['most_recent_meeting'] = $view_builder->view($video);
     $variables['all_recordings_link'] = Url::fromUri(\Drupal::config('paatokset_helsinki_kanava.settings')->get('all_recordings_link'), [
       'query' => [
@@ -88,11 +87,23 @@ function paatokset_helsinki_kanava_preprocess_node__policymaker(array &$variable
     ])->toString();
   }
 
-  $upcomingIds = \Drupal::entityQuery('meeting_video')
+  $upcomingQuery = \Drupal::entityQuery('meeting_video')
     ->accessCheck(TRUE)
     ->range(0, 1)
-    ->condition('start_time', strtotime('now'), '>')
-    ->execute();
+    ->sort('start_time', 'DESC');
+
+  // If debug mode is on, get next available livestream.
+  if (\Drupal::config('paatokset_helsinki_kanava.settings')->get('debug_mode')) {
+    $upcomingQuery->notExists('asset_id');
+  }
+  else {
+    // Otherwise, limit db query to estimated start and end times.
+    $upcomingQuery
+      ->condition('start_time', strtotime('+1 hour'), '<=')
+      ->condition('start_time', strtotime('-8 hour'), '>=');
+  }
+
+  $upcomingIds = $upcomingQuery->execute();
 
   $liveStream = NULL;
   if (!empty($upcomingIds)) {
@@ -123,11 +134,23 @@ function paatokset_helsinki_kanava_preprocess_node__policymaker(array &$variable
  *   If livestream should be displayed.
  */
 function _paatokset_helsinki_kanava_should_show_stream(string $time): bool {
+  // Show next available livestream regardless of time if debug mode is on.
   if (\Drupal::config('paatokset_helsinki_kanava.settings')->get('debug_mode')) {
     return TRUE;
   }
 
-  return strtotime('+1 hour') > $time;
+  // Don't show stream if the starting time is in more than 1 hour.
+  if ((int) $time > strtotime('+1 hour')) {
+    return FALSE;
+  }
+
+  // Stop showing stream after 8 hours have passed.
+  // Meetings can last from 2 to 6 hours usually.
+  if ((int) $time < strtotime('-8 hour')) {
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 /**
@@ -138,7 +161,7 @@ function _paatokset_helsinki_kanava_should_show_label(string $time): bool {
     return TRUE;
   }
 
-  // Convert start time to date only.
+  // Show label only on days before stream. Convert start time to date only.
   $date = strtotime(date('j.n.Y', (int) $time));
   return strtotime('now') < $date;
 }


### PR DESCRIPTION
## What was done

* Fix next livestream date label to use correct timestamp.
* Fix council livestream logic to show livestream embed 1 hour before start and 8 hours after. The meetings can last anywhere from 2 to 6 hours.

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0-livestream-fixes`
* Make sure you have at least the city council node, upcoming meetings and meeting videos imported:
  * `drush ap:update organization 02900 -v;`
  * `drush ap:update meetings 02900202321 -v`  
  * `drush migrate-import paatokset_meeting_videos --update`
* Run `make drush-cr`

## How to test
* Go to the council page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto
  * [ ] The next upcoming meeting is on 13.12.2023, so the livestream should not be visible. There should be a label about the date and time
* Turn on the debug mode: https://helsinki-paatokset.docker.so/fi/admin/config/helsinki-kanava/settings
  * [ ] Reload the council page. Now the announcement about the meeting livestream and the livestream itself should be visible, regardless of the actual starting time. The livestream is shown as a separate video embed at the top of the page
  *  Turn the debug mode off for now and run `drush cr`. The livestream should disappear.
* Adjust the `start_time` value for the meeting video. You can get a relevant timestamp through the `drush php:cli` with `strtotime('+1 hour')` and you can find the video id through `drush sql:cli` with `select id,name,asset_id from paatokset_meeting_video_field_data`. The ID should be `246041101`
  * Edit the start_time by running: `update paatokset_meeting_video_field_data set start_time=TIMESTAMP where id=246041101;update paatokset_meeting_video_field_revision set start_time=TIMESTAMP where id=246041101;` 
  * You might have to run `drush cr` after changing the timestamp so the template picks up the changes
* [ ] Adjust the start time to 1 hours from now with `strtotime('+1 hour')`. The livestream should appear again
* [ ] Adjust the start time to 2 hours from now with `strtotime('+1 hour')`. The stream should not be visible.
* [ ] Adjust the start time to 7 hours in the past with `strtotime('-7 hour)`. The stream should be visible.
* [ ] Adjust the start time to 9 hours in the past with `strtotime('-9 hour')`. The stream should not be visible.
* [ ] Does the logic make sense? Could it be simplified somehow?
* [ ] Any caching aspects that should be considered? The meeting video migration is run hourly, so technically the cache should be invalidated before the livestream starts.
* [ ] Check that code follows our standards