### PR TITLE
UHF-0: Lock drupal core version to 10.1.17, update search app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "elasticsearch/elasticsearch": "^7.15",
         "josdejong/jsoneditor": "^5.29",
         "league/csv": "^9.8",
-        "paatokset/paatokset_search": "1.1.0"
+        "paatokset/paatokset_search": "1.1.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -49,6 +49,9 @@
         "weitzman/drupal-test-traits": "^2.0"
     },
     "conflict": {
+        "drupal/core": ">=10.2",
+        "drupal/core-composer-scaffold": ">=10.2",
+        "drupal/core-dev": ">=10.2",
         "drupal/drupal": "*"
     },
     "config": {
@@ -144,9 +147,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "1.1.0",
+                "version": "1.1.1",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.1.0/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.1.1/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
             "composer/installers": true,
             "drupal/core-composer-scaffold": true,
             "phpstan/extension-installer": true,
-            "php-http/discovery": true
+            "php-http/discovery": false
         },
         "audit": {
             "abandoned": "report"

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
             "cweagans/composer-patches": true,
             "composer/installers": true,
             "drupal/core-composer-scaffold": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         },
         "audit": {
             "abandoned": "report"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b28653851d78b5d0f13617bc5ca8e12f",
+    "content-hash": "937ab72c4226332f1b8b6c80b51b3f67",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8634,10 +8634,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.1.0/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.1.1/paatokset_search.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
This PR locks Drupal core to version 10.1.17 and updates the search app.