### PR TITLE
UHF-X: Fix errors with org chart import and printing.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_organization.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_organization.yml
@@ -40,7 +40,12 @@ process:
       source: response/OrganizationLevelAbove/organizations
       process:
         value: ID
-  field_org_level_below_ids: response/OrganizationLevelBelow/organizations/0/ID
+  field_org_level_below_ids:
+    -
+      plugin: sub_process
+      source: response/OrganizationLevelBelow/organizations
+      process:
+        value: ID
 destination:
   plugin: 'entity:node'
   translations: true

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -455,7 +455,7 @@ class AhjoProxy implements ContainerInjectionInterface {
    */
   public function getOrgChart(string $orgId, int $steps = 3, string $langcode = 'fi'): ?array {
     $nodeStorage = $this->entityTypeManager->getStorage('node');
-    $ids = $nodeStorage('node')->getQuery()
+    $ids = $nodeStorage->getQuery()
       ->accessCheck(TRUE)
       ->condition('status', 1)
       ->range(0, 1)
@@ -510,6 +510,7 @@ class AhjoProxy implements ContainerInjectionInterface {
         'TypeId',
         'Sector',
         'Formed',
+        'Existing',
       ];
       foreach ($values as $value) {
         if (isset($org[$value])) {


### PR DESCRIPTION
Fixes issues with organization chart migration and JSON endpoint:
- The migration only saved the first Organization level below ID and not all of them
- JSON endpoint code had a typo which caused a fatal error to be thrown

## How to install
* Make sure your instance is up and running on correct branch:
  * `git checkout UHF-x-org-chart-fixes` 
* `make drush-cr`

## How to test
* [x] Run the migration again with `drush migrate-import ahjo_organizations --update -v` (this will take a while)
* [x] Check some organization nodes and make sure the "LevelBelowIDs" values are set correctly: https://helsinki-paatokset.docker.so/fi/admin/content/organizations?title=hallitus (KaupunginHallitus especially should have multiple organizations below it)
* [x] Test that the organization chart endpoint actually returns JSON and has the full dataset: https://helsinki-paatokset.docker.so/fi/ahjo-proxy/org-chart/00001/9999
* [x] Check that code follows our standards