### PR TITLE
UHF-9947: Meeting agenda item languge URL fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Run PHPCS
         run: |
-          vendor/bin/phpcs public/modules/custom/ --ignore="*.js,*.css" --extensions=php,module,install --standard=Drupal
-          vendor/bin/phpcs public/themes/custom/ --ignore="*.js,*.css" --extensions=php,theme --standard=Drupal
+          vendor/bin/phpcs public/modules/custom/ --ignore="*.js,*.css" --extensions=php,module,install --standard=Drupal,DrupalPractice
+          vendor/bin/phpcs public/themes/custom/ --ignore="*.js,*.css" --extensions=php,theme --standard=Drupal,DrupalPractice
 
       - name: Download latest dump
         env:

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -829,7 +829,7 @@ function _paatokset_ahjo_api_lookup_organization_nid(string $decisionmaker_id): 
  * @param int $length
  *   Max length of string.
  *
- * @return string|null
+ * @return string
  *   Truncated value.
  */
 function _paatokset_ahjo_api_truncate_value(string $value, int $length = 255): string {
@@ -845,7 +845,7 @@ function _paatokset_ahjo_api_truncate_value(string $value, int $length = 255): s
  * @return bool
  *   TRUE is value is not empty, FALSE if it is.
  */
-function _paatokset_ahjo_api_true_if_not_empty($value): bool {
+function _paatokset_ahjo_api_true_if_not_empty(mixed $value): bool {
   return !empty($value);
 }
 
@@ -1004,7 +1004,7 @@ function _paatokset_ahjo_api_get_existing_value_with_override(array $values) {
  * @return string|null
  *   Top category name based on the first part of the code, if found.
  */
-function _paatokset_ahjo_api_get_top_category(array $values): ?string {
+function _paatokset_ahjo_api_get_top_category(mixed $values): ?string {
   if (!is_array($values)) {
     return NULL;
   }

--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoSubscriberController.php
@@ -99,7 +99,7 @@ class AhjoSubscriberController extends ControllerBase {
       $entity_id = (string) $content->id;
     }
     else {
-      $update_type = 'unknown';
+      $entity_id = 'unknown';
     }
 
     if ($item_id) {

--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/CaseNodeViewController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/CaseNodeViewController.php
@@ -129,7 +129,7 @@ final class CaseNodeViewController extends NodeViewController {
       $case->hasField('field_dm_org_name') &&
       !$case->get('field_dm_org_name')->isEmpty()
     ) {
-      return $case->getTitle() . ' - ' . $case->field_dm_org_name->value;
+      return $case->getTitle() . ' - ' . $case->get('field_dm_org_name')->value;
     }
 
     return $case->getTitle();
@@ -144,7 +144,7 @@ final class CaseNodeViewController extends NodeViewController {
    *   Decision native ID.
    */
   public function decisionTitle(string $case_id, NodeInterface $decision): ?string {
-    return $decision->getTitle() . ' - ' . $decision->field_dm_org_name->value;
+    return $decision->getTitle() . ' - ' . $decision->get('field_dm_org_name')->value;
   }
 
   /**

--- a/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsListBuilder.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsListBuilder.php
@@ -43,6 +43,7 @@ class DisallowedDecisionsListBuilder extends DraggableListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\paatokset_ahjo_api\Entity\DisallowedDecisions $entity  */
     $row['sorter'] = ['#markup' => ''];
     $row['label'] = $entity->label();
     $row['id'] = $entity->id();

--- a/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/DisallowedDecisionsStorageManager.php
@@ -57,6 +57,7 @@ class DisallowedDecisionsStorageManager extends ConfigEntityStorage {
   public function getDisallowedDecisionOrgs(): array {
     $orgs = [];
     $entities = $this->loadMultiple();
+    /** @var \Drupal\paatokset_ahjo_api\Entity\DisallowedDecisions[] $entities  */
     foreach ($entities as $entity) {
       if (!$entity->get('status')) {
         continue;
@@ -103,6 +104,7 @@ class DisallowedDecisionsStorageManager extends ConfigEntityStorage {
    *   Sections grouped by year. NULL if data is invalid or entity is hidden.
    */
   protected function getDisallowedSectionsByYearFromEntity(EntityInterface $entity): ?array {
+    /** @var \Drupal\paatokset_ahjo_api\Entity\DisallowedDecisions $entity  */
     if (!$entity->get('status')) {
       return NULL;
     }

--- a/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsForm.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Form/DisallowedDecisionsForm.php
@@ -49,6 +49,7 @@ class DisallowedDecisionsForm extends EntityForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
 
+    /** @var \Drupal\paatokset_ahjo_api\Entity\DisallowedDecisions $disallowed_decisions  */
     $disallowed_decisions = $this->entity;
     $form['label'] = [
       '#type' => 'textfield',
@@ -102,6 +103,8 @@ class DisallowedDecisionsForm extends EntityForm {
           ]));
     }
     $form_state->setRedirectUrl($disallowed_decisions->toUrl('collection'));
+
+    return $status;
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoEntityGenerate.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoEntityGenerate.php
@@ -76,9 +76,9 @@ class AhjoEntityGenerate extends EntityLookup {
     }
 
     // Updates either the existing or created entity.
-    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
     if ($entity = $this->entityTypeManager->getStorage($this->lookupEntityType)
       ->load($result)) {
+      /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
       $this->updateEntity($entity, $value);
     }
 
@@ -100,10 +100,10 @@ class AhjoEntityGenerate extends EntityLookup {
    */
   protected function generateEntity($value) {
     if (empty($value)) {
-      return;
+      return NULL;
     }
     if (!is_array($value)) {
-      return;
+      return NULL;
     }
 
     $entity = $this->entityTypeManager

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/SkipDisallowedDecisions.php
@@ -104,6 +104,7 @@ class SkipDisallowedDecisions extends ProcessPluginBase {
       return FALSE;
     }
 
+    /** @var \Drupal\paatokset_ahjo_api\DisallowedDecisionsStorageManager $dd_manager */
     $dd_manager = \Drupal::service('entity_type.manager')->getStorage('disallowed_decisions');
     return $dd_manager->checkIfDisallowed($dm_id, $year, $section);
   }

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -665,7 +665,7 @@ class CaseService {
     // Case alias exists, so build URL with query parameter.
     if ($case_alias && $this->routeExists($localizedCaseRoute)) {
       $case_url = Url::fromRoute($localizedCaseRoute, ['case' => $case_id]);
-      $case_url->setOption('query', [$this->getDecisionQueryKey($langcode) => $id]);
+      $case_url->setOption('query', [$this->getDecisionQueryKey($language) => $id]);
       return $case_url;
     }
 

--- a/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
+++ b/public/modules/custom/paatokset_ahjo_openid/src/AhjoOpenId.php
@@ -86,10 +86,10 @@ class AhjoOpenId {
   /**
    * Get Auth and refresh tokens.
    *
-   * @return ?mixed
+   * @return mixed
    *   Decoded json response or NULL on failure.
    */
-  public function getAuthAndRefreshTokens(string $code = NULL): ?string {
+  public function getAuthAndRefreshTokens(string $code = NULL): mixed {
     // getHeaders throw an exception if settings are not valid.
     if (!$this->validateSettings()) {
       return NULL;

--- a/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -7,7 +7,6 @@ namespace Drupal\paatokset_search\Commands;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
-use Drupal\node\Entity\Node;
 use Drush\Attributes\Command;
 use Drush\Commands\DrushCommands;
 
@@ -52,17 +51,16 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
     $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
     $formatted = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
 
-    $query
+    $ids = $query
       ->condition('type', 'decision')
       ->condition('field_decision_date', $formatted, '<')
       ->accessCheck(FALSE)
-      ->range(0, 100);
+      ->range(0, 100)
+      ->execute();
 
-    while ($ids = $query->execute()) {
-      foreach ($ids as $id) {
-        $node = $nodeStorage->load($id);
-        $node->delete();
-      }
+    foreach ($ids as $id) {
+      $node = $nodeStorage->load($id);
+      $node->delete();
     }
 
     return DrushCommands::EXIT_SUCCESS;

--- a/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -44,9 +44,8 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
       return DrushCommands::EXIT_SUCCESS;
     }
 
-    $query = $this->entityTypeManager
-      ->getStorage('node')
-      ->getQuery();
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+    $query = $nodeStorage->getQuery();
 
     $date = $dateFrom ? new DrupalDateTime($dateFrom) : new DrupalDateTime(date("Y-m-d", strtotime("-6 months")));
 
@@ -61,7 +60,7 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
 
     while ($ids = $query->execute()) {
       foreach ($ids as $id) {
-        $node = Node::load($id);
+        $node = $nodeStorage->load($id);
         $node->delete();
       }
     }

--- a/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_search/src/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -51,16 +51,17 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
     $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
     $formatted = $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
 
-    $ids = $query
+    $query
       ->condition('type', 'decision')
       ->condition('field_decision_date', $formatted, '<')
       ->accessCheck(FALSE)
-      ->range(0, 100)
-      ->execute();
+      ->range(0, 100);
 
-    foreach ($ids as $id) {
-      $node = $nodeStorage->load($id);
-      $node->delete();
+    while ($ids = $query->execute()) {
+      foreach ($ids as $id) {
+        $node = $nodeStorage->load($id);
+        $node->delete();
+      }
     }
 
     return DrushCommands::EXIT_SUCCESS;


### PR DESCRIPTION
# [UHF-9947](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9947)

## What was done
* Fixes issue with meeting agenda item language URLs, previously this used the wrong language's URL query parameter.
* Fixes some PHPCS DrupalPractice issues so the checks can be turned back on in Github's CI pipeline
* Fixes simple PHPStan issues.

## Replicate issue
* Install `dev` branch locally
* You can use `make new` and then `drush en paatokset_test_content` if you don't have the production data to test with
* Import test data:
```
drush mim ahjo_decisionmakers:all --update;
drush mim ahjo_decisionmakers:all_sv --update;
drush ap:update meetings 00400202414 -v;
drush ap:gm -v;
drush ap:ud --logic=case -v;
drush queue:run ahjo_api_retry_queue -v
drush ap:ud --logic=case -v;
```
* Go to https://helsinki-paatokset.docker.so/sv/beslutsfattare/stadsstyrelsen/dokumenter/00400202414
  * If you check the agenda item URLs, some of the query parameters should be in the wrong language (`?paatos=` query parameters on the swedish or english page)
  * If you don't see the query parameters, you're probably missing case nodes. Try running the `drush ap:ud` and queue commands again 

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9947-meeting-agenda-url-fix`
* Run `make drush-cr`

## How to test
* [x] Reload the meeting page. The URL query parameters should now be in the correct language
* [x] Run PHPCS checks with Drupal and DrupalPractice standards
* [ ] Check that code follows our standards

## Continuous documentation
* [x] This change doesn't require updates to the documentation

[UHF-9947]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ