### PR TITLE
UHF-10520: Enable helfi_tfa module

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -27,6 +27,7 @@ module:
   editor: 0
   editoria11y: 0
   elasticsearch_connector: 0
+  encrypt: 0
   entity: 0
   entity_browser: 0
   entity_reference_revisions: 0
@@ -82,6 +83,7 @@ module:
   helfi_platform_config_base: 0
   helfi_react_search: 0
   helfi_robots_header: 0
+  helfi_tfa: 0
   helfi_toc: 0
   helfi_tpr: 0
   helfi_tpr_config: 0
@@ -97,6 +99,7 @@ module:
   jquery_ui_draggable: 0
   json_field: 0
   json_field_widget: 0
+  key: 0
   key_auth: 0
   language: 0
   link: 0
@@ -147,6 +150,7 @@ module:
   purge_tokens: 0
   raven: 0
   readonly_field_widget: 0
+  real_aes: 0
   redirect: 0
   responsive_image: 0
   role_delegation: 0
@@ -162,6 +166,7 @@ module:
   taxonomy: 0
   telephone: 0
   text: 0
+  tfa: 0
   token: 0
   toolbar: 0
   translatable_menu_link_uri: 0

--- a/conf/cmi/encrypt.profile.real_aes.yml
+++ b/conf/cmi/encrypt.profile.real_aes.yml
@@ -1,0 +1,15 @@
+uuid: 90d7b880-aa02-4cff-aeb9-69e03db7a21b
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.tfa
+  module:
+    - real_aes
+_core:
+  default_config_hash: lDV_LbRGbNBnnVa6X72NK7xH7A1T9tasNNgP2hOhHKs
+id: real_aes
+label: 'Real AES'
+encryption_method: real_aes
+encryption_key: tfa
+encryption_method_configuration: {  }

--- a/conf/cmi/encrypt.settings.yml
+++ b/conf/cmi/encrypt.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: CMyccvAuba2yH-HYmcEL0pq1Seyxzq9VHhKbQKwAWY4
+check_profile_status: true
+allow_deprecated_plugins: false

--- a/conf/cmi/key.key.tfa.yml
+++ b/conf/cmi/key.key.tfa.yml
@@ -1,0 +1,19 @@
+uuid: 05f354f6-4d19-4cb0-9d95-0d16a1573e58
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: ARfRhKTJUSFXqKkDFwUncBUg8-5v7z_we3DETbYMYB0
+id: tfa
+label: TFA
+description: ''
+key_type: encryption
+key_type_settings:
+  key_size: 256
+key_provider: config
+key_provider_settings:
+  key_value: thisvaluewillbeoverridden1234567
+  base64_encoded: true
+key_input: text_field
+key_input_settings:
+  base64_encoded: false

--- a/conf/cmi/tfa.settings.yml
+++ b/conf/cmi/tfa.settings.yml
@@ -1,0 +1,50 @@
+_core:
+  default_config_hash: JyIkFj38h-aTLsrCfejAfP277qBJ61tlaLEBH44IHhg
+langcode: en
+enabled: true
+required_roles:
+  content_producer: content_producer
+  editor: editor
+  admin: admin
+  api_user: api_user
+  elevated_api_user: elevated_api_user
+  super_administrator: super_administrator
+  survey_editor: survey_editor
+send_plugins: {  }
+login_plugins: {  }
+login_plugin_settings:
+  tfa_trusted_browser:
+    cookie_allow_subdomains: true
+    cookie_expiration: 30
+    cookie_name: tfa-trusted-browser
+allowed_validation_plugins:
+  tfa_totp: tfa_totp
+default_validation_plugin: tfa_totp
+validation_plugin_settings:
+  tfa_recovery_code:
+    recovery_codes_amount: 10
+  tfa_hotp:
+    counter_window: 10
+    site_name_prefix: 1
+    name_prefix: TFA
+    issuer: Drupal
+  tfa_totp:
+    time_skew: 2
+    site_name_prefix: 1
+    name_prefix: TFA
+    issuer: Hel.fi
+validation_skip: 3
+users_without_tfa_redirect: false
+reset_pass_skip_enabled: true
+encryption: real_aes
+tfa_flood_uid_only: 1
+tfa_flood_window: 300
+tfa_flood_threshold: 6
+help_text: 'Contact support to reset your access'
+mail:
+  tfa_enabled_configuration:
+    subject: 'Your [site:name] account now has two-factor authentication'
+    body: "[user:display-name],\r\n\r\nThanks for configuring two-factor authentication on your [site:name] account!\r\n\r\nThis additional level of security will help to ensure that only you are able to log in to your account.\r\n\r\nIf you ever lose the device you configured, you should act quickly to delete its association with this account.\r\n\r\n--\r\n[site:name] team"
+  tfa_disabled_configuration:
+    subject: 'Your [site:name] account no longer has two-factor authentication'
+    body: "[user:display-name],\r\n\r\nTwo-factor authentication has been disabled on your [site:name] account.\r\n\r\nIf you did not take this action, please contact a site administrator immediately.\r\n\r\n--\r\n[site:name] team"

--- a/conf/cmi/tfa.settings.yml
+++ b/conf/cmi/tfa.settings.yml
@@ -6,10 +6,12 @@ required_roles:
   content_producer: content_producer
   editor: editor
   admin: admin
-  api_user: api_user
-  elevated_api_user: elevated_api_user
   super_administrator: super_administrator
   survey_editor: survey_editor
+  authenticated: '0'
+  read_only: '0'
+  api_user: '0'
+  elevated_api_user: '0'
 send_plugins: {  }
 login_plugins: {  }
 login_plugin_settings:

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.meeting_browser
+    - entity_browser.browser.paragraphs_library_items
     - filter.format.decision_html
     - filter.format.full_html
     - filter.format.minimal
@@ -60,6 +62,7 @@ dependencies:
     - simple_sitemap
     - system
     - taxonomy
+    - tfa
     - toolbar
     - view_unpublished
     - views_bulk_edit
@@ -182,6 +185,7 @@ permissions:
   - 'delete terms in pdf_categories'
   - 'delete terms in pdf_minutes_category'
   - 'delete trustee revisions'
+  - 'disable own tfa'
   - 'edit any announcement content'
   - 'edit any article content'
   - 'edit any case content'
@@ -247,6 +251,7 @@ permissions:
   - 'set page published on date'
   - 'set policymaker published on date'
   - 'set trustee published on date'
+  - 'setup own tfa'
   - 'translate announcement node'
   - 'translate any entity'
   - 'translate article node'

--- a/conf/cmi/user.role.api_user.yml
+++ b/conf/cmi/user.role.api_user.yml
@@ -3,17 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
-    - file
     - key_auth
     - paatokset_ahjo_proxy
-    - tfa
 id: api_user
 label: 'API user'
 weight: 6
 is_admin: null
 permissions:
   - 'access ahjo proxy'
-  - 'delete own files'
-  - 'disable own tfa'
-  - 'setup own tfa'
   - 'use key authentication'

--- a/conf/cmi/user.role.api_user.yml
+++ b/conf/cmi/user.role.api_user.yml
@@ -6,6 +6,7 @@ dependencies:
     - file
     - key_auth
     - paatokset_ahjo_proxy
+    - tfa
 id: api_user
 label: 'API user'
 weight: 6
@@ -13,4 +14,6 @@ is_admin: null
 permissions:
   - 'access ahjo proxy'
   - 'delete own files'
+  - 'disable own tfa'
+  - 'setup own tfa'
   - 'use key authentication'

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -5,13 +5,11 @@ dependencies:
   module:
     - eu_cookie_compliance
     - external_entities
-    - file
     - helfi_api_base
     - helfi_tpr
     - media
     - paragraphs
     - system
-    - tfa
     - toolbar
 _core:
   default_config_hash: 83Nuup-6oYkkdAsvg3nrR2pBOgtTXEV1JrzpCCLkYLM
@@ -22,10 +20,7 @@ is_admin: false
 permissions:
   - 'access content'
   - 'access toolbar'
-  - 'delete own files'
-  - 'disable own tfa'
   - 'display eu cookie compliance popup'
-  - 'setup own tfa'
   - 'view helfi_announcements external entity'
   - 'view helfi_news external entity'
   - 'view helfi_news_groups external entity'

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -11,6 +11,7 @@ dependencies:
     - media
     - paragraphs
     - system
+    - tfa
     - toolbar
 _core:
   default_config_hash: 83Nuup-6oYkkdAsvg3nrR2pBOgtTXEV1JrzpCCLkYLM
@@ -22,7 +23,9 @@ permissions:
   - 'access content'
   - 'access toolbar'
   - 'delete own files'
+  - 'disable own tfa'
   - 'display eu cookie compliance popup'
+  - 'setup own tfa'
   - 'view helfi_announcements external entity'
   - 'view helfi_news external entity'
   - 'view helfi_news_groups external entity'

--- a/conf/cmi/user.role.content_producer.yml
+++ b/conf/cmi/user.role.content_producer.yml
@@ -41,6 +41,7 @@ dependencies:
     - scheduler
     - system
     - taxonomy
+    - tfa
     - toolbar
     - view_unpublished
 _core:
@@ -97,6 +98,7 @@ permissions:
   - 'delete own page content'
   - 'delete own policymaker_images media'
   - 'delete own remote_video media'
+  - 'disable own tfa'
   - 'edit any announcement content'
   - 'edit any declaration_of_affiliation media'
   - 'edit any file media'
@@ -138,6 +140,7 @@ permissions:
   - 'set announcement published on date'
   - 'set landing_page published on date'
   - 'set page published on date'
+  - 'setup own tfa'
   - 'translate editable entities'
   - 'translate file media'
   - 'translate image media'

--- a/conf/cmi/user.role.editor.yml
+++ b/conf/cmi/user.role.editor.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.meeting_browser
+    - entity_browser.browser.paragraphs_library_items
     - filter.format.full_html
     - filter.format.minimal
     - media.type.ahjo_document
@@ -47,6 +49,7 @@ dependencies:
     - scheduler
     - system
     - taxonomy
+    - tfa
     - toolbar
     - view_unpublished
 id: editor
@@ -134,6 +137,7 @@ permissions:
   - 'delete terms in keywords'
   - 'delete terms in pdf_categories'
   - 'delete terms in pdf_minutes_category'
+  - 'disable own tfa'
   - 'edit any announcement content'
   - 'edit any article content'
   - 'edit any declaration_of_affiliation media'
@@ -186,6 +190,7 @@ permissions:
   - 'set meeting published on date'
   - 'set news_item published on date'
   - 'set page published on date'
+  - 'setup own tfa'
   - 'translate announcement node'
   - 'translate any entity'
   - 'translate article node'

--- a/conf/cmi/user.role.elevated_api_user.yml
+++ b/conf/cmi/user.role.elevated_api_user.yml
@@ -7,6 +7,7 @@ dependencies:
     - key_auth
     - paatokset_ahjo_openid
     - paatokset_ahjo_proxy
+    - tfa
 id: elevated_api_user
 label: 'Elevated API user'
 weight: 7
@@ -16,4 +17,6 @@ permissions:
   - 'access ahjo openid token'
   - 'access ahjo proxy'
   - 'delete own files'
+  - 'disable own tfa'
+  - 'setup own tfa'
   - 'use key authentication'

--- a/conf/cmi/user.role.elevated_api_user.yml
+++ b/conf/cmi/user.role.elevated_api_user.yml
@@ -3,11 +3,9 @@ langcode: en
 status: true
 dependencies:
   module:
-    - file
     - key_auth
     - paatokset_ahjo_openid
     - paatokset_ahjo_proxy
-    - tfa
 id: elevated_api_user
 label: 'Elevated API user'
 weight: 7
@@ -16,7 +14,4 @@ permissions:
   - 'access ahjo documents'
   - 'access ahjo openid token'
   - 'access ahjo proxy'
-  - 'delete own files'
-  - 'disable own tfa'
-  - 'setup own tfa'
   - 'use key authentication'

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -18,6 +18,7 @@ dependencies:
     - helfi_tpr
     - node
     - paragraphs
+    - tfa
     - toolbar
     - view_unpublished
 id: read_only
@@ -27,6 +28,8 @@ is_admin: null
 permissions:
   - 'access toolbar'
   - 'delete own files'
+  - 'disable own tfa'
+  - 'setup own tfa'
   - 'view any unpublished announcement content'
   - 'view any unpublished article content'
   - 'view any unpublished case content'

--- a/conf/cmi/user.role.read_only.yml
+++ b/conf/cmi/user.role.read_only.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.policymaker
     - node.type.trustee
   module:
-    - file
     - helfi_tpr
     - node
     - paragraphs
@@ -27,7 +26,6 @@ weight: 2
 is_admin: null
 permissions:
   - 'access toolbar'
-  - 'delete own files'
   - 'disable own tfa'
   - 'setup own tfa'
   - 'view any unpublished announcement content'

--- a/conf/cmi/user.role.survey_editor.yml
+++ b/conf/cmi/user.role.survey_editor.yml
@@ -8,6 +8,7 @@ dependencies:
     - content_translation
     - node
     - publication_date
+    - tfa
 _core:
   default_config_hash: CliaTgzCQcvNF9ot3u_EbHnydymXh8bvNgNFlSffj9s
 id: survey_editor
@@ -19,9 +20,11 @@ permissions:
   - 'delete any survey content'
   - 'delete own survey content'
   - 'delete survey revisions'
+  - 'disable own tfa'
   - 'edit any survey content'
   - 'edit own survey content'
   - 'revert survey revisions'
   - 'set survey published on date'
+  - 'setup own tfa'
   - 'translate survey node'
   - 'view survey revisions'


### PR DESCRIPTION
# [UHF-10520](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10520)

## What was done
This PR enables the helfi_tfa module and handles custom role configuration.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10520-enable-tfa`
  * Set up the TFA key locally, [instructions here](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/blob/main/modules/helfi_tfa/README.md). Get the TFA encryption key here: https://portal.azure.com/#@helsinginkaupunki.onmicrosoft.com/asset/Microsoft_Azure_KeyVault/Secret/https://hki-fqcslhrd-dev-kv.vault.azure.net/secrets/TFA-ENCRYPTION-KEY
  * If you don't have the production or test DB locally, you can follow [these instructions to set up the local environment.](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/PP/pages/6151897290/Lokaali+kehitysymp+rist#Kehitysymp%C3%A4rist%C3%B6n-pystytt%C3%A4minen%3A) You don't need any AHJO integration content to test this.
  * `drush updb -y;drush cim -y;`
* Run `make drush-cr`

## How to test
* [x] Login with `make drush-uli`. You shouldn't get a TFA warning for the UID1 user.
  * [ ] Edit the UID1 account to make sure it has the super administrator role: https://helsinki-paatokset.docker.so/fi/user/1/edit
* Create three new users, one with a content producer role, one with an API user role and one with an Elevated API user role.
  * Generate an API Key for each
* [x] Login with the content producer account and setup the TFA application. This process should work without any errors.
* [x] Login with the API user and the Elevated API user. You should not get the warning about TFA being mandatory. (Normally API users will not login directly, this is just to check that the config works).
* Open this URL in a private browsing window: https://helsinki-paatokset.docker.so/fi/ahjo-proxy/aggregated/a
  * [ ] Without an API key in the URL, you should get a 403 error.
  * [ ] Add the content producer API Key to the URL: `?api-key=[...]`. This should also result in a 403 error
  * [ ] Add the API user's key to the URL. This should result in an empty JSON response with 200 OK.
  * [ ] Add the Elevated API user's key to the URL. This should result in an empty JSON response with 200 OK.
  * [ ] Edit the API user account and deactivate it. Try the API key again, this time it should result in a 403 error. 
  * [ ] Do the same with the Elevated API user and test the API key, which should result in another 403 error.
* [x] Check that code follows our standards
* [ ] Check that the documentation makes sense: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/PP/pages/6189809682/K+ytt+j+roolit+oikeudet+ja+k+ytt+j+tilit#TFA%3A

## Continuous documentation
* [x] This feature has been documented/the documentation has been updated


[UHF-10520]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ