### PR TITLE
UHF-9917: Fix logic error when creating motions based on meeting agenda.

### DIFF
--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1878,13 +1878,21 @@ class AhjoProxy implements ContainerInjectionInterface {
     $case_id = $ids['case_id'];
     $title = $data['title'];
     $native_id = $data['native_id'];
+    $version_id = $data['version_id'];
     $meeting_id = $data['meeting_data']['meeting_id'];
     $meeting_date = $data['meeting_data']['meeting_date'];
     $meeting_number = $data['meeting_data']['meeting_number'];
     $org_id = $data['meeting_data']['org_id'];
     $org_name = $data['meeting_data']['org_name'];
 
-    $node = $case_service->findOrCreateMotion($case_id, $meeting_id, $title, TRUE);
+    // Attempt to find node by ID.
+    $node = $case_service->findMotionById($native_id, $version_id);
+
+    // If node can't be found use meeting data or create it.
+    if (!$node instanceof NodeInterface) {
+      $node = $case_service->findOrCreateMotionByMeetingData($native_id, $version_id, $case_id, $meeting_id, $title, TRUE);
+    }
+
     if (!$node instanceof NodeInterface) {
       $context['results']['failed'][] = $data['title'];
       return;
@@ -1974,6 +1982,7 @@ class AhjoProxy implements ContainerInjectionInterface {
     $node->set('field_top_category_name', $top_category);
     $node->set('field_classification_code', $classification_code);
     $node->set('field_decision_native_id', $native_id);
+    $node->set('field_decision_series_id', $version_id);
     $node->set('field_diary_number', $case_id);
     $node->set('field_meeting_id', $meeting_id);
     $node->set('field_decision_date', $meeting_date);

--- a/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/AhjoProxy.php
@@ -1890,7 +1890,7 @@ class AhjoProxy implements ContainerInjectionInterface {
 
     // If node can't be found use meeting data or create it.
     if (!$node instanceof NodeInterface) {
-      $node = $case_service->findOrCreateMotionByMeetingData($native_id, $version_id, $case_id, $meeting_id, $title, TRUE);
+      $node = $case_service->findOrCreateMotionByMeetingData($version_id, $case_id, $meeting_id, $title);
     }
 
     if (!$node instanceof NodeInterface) {

--- a/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
+++ b/public/modules/custom/paatokset_ahjo_proxy/src/Commands/AhjoAggregatorCommands.php
@@ -2402,6 +2402,13 @@ class AhjoAggregatorCommands extends DrushCommands {
           $native_id = $item['PDF']['NativeId'];
         }
 
+        if (isset($item['PDF']['VersionSeriesId'])) {
+          $version_id = $item['PDF']['VersionSeriesId'];
+        }
+        else {
+          $version_id = NULL;
+        }
+
         $item['PDF']['AgendaPoint'] = $item['AgendaPoint'];
 
         $endpoint = NULL;
@@ -2424,6 +2431,7 @@ class AhjoAggregatorCommands extends DrushCommands {
           'count' => $count,
           'title' => $item['AgendaItem'],
           'native_id' => $native_id,
+          'version_id' => $version_id,
           'pdf' => $item['PDF'],
           'html' => $item['HTML'],
           'meeting_data' => $meeting_data,


### PR DESCRIPTION
# [UHF-9917](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9917)

## What was done
Fixes logic error when creating motions. Previously if a meeting had agenda items with the same diary number and title, the system stored all of them in the same node.

This still leaves orphaned motions when the decisions are published.

## Replicate issue
* Make sure your instance is up and running on `dev` branch
* Run `drush ap:update meetings 00400202414 -v; drush ap:gm -v`
* Go to https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus/asiakirjat/00400202414
  * The points 17 and 18 should have the same URL. 

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9917-motion-creation-fix`
* Run `make drush-cr`

## How to test
* Run `drush ap:update meetings 00400202414 -v; drush ap:gm -v`
* Reload the page: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus/asiakirjat/00400202414
  * [x] The points 17 and 18 should now have different URLs
  * [x] Also test the english and swedish language versions
* [x] Follow both motion URLs, check that nothing breaks when viewing the case and navigating to different decisions and motions
* [ ] Can you think of any cases where this might causes issues or break down the line?
* [x] Check that code follows our standards

## Continuous documentation
* [x] This feature has been documented/the documentation has been updated

[UHF-9917]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ