### PR TITLE
UHF-8909 Language object refactor

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/navigation/links--language-block.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/navigation/links--language-block.html.twig
@@ -54,10 +54,10 @@
         {% if lang_override and override_url is not empty %}
           {% set language_link = override_url %}
           {% set element = 'a' %}
-        {% elseif not untranslated and not alternative_language and lang != current_langcode %}
+        {% elseif not untranslated and not alternative_language and lang != language.id %}
           {% set language_link = path('<current>', {}, {'language': item.link['#options']['language']}) %}
           {% set element = 'a' %}
-        {% elseif lang == current_langcode %}
+        {% elseif lang == language.id %}
           {% set language_link = path('<current>', {}, {'language': item.link['#options']['language']}) %}
           {% set element = 'a' %}
           {% set ariaCurrent = create_attribute({'aria-current': 'true'}) %}


### PR DESCRIPTION
# [UHF-8909](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8909)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Use the language object which is set in [helfi_api_base_template_preprocess_default_variables_alter()](https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/173/files#diff-c6358d300a9a1d9956fb89a8182da48065f9342a0f9e4ff310dde94f523a6382R113).

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8909`
  * `make new`
  * `make shell`
  * Enable the test content: `drush en -y paatokset_test_content`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the language links block works as before
    * You can test the existence of `{{ language.id }}`, by dumping the language  `{{ dump(language) }}` in `public/themes/custom/hdbt_subtheme/templates/navigation/links--language-block.html.twig`
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1028
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/292
* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/173
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/904
* https://github.com/City-of-Helsinki/drupal-kaupunkitieto/pull/22
* https://github.com/City-of-Helsinki/helsinki-paatokset/pull/444


[UHF-8909]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ