### PR TITLE
Fix tunnistamo redirect_url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,9 @@
             ]
         },
         "patches": {
+            "drupal/core": {
+                "[#3385550] Language negotiation breaks updating Drupal 9 to 10": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-module-helfi-proxy/ffbde3654e0011e237a17ea1cb3a7291685e0c30/patches/3385550.patch"
+            },
             "drupal/default_content": {
                 "Don't reimport translations": "https://www.drupal.org/files/issues/2020-10-14/default_content-3176839-2.patch"
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0f505a15a6704758c96c9745c593393",
+    "content-hash": "8e6fbe4434e0fd3ada20a6aac433ba74",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Add patch from helfi_proxy that fixes `LANGCODE_NOT_APPLICABLE` urls. Päätökset does not use helfi_proxy module. 
