### PR TITLE
UHF-8851: Update paatokset_search react app to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drush/drush": "^12",
         "josdejong/jsoneditor": "^5.29",
         "league/csv": "^9.8",
-        "paatokset/paatokset_search": "^1.3.2"
+        "paatokset/paatokset_search": "^1.3.3"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
@@ -144,9 +144,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "1.3.2",
+                "version": "1.3.3",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.2/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.3/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57a37c90595a397db423b61aa06aff84",
+    "content-hash": "b31df38bce668bed471c758584972d92",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9963,10 +9963,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.2/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.3/paatokset_search.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
# [UHF-8851](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8851)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Update paatokset_search react app to latest version

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8851`
  * `composer update paatokset/paatokset_search`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the policymakers and decisions searches have now the features changes added here: https://github.com/City-of-Helsinki/paatokset-search/pull/47
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

[UHF-8851]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ