### PR TITLE
UHF-10255: Add X-Robots-Tag if environment variable is set

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -123,6 +123,7 @@ module:
   paatokset_config: 0
   paatokset_council_info: 0
   paatokset_datapumppu: 0
+  paatokset_headers: 0
   paatokset_helsinki_kanava: 0
   paatokset_lang_switcher: 0
   paatokset_pdf_listing: 0

--- a/public/modules/custom/paatokset_headers/paatokset_headers.info.yml
+++ b/public/modules/custom/paatokset_headers/paatokset_headers.info.yml
@@ -1,0 +1,5 @@
+name: Päätökset Headers
+type: module
+description: Adds headers to page responses.
+package: Custom
+core_version_requirement: ^9 || ^10

--- a/public/modules/custom/paatokset_headers/paatokset_headers.services.yml
+++ b/public/modules/custom/paatokset_headers/paatokset_headers.services.yml
@@ -1,0 +1,4 @@
+services:
+  Drupal\paatokset_headers\EventSubscriber\RobotsResponseSubscriber:
+    tags:
+      - { name: event_subscriber }

--- a/public/modules/custom/paatokset_headers/src/EventSubscriber/RobotsResponseSubscriber.php
+++ b/public/modules/custom/paatokset_headers/src/EventSubscriber/RobotsResponseSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\paatokset_headers\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds an X-Robots-Tag to response headers.
+ */
+final class RobotsResponseSubscriber implements EventSubscriberInterface {
+
+  public const X_ROBOTS_TAG_HEADER_NAME = 'DRUPAL_X_ROBOTS_TAG_HEADER';
+
+  /**
+   * Adds an X-Robots-Tag response header.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event to respond to.
+   */
+  public function onResponse(ResponseEvent $event) : void {
+    $response = $event->getResponse();
+
+    if ((bool) getenv(self::X_ROBOTS_TAG_HEADER_NAME)) {
+      $response->headers->add(['X-Robots-Tag' => 'noindex, nofollow']);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    $events[KernelEvents::RESPONSE][] = ['onResponse', -100];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
# [UHF-10255](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10255)

## What was done
Add and enable a new custom module that adds the `X-Robots-Tag: noindex, nofollow` header when `DRUPAL_X_ROBOTS_TAG_HEADER` environment variable is set to true.

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10255-add-noindex-tag`
  * `make fresh`
* Run `make drush-cr`

## How to test
* [ ] Open any page and check that the `x-robots-tag` header is not set.
* Add `DRUPAL_X_ROBOTS_TAG_HEADER: 1` to `compose.yaml` or `compose.override.yaml` under `services` -> `app` -> `environment`, then run `make up drush-cr`
  * [ ] Reload the page. The header should be set now
* Remove the env variable line from `compose.yaml`, then run `make up drush-cr`
  * [ ] Reload the page. The header should be gone.
* [ ] Check that code follows our standards

## Continuous documentation

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Other PRs
* https://github.com/City-of-Helsinki/drupal-palvelukeskus/pull/41


[UHF-10255]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ