### PR TITLE
UHF-0000: Fix internal link settings

### DIFF
--- a/public/sites/default/production.services.yml
+++ b/public/sites/default/production.services.yml
@@ -2,8 +2,5 @@
 parameters:
   helfi_api_base.logger_enabled: false
   helfi_api_base.internal_domains:
-    - 'hel.fi'
-    - 'www.hel.fi'
     - 'paatokset.hel.fi'
-    - 'avustukset.hel.fi'
     - 'nginx-paatokset-prod.apps.platta.hel.fi'

--- a/public/sites/default/services.yml
+++ b/public/sites/default/services.yml
@@ -2,9 +2,6 @@
 parameters:
   helfi_api_base.logger_enabled: false
   helfi_api_base.internal_domains:
-    - 'hel.fi'
-    - 'www.hel.fi'
     - 'paatokset.hel.fi'
-    - 'avustukset.hel.fi'
     - 'nginx-paatokset-prod.apps.platta.hel.fi'
     - 'helsinki-paatokset.docker.so'

--- a/public/sites/default/staging.services.yml
+++ b/public/sites/default/staging.services.yml
@@ -2,8 +2,5 @@
 parameters:
   helfi_api_base.logger_enabled: false
   helfi_api_base.internal_domains:
-    - 'hel.fi'
-    - 'www.hel.fi'
     - 'paatokset.hel.fi'
-    - 'avustukset.hel.fi'
     - 'nginx-paatokset-staging.apps.platta.hel.fi'

--- a/public/sites/default/test.services.yml
+++ b/public/sites/default/test.services.yml
@@ -2,8 +2,5 @@
 parameters:
   helfi_api_base.logger_enabled: false
   helfi_api_base.internal_domains:
-    - 'hel.fi'
-    - 'www.hel.fi'
     - 'paatokset.hel.fi'
-    - 'avustukset.hel.fi'
     - 'nginx-paatokset-test.agw.arodevtest.hel.fi'


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)

## What was done

Fix internal link settings so hel.fi and avustukset.hel.fi show up as external links.

## Replicate issue before checking out branch
* Create a new landing page or page
  * Add a link list component with https://hel.fi, https://www.hel.fi, https://avustukset.hel.fi
  * Add a text component with the same links
* These should appear WITHOUT the external link arrow

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-x-change-external-link-settings`
  * `make drush-cr`

## How to test
* [x] Reload the page after the cache clear. The external link icons should appear now.
* [x] Check that code follows our standards