### PR TITLE
UHF-9585: Add AD role mapping for Päätökset

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -26,6 +26,22 @@ $config['elastic_proxy.settings']['elastic_proxy_url'] = drupal_get_env(['REACT_
 // Sentry DSN for React.
 $config['paatokset_search.settings']['sentry_dsn_react'] = getenv('SENTRY_DSN_REACT');
 
+// AD role mapping
+$config['openid_connect.client.tunnistamo']['settings']['ad_roles'] = [
+  [
+    'ad_role' => 'Drupal_Helfi_kaupunkitaso_paakayttajat',
+    'roles' => ['admin'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Paatokset_sisallontuottajat_laaja',
+    'roles' => ['editor'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Paatokset_sisallontuottajat_suppea',
+    'roles' => ['content_producer'],
+  ],
+];
+
 $additionalEnvVars = [
   'AZURE_BLOB_STORAGE_SAS_TOKEN|BLOBSTORAGE_SAS_TOKEN',
   'AZURE_BLOB_STORAGE_NAME',


### PR DESCRIPTION
# [UHF-9585](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9585)

## What was done
Adds automatic AD role mapping for Päätökset project.

## How to test
Can't be tested locally, just check that the AD groups match the ones in the ticket. Will be tested further on test and staging before production release.

[UHF-9585]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ