### PR TITLE
UHF-10256: Sort meeting agenda and minutes list correctly

### DIFF
--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -1667,6 +1667,7 @@ class PolicymakerService {
         $id = 'x-' . $last_count . '-' . $data['Section'];
         $agendaItemsLast[$id] = [
           'subject' => $data['AgendaItem'],
+          'section' => (int) $data['Section'],
           'index' => $index,
           'link' => $agenda_link,
           'native_id' => $native_id,
@@ -1691,6 +1692,12 @@ class PolicymakerService {
       return $item1['sequence'] - $item2['sequence'];
     });
     usort($agendaItems, function ($item1, $item2) {
+      return $item1['section'] - $item2['section'];
+    });
+
+    // Sort items without sequence number by section number.
+    // These will be displayed last on the list.
+    usort($agendaItemsLast, function ($item1, $item2) {
       return $item1['section'] - $item2['section'];
     });
 

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -1673,15 +1673,26 @@ class PolicymakerService {
         ];
       }
       else {
-        $id = $data['AgendaPoint'] . '-' . $data['Section'];
+        $id = $data['Section'] . '-' . $data['AgendaPoint'];
         $agendaItems[$id] = [
           'subject' => $data['AgendaItem'],
+          'sequence' => (int) $data['AgendaPoint'],
+          'section' => (int) $data['Section'],
           'index' => $index,
           'link' => $agenda_link,
           'native_id' => $native_id,
         ];
       }
     }
+
+    // Sort agenda items first by sequence number, then by section number.
+    // Missing section or sequence numbers will be handled as 0.
+    usort($agendaItems, function ($item1, $item2) {
+      return $item1['sequence'] - $item2['sequence'];
+    });
+    usort($agendaItems, function ($item1, $item2) {
+      return $item1['section'] - $item2['section'];
+    });
 
     return array_merge($agendaItems, $agendaItemsLast);
   }


### PR DESCRIPTION
# [UHF-10256](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10256)

## What was done
Changes meeting agenda and minutes list sorting to follow this logic:
1. Sort by sequence number (for agenda lists)
2. Sort by section number (This is the one with §. For minutes, sometimes the order items are handled in changes during the meeting).

Old custom handling for items without sequence numbers has been removed. These are no longer displayed at the end of the list, but are sorted based on their section number.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10256`
* Run `make drush-cr`

## Get test content
* Make sure you have all decisionmakers imported:
  * `drush mim ahjo_decisionmakers:all --update` 
* Get meeting data for testing:
```
drush ap:update meetings U321202411 -v;
drush ap:update meetings U32120249 -v;
drush ap:update meetings U32120241 -v;
drush ap:update meetings 0290020189 -v;
drush ap:update meetings U7190020183 -v;
drush ap:update meetings U54020189 -v;
```
* Also, fetch all meetings for the last year, just in case: (this will take a while)
  * `drush ap:agg meetings --start=2024-01-01T00:00:00 --queue -v;drush queue:run ahjo_api_aggregation_queue -v` 

## How to test
* Check that this feature works
  * [x] Upcoming meetings with only agendas published should be listed by the sequence number
    * Find some of these by opening random organizations and checking their document pages for Esityslista documents  
  * [x] Order changed during meeting:
    * https://helsinki-paatokset.docker.so/fi/paattajat/sosiaali-terveys-ja-pelastuslautakunta/asiakirjat/U321202411
    * https://helsinki-paatokset.docker.so/fi/paattajat/sosiaali-terveys-ja-pelastuslautakunta/asiakirjat/U32120249
    * [x] Also manually change the order or a random meeting's agenda to see if the sorting functionality works. You can edit a meeting node by going to: https://helsinki-paatokset.docker.so/fi/kokoukset/0290020241 for example, and changing the last URL segment to the meeting's ID.
  * [x] Cases where alphabetical and numerical sorting would cause issues:
    * https://helsinki-paatokset.docker.so/fi/paattajat/sosiaali-terveys-ja-pelastuslautakunta/asiakirjat/U32120241 
    * Try to test a few more, these are usually the first documents for each year for most organizations.
  * [x] Cases where agenda items have been added without sequence numbers:
    * These should be sorted by section number.  
    * https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat/0290020189
    * https://helsinki-paatokset.docker.so/fi/paattajat/kaupunkiymparistolautakunta/asiakirjat/U54020189  
* [x] Check that code follows our standards
* [x] Check that the updated documentation makes sense: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/PP/pages/8333819923/Kriittiset+toiminnallisuudet+ja+ongelmatilanteiden+selvitys#Kokousdata-ja-toimielinten-asiakirjat
  * The part starting from "Esityslistojen ja pöytäkirjojen asiakohtien järjestys" was added for this change
  * Should this be added anywhere else in the documentation, or this is enough?

## Continuous documentation
* [x] This feature has been documented/the documentation has been updated


[UHF-10256]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ