### PR TITLE
Set connect_existing_users to true

### DIFF
--- a/conf/cmi/openid_connect.settings.yml
+++ b/conf/cmi/openid_connect.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: NFnOZU6VCOfURCAR4-O3V7eMHTx2LNqnCmDKRSNjjns
 always_save_userinfo: true
-connect_existing_users: false
+connect_existing_users: true
 override_registration_settings: true
 end_session_enabled: true
 user_login_display: above
@@ -15,3 +15,5 @@ role_mappings:
   editor: {  }
   admin: {  }
   api_user: {  }
+  elevated_api_user: {  }
+  super_administrator: {  }


### PR DESCRIPTION
This change fixes profiili login for existing users. The settings was enabled in production as a hotfix.