### PR TITLE
UHF-10228: Fix trustee node visibility in decisionmaker search.

### DIFF
--- a/conf/cmi/core.entity_form_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_form_display.node.trustee.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.trustee.field_first_name
     - field.field.node.trustee.field_last_name
+    - field.field.node.trustee.field_policymaker_existing
     - field.field.node.trustee.field_policymaker_reference
     - field.field.node.trustee.field_trustee_chairmanships
     - field.field.node.trustee.field_trustee_council_group
@@ -27,6 +28,7 @@ dependencies:
     - json_field
     - link
     - path
+    - publication_date
     - scheduler
 id: node.trustee.default
 targetEntityType: node
@@ -35,7 +37,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 19
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -57,7 +59,7 @@ content:
     third_party_settings: {  }
   field_policymaker_reference:
     type: entity_reference_autocomplete
-    weight: 26
+    weight: 29
     region: content
     settings:
       match_operator: CONTAINS
@@ -67,7 +69,7 @@ content:
     third_party_settings: {  }
   field_trustee_chairmanships:
     type: json_textarea
-    weight: 14
+    weight: 17
     region: content
     settings:
       rows: 5
@@ -83,7 +85,7 @@ content:
     third_party_settings: {  }
   field_trustee_datapumppu_id:
     type: string_textfield
-    weight: 24
+    weight: 27
     region: content
     settings:
       size: 60
@@ -91,7 +93,7 @@ content:
     third_party_settings: {  }
   field_trustee_email:
     type: email_default
-    weight: 10
+    weight: 11
     region: content
     settings:
       placeholder: ''
@@ -123,7 +125,7 @@ content:
     third_party_settings: {  }
   field_trustee_image:
     type: image_image
-    weight: 11
+    weight: 14
     region: content
     settings:
       progress_indicator: throbber
@@ -131,7 +133,7 @@ content:
     third_party_settings: {  }
   field_trustee_initiatives:
     type: json_textarea
-    weight: 12
+    weight: 15
     region: content
     settings:
       rows: 5
@@ -155,7 +157,7 @@ content:
     third_party_settings: {  }
   field_trustee_resolutions:
     type: json_textarea
-    weight: 13
+    weight: 16
     region: content
     settings:
       rows: 5
@@ -171,27 +173,27 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 16
+    weight: 19
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 20
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 17
+    weight: 20
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 22
+    weight: 25
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -202,20 +204,20 @@ content:
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 21
+    weight: 24
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 18
+    weight: 21
     region: content
     settings:
       display_label: true
@@ -229,13 +231,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 15
+    weight: 18
     region: content
     settings:
       match_operator: CONTAINS
@@ -245,14 +247,15 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 23
+    weight: 26
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 25
+    weight: 28
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_policymaker_existing: true
   hide_sidebar_navigation: true

--- a/conf/cmi/core.entity_view_display.node.trustee.default.yml
+++ b/conf/cmi/core.entity_view_display.node.trustee.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.trustee.field_first_name
     - field.field.node.trustee.field_last_name
+    - field.field.node.trustee.field_policymaker_existing
     - field.field.node.trustee.field_policymaker_reference
     - field.field.node.trustee.field_trustee_chairmanships
     - field.field.node.trustee.field_trustee_council_group
@@ -53,7 +54,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 16
+    weight: 15
     region: content
   field_trustee_chairmanships:
     type: json
@@ -61,7 +62,7 @@ content:
     settings:
       attach_library: true
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   field_trustee_council_group:
     type: string
@@ -69,7 +70,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   field_trustee_datapumppu_id:
     type: string
@@ -84,7 +85,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 15
+    weight: 14
     region: content
   field_trustee_home_district:
     type: string
@@ -104,7 +105,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: null
+    weight: 0
     region: content
   field_trustee_image:
     type: image
@@ -115,7 +116,7 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_trustee_initiatives:
     type: json
@@ -123,7 +124,7 @@ content:
     settings:
       attach_library: true
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   field_trustee_phone:
     type: string
@@ -147,7 +148,7 @@ content:
     settings:
       attach_library: true
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   field_trustee_title:
     type: string
@@ -155,14 +156,15 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
 hidden:
+  field_policymaker_existing: true
   field_trustee_id: true
   langcode: true
   published_at: true

--- a/conf/cmi/core.entity_view_display.node.trustee.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.trustee.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.trustee.field_first_name
     - field.field.node.trustee.field_last_name
+    - field.field.node.trustee.field_policymaker_existing
     - field.field.node.trustee.field_policymaker_reference
     - field.field.node.trustee.field_trustee_chairmanships
     - field.field.node.trustee.field_trustee_council_group
@@ -36,6 +37,7 @@ content:
 hidden:
   field_first_name: true
   field_last_name: true
+  field_policymaker_existing: true
   field_policymaker_reference: true
   field_trustee_chairmanships: true
   field_trustee_council_group: true

--- a/conf/cmi/field.field.node.trustee.field_policymaker_existing.yml
+++ b/conf/cmi/field.field.node.trustee.field_policymaker_existing.yml
@@ -1,0 +1,23 @@
+uuid: 3902a006-b3f4-47a6-969c-d628a4c54f25
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_policymaker_existing
+    - node.type.trustee
+id: node.trustee.field_policymaker_existing
+field_name: field_policymaker_existing
+entity_type: node
+bundle: trustee
+label: 'Active policymaker'
+description: 'Used on Trustee nodes for search index visibility.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: Käytössä
+  off_label: 'Pois päältä'
+field_type: boolean

--- a/public/modules/custom/paatokset_search/paatokset_search.deploy.php
+++ b/public/modules/custom/paatokset_search/paatokset_search.deploy.php
@@ -10,7 +10,7 @@ use Drupal\node\Entity\Node;
 /**
  * Set field_policymaker_existing field on all trustee nodes.
  */
-function paatokset_search_update_9001(): void {
+function paatokset_search_deploy_0001_trustee_field(): void {
   $query = \Drupal::entityQuery('node');
   $nids = $query->accessCheck(TRUE)
     ->condition('status', 1)

--- a/public/modules/custom/paatokset_search/paatokset_search.install
+++ b/public/modules/custom/paatokset_search/paatokset_search.install
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Contains installation hooks for Päätökset Search module.
+ */
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Set field_policymaker_existing field on all trustee nodes.
+ */
+function paatokset_search_update_9001(): void {
+  $query = \Drupal::entityQuery('node');
+  $nids = $query->accessCheck(TRUE)
+    ->condition('status', 1)
+    ->notExists('field_policymaker_existing')
+    ->condition('type', 'trustee')
+    ->execute();
+  if (!$nids) {
+    return;
+  }
+
+  $nodes = Node::loadMultiple($nids);
+
+  foreach ($nodes as $node) {
+    $node->set('field_policymaker_existing', 1);
+    $node->save();
+  }
+}

--- a/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/OrganizationHierarchy.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/search_api/processor/OrganizationHierarchy.php
@@ -6,6 +6,7 @@ namespace Drupal\paatokset_search\Plugin\search_api\processor;
 
 use Drupal\node\NodeInterface;
 use Drupal\paatokset_policymakers\Service\OrganizationPathBuilder;
+use Drupal\search_api\Item\FieldInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 
 /**
@@ -45,7 +46,9 @@ final class OrganizationHierarchy extends ProcessorPluginBase {
       }
 
       $field = $item->getField('organization_hierarchy');
-      $field->setValues($organization_hierarchy);
+      if ($field instanceof FieldInterface) {
+        $field->setValues($organization_hierarchy);
+      }
     }
 
   }


### PR DESCRIPTION
# [UHF-10228](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10228)

## What was done
Fixes a logic error in decisionmaker search which excluded all trustee nodes from the results.

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10228-fix-policymaker-search`
  * `make fresh` (If you use some other commands to import the database dump etc, at least run `make drush-cim drush-updb`.
* Run `make drush-cr`
* If you don't have all trustee nodes locally, run these commands:
```
drush migrate-import ahjo_trustees:all --update;
drush migrate-import ahjo_trustees:all_sv --update
```
* Run `drush sapi-c policymakers;drush sapi-rt policymakers;drush sapi-i policymakers`

## How to test
* Go to: https://helsinki-paatokset.docker.so/fi/paattajat/
  * [x] Search for any city council members by name, they should appear as search suggestions and results. (Find the list here: https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto#members-list)
  * [x] Search for a person who isn't a member of the city council. These should not appear as suggestions or results. You can find examples here: https://helsinki-paatokset.docker.so/fi/paattajat/liikenneliikelaitoksen-johtokunta (Check the profile pages for a full list of roles)
* [x] Check that code follows our standards

## Continuous documentation
* [x] This change doesn't require updates to the documentation


[UHF-10228]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ