### PR TITLE
UHF-0: Remove old openid settings, fix make new

### DIFF
--- a/conf/cmi/openid_connect.client.tunnistamo.yml
+++ b/conf/cmi/openid_connect.client.tunnistamo.yml
@@ -10,11 +10,11 @@ id: tunnistamo
 label: Tunnistamo
 plugin: tunnistamo
 settings:
-  client_id: helfi-paatokset-dev
-  client_secret: 06426526-4e68-41c2-81a3-fe22ec8c318b
+  client_id: ''
+  client_secret: ''
   iss_allowed_domains: ''
   is_production: 0
   auto_login: 0
-  environment_url: 'https://tunnistamo.test.hel.ninja'
+  environment_url: ''
   client_scopes: ''
   client_roles: {  }

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
@@ -6,7 +6,7 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Routing\RouteProvider;
+use Drupal\Core\Routing\RouteProviderInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
@@ -40,7 +40,7 @@ class PolicymakerSideNav extends BlockBase implements ContainerFactoryPluginInte
     $plugin_id,
     $plugin_definition,
     private MenuLinkTreeInterface $menuTree,
-    private RouteProvider $routeProvider,
+    private RouteProviderInterface $routeProvider,
     private PolicymakerService $policymakerService,
     private string $currentLang,
     private string $currentPath


### PR DESCRIPTION
## What was done
* Removes deprecated openID settings from config
* Fixes an issue with a block constructor that prevented `make new` from running

## How to install
* Make sure you have Tunnistamo / Helsinki Profiili settings in your env file. (If not, add them an run `make up`)
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0-remove-old-openid-settings`
  * `make new` (take a database backup before this so you can return to the previous state)
* Run `make drush-cr`

## How to test
* [x] The `make new` command runs without fatal errors
* [x] Go to OpenID settings and verify the ID and key are set: https://helsinki-paatokset.docker.so/fi/admin/config/people/openid-connect/tunnistamo/edit
* [x] Run `drush cex` and make sure the OpenID settings aren't getting exported
* [x] Check that code follows our standards
