### PR TITLE
UHF-x: Organization chart fixes

### DIFF
--- a/conf/cmi/search_api.index.decisions.yml
+++ b/conf/cmi/search_api.index.decisions.yml
@@ -3,25 +3,26 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_decision_case_title
     - field.storage.node.field_classification_title
     - field.storage.node.field_decision_content_parsed
     - field.storage.node.field_decision_motion_parsed
-    - field.storage.node.field_diary_number
-    - field.storage.node.field_full_title
-    - field.storage.node.field_meeting_date
-    - field.storage.node.field_decision_native_id
+    - field.storage.node.field_decision_section
     - field.storage.node.field_is_decision
     - field.storage.node.field_policymaker_id
+    - field.storage.node.field_decision_native_id
+    - field.storage.node.field_diary_number
+    - field.storage.node.field_decision_case_title
+    - field.storage.node.field_meeting_date
     - field.storage.node.field_dm_org_above_name
     - field.storage.node.field_dm_org_name
     - field.storage.node.field_organization_type
-    - field.storage.node.field_decision_section
+    - field.storage.node.field_full_title
     - field.storage.node.field_top_category_name
     - search_api.server.elasticsearch
   module:
     - node
     - search_api
+    - helfi_react_search
     - paatokset_search
 id: decisions
 name: Decisions
@@ -166,6 +167,11 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: sector
     type: string
+  sector_data:
+    label: 'Sector data'
+    datasource_id: 'entity:node'
+    property_path: sector_data
+    type: text
   sector_id:
     label: 'Sector ID'
     datasource_id: 'entity:node'
@@ -239,14 +245,23 @@ processor_settings:
   content_access:
     weights:
       preprocess_query: -30
+  custom_value: {  }
   decision_url: {  }
   decisionmaker_combined_title: {  }
+  decisionmaker_searchfield_data: {  }
+  district_image_absolute_url: {  }
   entity_status: {  }
   entity_type: {  }
   has_translation: {  }
-  hidden_decisions: {  }
+  hidden_decisions:
+    weights:
+      preprocess_index: 100
   language_with_fallback: {  }
+  project_execution_schedule: {  }
+  project_image_absolute_url: {  }
+  project_plan_schedule: {  }
   rendered_item: {  }
+  sector_data: {  }
   sector_id: {  }
   sector_json: {  }
   special_status: {  }

--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -170,7 +170,6 @@ processor_settings:
   entity_type: {  }
   exclude_trustees: {  }
   has_translation: {  }
-  inactive_decisionmakers: {  }
   language_with_fallback: {  }
   organization_hierarchy: {  }
   project_execution_schedule: {  }

--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -3,13 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_dm_org_name
+    - field.storage.node.field_policymaker_existing
     - field.storage.node.field_first_name
     - field.storage.node.field_last_name
-    - field.storage.node.field_organization_type
-    - field.storage.node.field_sector_name
     - field.storage.node.field_dm_organization
+    - field.storage.node.field_dm_org_name
+    - field.storage.node.field_organization_type
     - field.storage.node.field_ahjo_title
+    - field.storage.node.field_sector_name
     - search_api.server.elasticsearch
   module:
     - node
@@ -68,6 +69,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_organization_type
+  field_policymaker_existing:
+    label: 'Active policymaker'
+    datasource_id: 'entity:node'
+    property_path: field_policymaker_existing
+    type: boolean
+    dependencies:
+      config:
+        - field.storage.node.field_policymaker_existing
   field_sector_name:
     label: 'Sector name'
     datasource_id: 'entity:node'
@@ -165,6 +174,7 @@ processor_settings:
   custom_value: {  }
   decision_url: {  }
   decisionmaker_combined_title: {  }
+  decisionmaker_searchfield_data: {  }
   district_image_absolute_url: {  }
   entity_status: {  }
   entity_type: {  }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - --max_allowed_packet=512M
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_swedish_ci
+      - --sort_buffer_size=4096k
     environment:
       MYSQL_DATABASE: drupal
       MYSQL_USER: drupal

--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_organization.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_organization.yml
@@ -40,7 +40,12 @@ process:
       source: response/OrganizationLevelAbove/organizations
       process:
         value: ID
-  field_org_level_below_ids: response/OrganizationLevelBelow/organizations/0/ID
+  field_org_level_below_ids:
+    -
+      plugin: sub_process
+      source: response/OrganizationLevelBelow/organizations
+      process:
+        value: ID
 destination:
   plugin: 'entity:node'
   translations: true

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -455,7 +455,7 @@ class AhjoProxy implements ContainerInjectionInterface {
    */
   public function getOrgChart(string $orgId, int $steps = 3, string $langcode = 'fi'): ?array {
     $nodeStorage = $this->entityTypeManager->getStorage('node');
-    $ids = $nodeStorage('node')->getQuery()
+    $ids = $nodeStorage->getQuery()
       ->accessCheck(TRUE)
       ->condition('status', 1)
       ->range(0, 1)
@@ -510,6 +510,7 @@ class AhjoProxy implements ContainerInjectionInterface {
         'TypeId',
         'Sector',
         'Formed',
+        'Existing',
       ];
       foreach ($values as $value) {
         if (isset($org[$value])) {

--- a/public/modules/custom/paatokset_search/drush.services.yml
+++ b/public/modules/custom/paatokset_search/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  paatokset.database_cleaner:
+    class: \Drupal\paatokset_search\Commands\DevelopmentDatabaseCleanerCommand
+    arguments:
+      - '@entity_type.manager'
+    tags:
+      - { name: drush.command }

--- a/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Drupal\paatokset_search\Commands;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drush\Attributes\Command;
-use Drush\Commands\DrushCommands;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\node\Entity\Node;
-
+use Drush\Attributes\Command;
+use Drush\Commands\DrushCommands;
 
 /**
  * A drush command to clean up database for development purpose.
@@ -25,21 +24,20 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
-  )
-  {
+  ) {
   }
 
   /**
    * Deletes the old decisions.
    *
-   * @param array $options
-   *   The options.
+   * @param string $dateFrom
+   *   Decisions older than given date will be removed from database.
    *
    * @return int
    *   The exit code.
    */
   #[Command(name: 'paatokset:decisions:delete')]
-  public function databaseCleanup(string $dateFrom = null): int {
+  public function databaseCleanup(string $dateFrom = NULL): int {
 
     if (getenv('APP_ENV') !== 'local') {
       $this->io()->writeln('Stopping execution. APP_ENV is not "local" or is missing.');
@@ -59,9 +57,9 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
       ->condition('type', 'decision')
       ->condition('field_decision_date', $formatted, '<')
       ->accessCheck(FALSE)
-      ->range(0,100);
+      ->range(0, 100);
 
-    while($ids = $query->execute()) {
+    while ($ids = $query->execute()) {
       foreach ($ids as $id) {
         $node = Node::load($id);
         $node->delete();

--- a/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\paatokset_search\Commands;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\node\Entity\Node;
 use Drush\Attributes\Command;

--- a/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\paatokset_search\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Attributes\Command;
+use Drush\Commands\DrushCommands;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\node\Entity\Node;
+
+
+/**
+ * A drush command to clean up database for development purpose.
+ */
+final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager service.
+   */
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  )
+  {
+  }
+
+  /**
+   * Deletes the old decisions.
+   *
+   * @param array $options
+   *   The options.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'paatokset:decisions:delete')]
+  public function databaseCleanup(string $dateFrom = null): int {
+
+    if (getenv('APP_ENV') !== 'local') {
+      $this->io()->writeln('Stopping execution. APP_ENV is not "local" or is missing.');
+      return DrushCommands::EXIT_SUCCESS;
+    }
+
+    $query = $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery();
+
+    $date = $dateFrom ? new DrupalDateTime($dateFrom) : new DrupalDateTime(date("Y-m-d", strtotime("-6 months")));
+
+    $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
+    $formatted = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+
+    $query
+      ->condition('type', 'decision')
+      ->condition('field_decision_date', $formatted, '<')
+      ->accessCheck(FALSE)
+      ->range(0,100);
+
+    while($ids = $query->execute()) {
+      foreach ($ids as $id) {
+        $node = Node::load($id);
+        $node->delete();
+      }
+    }
+
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+}

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/DecisionmakerSearchfieldData.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/DecisionmakerSearchfieldData.php
@@ -17,9 +17,7 @@ use Drupal\search_api\Processor\ProcessorProperty;
  *    description = @Translation("Combines policymaker_id id, organization_name and organization_above_name."),
  *    stages = {
  *      "add_properties" = 0,
- *    },
- *    locked = true,
- *    hidden = true,
+ *    }
  * )
  */
 class DecisionmakerSearchfieldData extends ProcessorPluginBase {

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/DecisionmakerSearchfieldData.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/DecisionmakerSearchfieldData.php
@@ -62,6 +62,7 @@ class DecisionmakerSearchfieldData extends ProcessorPluginBase {
       if ($node->getType() === 'policymaker') {
         $org_name_field = 'field_ahjo_title';
         $org_above_name_field = 'field_dm_org_name';
+        $sector_field = 'field_sector_name';
       }
       else {
         $org_name_field = 'field_dm_org_name';
@@ -73,6 +74,10 @@ class DecisionmakerSearchfieldData extends ProcessorPluginBase {
       foreach ($languages as $langcode) {
         $node = $node->hasTranslation($langcode) ? $node->getTranslation($langcode) : $original_translation;
 
+        if (isset($sector_field) && $node->hasField($sector_field)) {
+          $data['sector'][$langcode] = $node->get($sector_field)->value;
+        }
+
         if ($node->hasField($org_name_field)) {
           $data['organization'][$langcode] = $node->get($org_name_field)->value;
         }
@@ -83,10 +88,9 @@ class DecisionmakerSearchfieldData extends ProcessorPluginBase {
 
       $fields = $this->getFieldsHelper()
         ->filterForPropertyPath($item->getFields(), 'entity:node', 'decisionmaker_searchfield_data');
+
       if (isset($fields['decisionmaker_searchfield_data'])) {
-        $fields['decisionmaker_searchfield_data']->addValue(
-          json_encode($data)
-        );
+        $fields['decisionmaker_searchfield_data']->addValue(json_encode($data));
       }
 
     }

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorData.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorData.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\paatokset_search\Plugin\search_api\processor;
+
+use Drupal\node\NodeInterface;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+
+/**
+ * Adds decisionmaker related sector data to index as json.
+ *
+ * @SearchApiProcessor(
+ *    id = "sector_data",
+ *    label = @Translation("Decisionmaker sector data"),
+ *    description = @Translation("Sector data."),
+ *    stages = {
+ *      "add_properties" = 0,
+ *    }
+ * )
+ */
+class SectorData extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if ($datasource) {
+      $definition = [
+        'label' => $this->t('Decisionmaker search dropdown title'),
+        'description' => $this->t('Combine decisionmaker policymaker_id, organization_name and organization_above_name.'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['sector_data'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $datasourceId = $item->getDataSourceId();
+    if ($datasourceId === 'entity:node') {
+      $node = $item->getOriginalObject()->getValue();
+
+      if (!$node instanceof NodeInterface) {
+        return;
+      }
+
+      $data = [];
+      if ($node->hasField('field_policymaker_id')) {
+        $data['id'] = $node->get('field_policymaker_id')->value;
+      }
+
+      $sector_data = null;
+      $sector_field = 'field_sector_name';
+
+      if ($node->getType() !== 'policymaker') {
+        $dm = null;
+        $dmId = $node->hasField('field_policymaker_id') ? $node->get('field_policymaker_id')->value : null;
+        if ($dmId) {
+          $nodes = \Drupal::entityTypeManager()
+            ->getStorage('node')
+            ->loadByProperties([
+              'type' => 'policymaker',
+              'field_policymaker_id' => $dmId,
+            ]);
+
+          $dm = reset($nodes);
+        }
+
+        if (!$dm) {
+          $data['sector'] = ['fi' => null, 'en' => null, 'sv' => null];
+        } else {
+          $original_translation = $dm->hasTranslation('fi') ? $dm->getTranslation('fi') : $dm;
+          $languages = ['fi', 'en', 'sv'];
+
+          foreach ($languages as $langcode) {
+            $dm = $dm->hasTranslation($langcode) ? $dm->getTranslation($langcode) : $original_translation;
+            if ($dm && $dm->hasTranslation($langcode)) {
+              $dm = $dm->getTranslation($langcode);
+              $data['sector'][$langcode] = $dm->get($sector_field)->value;
+            }
+          }
+        }
+
+        $fields = $this->getFieldsHelper()
+          ->filterForPropertyPath($item->getFields(), 'entity:node', 'sector_data');
+        if (isset($fields['sector_data'])) {
+          $fields['sector_data']->addValue(
+            json_encode($data)
+          );
+        }
+      }
+
+    }
+  }
+
+}

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorData.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/SectorData.php
@@ -62,8 +62,8 @@ class SectorData extends ProcessorPluginBase {
       }
 
       $sector_field = 'field_sector_name';
-      $dm = null;
-      $dmId = $node->hasField('field_policymaker_id') ? $node->get('field_policymaker_id')->value : null;
+      $dm = NULL;
+      $dmId = $node->hasField('field_policymaker_id') ? $node->get('field_policymaker_id')->value : NULL;
       if ($dmId) {
         $nodes = \Drupal::entityTypeManager()
           ->getStorage('node')
@@ -75,7 +75,7 @@ class SectorData extends ProcessorPluginBase {
         $dm = reset($nodes);
       }
 
-      $data['sector'] = ['fi' => null, 'en' => null, 'sv' => null];
+      $data['sector'] = ['fi' => NULL, 'en' => NULL, 'sv' => NULL];
 
       if ($dm) {
         $original_translation = $dm->hasTranslation('fi') ? $dm->getTranslation('fi') : $dm;


### PR DESCRIPTION
Fixes issues with organization chart migration and JSON endpoint:
- The migration only saved the first Organization level below ID and not all of them
- JSON endpoint code had a typo which caused a fatal error to be thrown

## How to install
* Make sure your instance is up and running on correct branch:
  * `git checkout UHF-x-org-chart-fixes` 
* `make drush-cr`

## How to test
* [ ] Run the migration again with `drush migrate-import ahjo_organizations --update -v` (this will take a while)
* [ ] Check some organization nodes and make sure the "LevelBelowIDs" values are set correctly: https://helsinki-paatokset.docker.so/fi/admin/content/organizations?title=hallitus (KaupunginHallitus especially should have multiple organizations below it)
* [ ] Test that the organization chart endpoint actually returns JSON and has the full dataset: https://helsinki-paatokset.docker.so/fi/ahjo-proxy/org-chart/00001/9999
* [ ] Check that code follows our standards