### PR TITLE
UHF-X: import old documents

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
       - install
       - theme
   paths:
+    - ./public/modules/custom/paatokset_submenus
     - ./public/modules/custom/paatokset_ahjo_openid
     - ./public/modules/custom/paatokset_ahjo_api/src/Plugin/QueueWorker
     - ./public/modules/custom/paatokset_ahjo_api/src/Plugin/Deriver

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -112,7 +112,7 @@ class PolicymakerService {
    *   Language manager service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Entity type manager.
-   * @param Drupal\Core\Config\ConfigFactoryInterface $config
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
    *   Config service.
    * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
    *   Route match service.
@@ -199,7 +199,7 @@ class PolicymakerService {
    * @param string|null $langcode
    *   Translation to get. Leave null to return active translation.
    *
-   * @return Drupal\node\NodeInterface|null
+   * @return \Drupal\node\NodeInterface|null
    *   Policymaker node or NULL.
    */
   public function getPolicyMaker(?string $id = NULL, ?string $langcode = NULL): ?Node {
@@ -244,7 +244,7 @@ class PolicymakerService {
   /**
    * Set policy maker node.
    *
-   * @param Drupal\node\NodeInterface $node
+   * @param \Drupal\node\NodeInterface $node
    *   Policy maker ID.
    */
   public function setPolicyMakerNode(NodeInterface $node): void {
@@ -266,7 +266,7 @@ class PolicymakerService {
    * Set policymaker from current path.
    *
    * @return bool
-   *   TRUE if setting pm was succesful.
+   *   TRUE if setting pm was successful.
    */
   public function setPolicyMakerByPath(): bool {
     $node = $this->routeMatch->getParameter('node');

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -43,7 +43,7 @@ class PolicymakerService {
   /**
    * Cut off date for old meetings.
    */
-  const MEETING_START_DATE = '2018-04-01';
+  const MEETING_START_DATE = '2017-01-01';
 
   /**
    * Policymaker roles for trustees (not decisionmaker organizations).

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/AgendasSubmenuBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/AgendasSubmenuBlock.php
@@ -1,32 +1,35 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\paatokset_submenus\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\node\NodeInterface;
 use Drupal\paatokset_policymakers\Service\PolicymakerService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides Agendas Submenu Block.
- *
- * @Block(
- *    id = "agendas_submenu",
- *    admin_label = @Translation("Agendas Submenu"),
- *    category = @Translation("Paatokset custom blocks")
- * )
  */
+#[Block(
+  id: 'agendas_submenu',
+  admin_label: new TranslatableMarkup('Agendas Submenu'),
+  category: new TranslatableMarkup('Paatokset custom blocks')
+)]
 class AgendasSubmenuBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
    * {@inheritDoc}
    */
-  public function __construct(
+  final public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private PolicymakerService $policymakerService,
+    private readonly PolicymakerService $policymakerService,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->policymakerService->setPolicyMakerByPath();
@@ -47,7 +50,7 @@ class AgendasSubmenuBlock extends BlockBase implements ContainerFactoryPluginInt
   /**
    * Build the attributes.
    */
-  public function build() {
+  public function build(): array {
     $list = $this->policymakerService->getAgendasListFromElasticSearch(NULL, TRUE);
     $years = array_keys($list);
 
@@ -61,7 +64,7 @@ class AgendasSubmenuBlock extends BlockBase implements ContainerFactoryPluginInt
   /**
    * Get cache tags.
    */
-  public function getCacheTags() {
+  public function getCacheTags(): array {
     $policymaker = $this->policymakerService->getPolicyMaker();
     if ($policymaker instanceof NodeInterface && $policymaker->hasField('field_policymaker_id')) {
       $policymaker_id = $policymaker->get('field_policymaker_id')->value;
@@ -73,7 +76,7 @@ class AgendasSubmenuBlock extends BlockBase implements ContainerFactoryPluginInt
   /**
    * Get cache contexts.
    */
-  public function getCacheContexts() {
+  public function getCacheContexts(): array {
     return ['url.path', 'url.query_args'];
   }
 

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/DocumentsBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/DocumentsBlock.php
@@ -1,32 +1,35 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\paatokset_submenus\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\node\NodeInterface;
 use Drupal\paatokset_policymakers\Service\PolicymakerService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides Agendas Submenu Documents Block.
- *
- * @Block(
- *    id = "agendas_submenu_documents",
- *    admin_label = @Translation("Paatokset policymaker documents"),
- *    category = @Translation("Paatokset custom blocks")
- * )
  */
+#[Block(
+  id: 'agendas_submenu_documents',
+  admin_label: new TranslatableMarkup('Paatokset policymaker documents'),
+  category: new TranslatableMarkup('Paatokset custom blocks')
+)]
 class DocumentsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
    * {@inheritDoc}
    */
-  public function __construct(
+  final public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private PolicymakerService $policymakerService,
+    private readonly PolicymakerService $policymakerService,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->policymakerService->setPolicyMakerByPath();
@@ -45,9 +48,9 @@ class DocumentsBlock extends BlockBase implements ContainerFactoryPluginInterfac
   }
 
   /**
-   * Build the attributes.
+   * {@inheritDoc}
    */
-  public function build() {
+  public function build(): array {
     $list = $this->policymakerService->getApiMinutesFromElasticSearch(NULL, TRUE);
 
     return [
@@ -58,9 +61,9 @@ class DocumentsBlock extends BlockBase implements ContainerFactoryPluginInterfac
   }
 
   /**
-   * Get cache tags.
+   * {@inheritDoc}
    */
-  public function getCacheTags() {
+  public function getCacheTags(): array {
     $policymaker = $this->policymakerService->getPolicyMaker();
     if ($policymaker instanceof NodeInterface && $policymaker->hasField('field_policymaker_id')) {
       $policymaker_id = $policymaker->get('field_policymaker_id')->value;
@@ -70,9 +73,9 @@ class DocumentsBlock extends BlockBase implements ContainerFactoryPluginInterfac
   }
 
   /**
-   * Get cache contexts.
+   * {@inheritDoc}
    */
-  public function getCacheContexts() {
+  public function getCacheContexts(): array {
     return ['url.path', 'url.query_args'];
   }
 

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/MinutesOfDiscussionBlock.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/MinutesOfDiscussionBlock.php
@@ -1,31 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\paatokset_submenus\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\paatokset_policymakers\Service\PolicymakerService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides Agendas Submenu Documents Block.
- *
- * @Block(
- *    id = "paatokset_minutes_of_discussion",
- *    admin_label = @Translation("Paatokset minutes of discussion block"),
- *    category = @Translation("Paatokset custom blocks")
- * )
  */
+#[Block(
+  id: 'paatokset_minutes_of_discussion',
+  admin_label: new TranslatableMarkup('Paatokset minutes of discussion block'),
+  category: new TranslatableMarkup('Paatokset custom blocks')
+)]
 class MinutesOfDiscussionBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
    * {@inheritDoc}
    */
-  public function __construct(
+  final public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private PolicymakerService $policymakerService,
+    private readonly PolicymakerService $policymakerService,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->policymakerService->setPolicyMakerByPath();
@@ -44,9 +47,9 @@ class MinutesOfDiscussionBlock extends BlockBase implements ContainerFactoryPlug
   }
 
   /**
-   * Build the attributes.
+   * {@inheritDoc}
    */
-  public function build() {
+  public function build(): array {
     $minutes = $this->policymakerService->getMinutesOfDiscussion(NULL, TRUE);
 
     return [
@@ -56,9 +59,9 @@ class MinutesOfDiscussionBlock extends BlockBase implements ContainerFactoryPlug
   }
 
   /**
-   * Get cache tags.
+   * {@inheritDoc}
    */
-  public function getCacheTags() {
+  public function getCacheTags(): array {
     return [
       'media_list:minutes_of_the_discussion',
       'node_list:meeting',
@@ -66,9 +69,9 @@ class MinutesOfDiscussionBlock extends BlockBase implements ContainerFactoryPlug
   }
 
   /**
-   * Get cache contexts.
+   * {@inheritDoc}
    */
-  public function getCacheContexts() {
+  public function getCacheContexts(): array {
     return ['url.path', 'url.query_args'];
   }
 

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerMobileNav.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerMobileNav.php
@@ -1,24 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\paatokset_submenus\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 
 /**
  * Provides Agendas Submenu Block.
- *
- * @Block(
- *    id = "policymaker_side_nav_mobile",
- *    admin_label = @Translation("Policymaker mobile navigation"),
- *    category = @Translation("Paatokset custom blocks")
- * )
  */
+#[Block(
+  id: 'policymaker_side_nav_mobile',
+  admin_label: new TranslatableMarkup('Policymaker mobile navigation'),
+  category: new TranslatableMarkup('Paatokset custom blocks')
+)]
 class PolicymakerMobileNav extends PolicymakerSideNav {
 
   /**
    * {@inheritdoc}
    */
-  public function build() {
+  public function build(): array {
     $options = $this->itemsToOptions();
 
     return [
@@ -33,12 +36,12 @@ class PolicymakerMobileNav extends PolicymakerSideNav {
    * @return array
    *   Array of options + current option
    */
-  private function itemsToOptions() {
+  private function itemsToOptions(): array {
     if (!is_array($this->items)) {
       return [];
     }
 
-    $currentPath = $currentPath = Url::fromRoute('<current>')->toString();
+    $currentPath = Url::fromRoute('<current>')->toString();
     $currentOption = NULL;
     $options = [];
     foreach ($this->items as $option) {

--- a/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
+++ b/public/modules/custom/paatokset_submenus/src/Plugin/Block/PolicymakerSideNav.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\paatokset_submenus\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteProviderInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
@@ -16,13 +21,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides Agendas Submenu Block.
- *
- * @Block(
- *    id = "policymaker_side_nav",
- *    admin_label = @Translation("Policymaker side navigation"),
- *    category = @Translation("Paatokset custom blocks")
- * )
  */
+#[Block(
+  id: 'policymaker_side_nav',
+  admin_label: new TranslatableMarkup('Policymaker side navigation'),
+  category: new TranslatableMarkup('Paatokset custom blocks')
+)]
 class PolicymakerSideNav extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
@@ -35,15 +39,15 @@ class PolicymakerSideNav extends BlockBase implements ContainerFactoryPluginInte
   /**
    * {@inheritDoc}
    */
-  public function __construct(
+  final public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private MenuLinkTreeInterface $menuTree,
-    private RouteProviderInterface $routeProvider,
-    private PolicymakerService $policymakerService,
-    private string $currentLang,
-    private string $currentPath,
+    private readonly MenuLinkTreeInterface $menuTree,
+    private readonly RouteProviderInterface $routeProvider,
+    private readonly PolicymakerService $policymakerService,
+    private readonly string $currentLang,
+    private readonly string $currentPath,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->policymakerService->setPolicyMakerByPath();
@@ -69,7 +73,7 @@ class PolicymakerSideNav extends BlockBase implements ContainerFactoryPluginInte
   /**
    * {@inheritDoc}
    */
-  public function build() {
+  public function build(): array {
     return [
       '#items' => $this->items,
       '#currentPath' => $this->currentPath,
@@ -79,7 +83,7 @@ class PolicymakerSideNav extends BlockBase implements ContainerFactoryPluginInte
   /**
    * {@inheritDoc}
    */
-  public function getCacheTags() {
+  public function getCacheTags(): array {
     $cache_tags = [
       'config:system.menu.main',
     ];
@@ -96,7 +100,7 @@ class PolicymakerSideNav extends BlockBase implements ContainerFactoryPluginInte
   /**
    * {@inheritDoc}
    */
-  public function getCacheContexts() {
+  public function getCacheContexts(): array {
     return ['url.path', 'url.query_args'];
   }
 
@@ -282,8 +286,9 @@ class PolicymakerSideNav extends BlockBase implements ContainerFactoryPluginInte
    */
   protected function getCustomLinks(NodeInterface $policymaker): array {
     $items = [];
-    $customLinks = $policymaker->field_custom_menu_links->referencedEntities();
+    $customLinks = $policymaker->get('field_custom_menu_links')->referencedEntities();
     foreach ($customLinks as $link) {
+      assert($link instanceof FieldableEntityInterface);
       if (empty($link->field_referenced_content->entity)) {
         continue;
       }


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Shown documents are capped at >= 1.8.2018. This PR allows showing documents from 1.1.2017.  

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-import-old-decisions`
  * `make fresh` with production database
  * `drush sapi-i meetings`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus/asiakirjat shows older documents.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation
