### PR TITLE
UHF-11094: remove sector field from index

### DIFF
--- a/conf/cmi/search_api.index.decisions.yml
+++ b/conf/cmi/search_api.index.decisions.yml
@@ -165,11 +165,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_organization_type
-  sector:
-    label: Sector
-    datasource_id: 'entity:node'
-    property_path: sector
-    type: string
   sector_id:
     label: 'Sector ID'
     datasource_id: 'entity:node'

--- a/conf/cmi/search_api.index.policymakers.yml
+++ b/conf/cmi/search_api.index.policymakers.yml
@@ -112,11 +112,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_dm_organization
-  sector:
-    label: Sector
-    datasource_id: 'entity:node'
-    property_path: sector
-    type: string
   status:
     label: status
     datasource_id: 'entity:node'


### PR DESCRIPTION
# [UHF-11094](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11094)

## What was done

Sector fields were added in 6938476a82f46ce6e28648b3d2bd9180bd6fc7b0 along with with `Drupal\paatokset_search\Plugin\search_api\processor\SectorJSON` processor.

This processor was removed in 2f59d7af644ac507a9b8d43eefd4e56c505a2e79, but its config was left in place. This should fix: https://sentry.hel.fi/organizations/city-of-helsinki/issues/39131/

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11094-remove-sector`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Check that search app works after reindexing.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/helsinki-paatokset/pull/507


[UHF-11094]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ