### PR TITLE
UHF-9974: Change robots txt rule to be more specific.

### DIFF
--- a/assets/robots-append.txt
+++ b/assets/robots-append.txt
@@ -2,4 +2,10 @@
 Disallow: /*?*from=*
 Disallow: /*?*to=*
 Disallow: /*?*category=*
-Disallow: /*?*s=*
+Disallow: /*?*dm=*
+Disallow: /fi/asia?*s=*
+Disallow: /sv/arende?*s=*
+Disallow: /en/case?*s=*
+Disallow: /fi/paattajat?*s=*
+Disallow: /sv/beslutsfattare?*s=*
+Disallow: /en/decisionmakers?*s=*

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -76,4 +76,10 @@ Disallow: /index.php/*/media/oembed
 Disallow: /*?*from=*
 Disallow: /*?*to=*
 Disallow: /*?*category=*
-Disallow: /*?*s=*
+Disallow: /*?*dm=*
+Disallow: /fi/asia?*s=*
+Disallow: /sv/arende?*s=*
+Disallow: /en/case?*s=*
+Disallow: /fi/paattajat?*s=*
+Disallow: /sv/beslutsfattare?*s=*
+Disallow: /en/decisionmakers?*s=*


### PR DESCRIPTION
# [UHF-9974](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9974)

## What was done
Changes robots.txt rule to be more specific in order to prevent it blocking decision URLs.

## How to test
Use this robots.txt validator: https://technicalseo.com/tools/robots-txt/

* [ ] Test this URL: https://paatokset.hel.fi/fi/asia/hel-2016-012511?paatos=8cb6b9ed-98d5-4456-8ed4-f2b47b04852b, but replace the last rule `Disallow: /*?*s=*` with the changes from this PR. Nothing should be disallowed on this URL
* [ ] Test this URL: https://paatokset.hel.fi/fi/asia?s=%22asdasd%22&category=
%5B%22Henkil%C3%B6st%C3%B6asiat%22%5D&dm=%2202900%22, it should be blocked because of the search queries
* [ ] Test this URL: https://paatokset.hel.fi/sv/beslutsfattare?s=%22ssss%22, it should be blocked too
* [x] Check that code follows our standards

## Continuous documentation
* [x] This change doesn't require updates to the documentation

## Other PRs
*  https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/600


[UHF-9974]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ