### PR TITLE
UHF-11285: Fix helsinki kanava

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
     - ./public/modules/custom/paatokset_ahjo_api/src/Plugin/Deriver
     - ./public/modules/custom/paatokset_ahjo_api/src/AhjoQueueWorkerBase.php
     - ./public/modules/custom/paatokset_datapumppu
+    - ./public/modules/custom/paatokset_helsinki_kanava
     # TODO: Enable for all files.
     #- ./public/modules/custom
     #- ./public/themes/custom

--- a/public/modules/custom/paatokset_helsinki_kanava/config/schema/paatokset_helsinki_kanava.schema.yml
+++ b/public/modules/custom/paatokset_helsinki_kanava/config/schema/paatokset_helsinki_kanava.schema.yml
@@ -1,0 +1,9 @@
+paatokset_helsinki_kanava.settings:
+  type: config_object
+  mapping:
+    debug_mode:
+      type: boolean
+    city_council_id:
+      type: string
+    all_recordings_link:
+      type: string

--- a/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.install
+++ b/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.install
@@ -13,7 +13,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 /**
  * Add start_time field to meeting videos.
  */
-function paatokset_helsinki_kanava_update_9001() {
+function paatokset_helsinki_kanava_update_9001(): void {
   $entity_type_id = 'meeting_video';
   $field_storage_definition = BaseFieldDefinition::create('string')
     ->setLabel(new TranslatableMarkup('start_time'))
@@ -30,7 +30,7 @@ function paatokset_helsinki_kanava_update_9001() {
 /**
  * Add asset ID field for meeting videos.
  */
-function paatokset_helsinki_kanava_update_9002() {
+function paatokset_helsinki_kanava_update_9002(): void {
   $entity_type_id = 'meeting_video';
   $field_storage_definition = BaseFieldDefinition::create('string')
     ->setLabel(new TranslatableMarkup('asset_id'))

--- a/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.install
+++ b/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.install
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Install hooks for Helsinki Kanava integration.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Add start_time field to meeting videos.
+ */
+function paatokset_helsinki_kanava_update_9001() {
+  $entity_type_id = 'meeting_video';
+  $field_storage_definition = BaseFieldDefinition::create('string')
+    ->setLabel(new TranslatableMarkup('start_time'))
+    ->setTranslatable(TRUE)
+    ->setRevisionable(TRUE)
+    ->setDefaultValue('')
+    ->setCardinality(1)
+    ->setDisplayConfigurable('view', TRUE)
+    ->setDisplayConfigurable('form', TRUE);
+
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('start_time', $entity_type_id, $entity_type_id, $field_storage_definition);
+}
+
+/**
+ * Add asset ID field for meeting videos.
+ */
+function paatokset_helsinki_kanava_update_9002() {
+  $entity_type_id = 'meeting_video';
+  $field_storage_definition = BaseFieldDefinition::create('string')
+    ->setLabel(new TranslatableMarkup('asset_id'))
+    ->setTranslatable(TRUE)
+    ->setRevisionable(TRUE)
+    ->setDefaultValue('')
+    ->setCardinality(1)
+    ->setDisplayConfigurable('view', TRUE)
+    ->setDisplayConfigurable('form', TRUE);
+
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('asset_id', $entity_type_id, $entity_type_id, $field_storage_definition);
+}

--- a/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
+++ b/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
@@ -65,7 +65,6 @@ function paatokset_helsinki_kanava_preprocess_node__policymaker(array &$variable
     ->accessCheck(TRUE)
     ->range(0, 10)
     ->condition('start_time', strtotime('now'), '<')
-    ->condition('asset_id', '', '<>')
     ->sort('start_time', 'DESC');
 
   $ids = $query->execute();
@@ -79,11 +78,7 @@ function paatokset_helsinki_kanava_preprocess_node__policymaker(array &$variable
     $view_builder = \Drupal::entityTypeManager()->getViewBuilder($video->getEntityTypeId());
 
     $variables['most_recent_meeting'] = $view_builder->view($video);
-    $variables['all_recordings_link'] = Url::fromUri(\Drupal::config('paatokset_helsinki_kanava.settings')->get('all_recordings_link'), [
-      'query' => [
-        'assetId' => $video->get('asset_id')->value,
-      ],
-    ])->toString();
+    $variables['all_recordings_link'] = Url::fromUri(\Drupal::config('paatokset_helsinki_kanava.settings')->get('all_recordings_link'))->toString();
   }
 
   $upcomingIds = \Drupal::entityQuery('meeting_video')

--- a/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
+++ b/public/modules/custom/paatokset_helsinki_kanava/paatokset_helsinki_kanava.module
@@ -7,9 +7,7 @@
 
 declare(strict_types=1);
 
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Render\Element;
-use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\paatokset_helsinki_kanava\Entity\MeetingVideo;
 
@@ -139,38 +137,4 @@ function _paatokset_helsinki_kanava_should_show_label(string $time): bool {
   // Convert start time to date only.
   $date = strtotime(date('j.n.Y', (int) $time));
   return strtotime('now') < $date;
-}
-
-/**
- * Add start_time field to meeting videos.
- */
-function paatokset_helsinki_kanava_update_9001() {
-  $entity_type_id = 'meeting_video';
-  $field_storage_definition = BaseFieldDefinition::create('string')
-    ->setLabel(new TranslatableMarkup('start_time'))
-    ->setTranslatable(TRUE)
-    ->setRevisionable(TRUE)
-    ->setDefaultValue('')
-    ->setCardinality(1)
-    ->setDisplayConfigurable('view', TRUE)
-    ->setDisplayConfigurable('form', TRUE);
-
-  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('start_time', $entity_type_id, $entity_type_id, $field_storage_definition);
-}
-
-/**
- * Add asset ID field for meeting videos.
- */
-function paatokset_helsinki_kanava_update_9002() {
-  $entity_type_id = 'meeting_video';
-  $field_storage_definition = BaseFieldDefinition::create('string')
-    ->setLabel(new TranslatableMarkup('asset_id'))
-    ->setTranslatable(TRUE)
-    ->setRevisionable(TRUE)
-    ->setDefaultValue('')
-    ->setCardinality(1)
-    ->setDisplayConfigurable('view', TRUE)
-    ->setDisplayConfigurable('form', TRUE);
-
-  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('asset_id', $entity_type_id, $entity_type_id, $field_storage_definition);
 }

--- a/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/Block/AnnouncementsBlock.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/Block/AnnouncementsBlock.php
@@ -2,13 +2,15 @@
 
 namespace Drupal\paatokset_helsinki_kanava\Plugin\Block;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\Core\Url;
 use Drupal\paatokset_ahjo_api\Service\MeetingService;
 use Drupal\paatokset_policymakers\Service\PolicymakerService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -24,15 +26,27 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
+   * Number of seconds before the meeting when alert becomes visible.
+   */
+  public const ALERT_OFFSET = 60 * 60 * 24;
+
+  /**
+   * Minimum time the block can cache. Set to 10 minutes.
+   */
+  public const MIN_CACHE_TTL = 60 * 10;
+
+  /**
    * {@inheritDoc}
    */
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private ConfigFactoryInterface $config,
-    private PolicymakerService $policymakerService,
-    private MeetingService $meetingService,
+    private readonly ConfigFactoryInterface $config,
+    private readonly PolicymakerService $policymakerService,
+    private readonly MeetingService $meetingService,
+    private readonly DateFormatterInterface $formatter,
+    private readonly TimeInterface $time,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -47,7 +61,9 @@ final class AnnouncementsBlock extends BlockBase implements ContainerFactoryPlug
       $plugin_definition,
       $container->get('config.factory'),
       $container->get('paatokset_policymakers'),
-      $container->get('paatokset_ahjo_meetings')
+      $container->get('paatokset_ahjo_meetings'),
+      $container->get(DateFormatterInterface::class),
+      $container->get(TimeInterface::class)
     );
   }
 
@@ -57,41 +73,48 @@ final class AnnouncementsBlock extends BlockBase implements ContainerFactoryPlug
   public function build(): array {
     $council_id = $this->config->get('paatokset_helsinki_kanava.settings')->get('city_council_id');
     $councilNode = $this->policymakerService->getPolicyMaker($council_id);
+    $ttl = Cache::PERMANENT;
 
+    // @todo This should be based on video entities like hook_preprocess_node__policymaker, UHF-9549.
     $announcement = [];
     if ($councilNode) {
-      $nextMeetingDate = $this->meetingService->nextMeetingDate($council_id);
+      $nextMeetingTimestamp = (int) $this->meetingService->nextMeetingDate($council_id);
+      $timeToNextMeeting = max($nextMeetingTimestamp - $this->time->getCurrentTime(), 0);
 
-      if ($nextMeetingDate && $this->shouldShowAlert($nextMeetingDate)) {
+      // Cache until the alert should be shown.
+      $ttl = max($timeToNextMeeting - self::ALERT_OFFSET, self::MIN_CACHE_TTL);
+
+      if ($nextMeetingTimestamp && $this->shouldShowAlert($nextMeetingTimestamp)) {
+        // If the alert is shown, cache until meeting starts.
+        $ttl = max($timeToNextMeeting, self::MIN_CACHE_TTL);
 
         $announcement['text'] = $this->t('Next council stream will start on @date at @time',
           [
-            '@date' => date('d.m', $nextMeetingDate),
-            '@time' => date('H:i', $nextMeetingDate),
+            '@date' => $this->formatter->format($nextMeetingTimestamp, 'custom', 'd.m', 'Europe/Helsinki'),
+            '@time' => $this->formatter->format($nextMeetingTimestamp, 'custom', 'H:i', 'Europe/Helsinki'),
           ]
         );
 
-        $url = $councilNode->toUrl();
+        $url = $councilNode->toUrl(options: [
+          'fragment' => 'policymaker-live-stream',
+        ]);
+
         if ($url) {
           $linkText = $this->t("You can see the stream on council's page, starting at @time", [
-            '@time' => date('H:i', $nextMeetingDate),
+            '@time' => $this->formatter->format($nextMeetingTimestamp, 'custom', 'H:i', 'Europe/Helsinki'),
           ]);
-          $announcement['link'] = Link::fromTextAndUrl($linkText, Url::fromUri('internal:' . $url->toString() . '#policymaker-live-stream'));
+          $announcement['link'] = Link::fromTextAndUrl($linkText, $url);
         }
       }
     }
 
     return [
-      '#cache' => ['contexts' => ['url.path']],
+      '#cache' => [
+        'max-age' => $ttl,
+        'contexts' => ['url.path'],
+      ],
       'announcement' => $announcement,
     ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCacheContexts(): array {
-    return ['url.path', 'url.query_args'];
   }
 
   /**
@@ -104,17 +127,17 @@ final class AnnouncementsBlock extends BlockBase implements ContainerFactoryPlug
   /**
    * Check if it is less than one day to the next meeting or test mode is on.
    *
-   * @param string $time
-   *   Time of next meeting.
+   * @param int $timestamp
+   *   Next meeting timestamp.
    *
    * @return bool
    *   If alert should be displayed.
    */
-  private function shouldShowAlert(string $time): bool {
+  private function shouldShowAlert(int $timestamp): bool {
     if ($this->config->get('paatokset_helsinki_kanava.settings')->get('debug_mode')) {
       return TRUE;
     }
-    return strtotime('+1 day') > (int) $time;
+    return $this->time->getCurrentTime() + self::ALERT_OFFSET > $timestamp;
   }
 
 }

--- a/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/Block/AnnouncementsBlock.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/Block/AnnouncementsBlock.php
@@ -2,10 +2,12 @@
 
 namespace Drupal\paatokset_helsinki_kanava\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\paatokset_ahjo_api\Service\MeetingService;
 use Drupal\paatokset_policymakers\Service\PolicymakerService;
@@ -13,14 +15,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides Agendas Submenu Block.
- *
- * @Block(
- *    id = "paatokset_helsinki_kanava_announcements",
- *    admin_label = @Translation("Helsinki Kanava announcements"),
- *    category = @Translation("Paatokset custom blocks")
- * )
  */
-class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInterface {
+#[Block(
+  id: "paatokset_helsinki_kanava_announcements",
+  admin_label: new TranslatableMarkup("Helsinki Kanava announcements"),
+  category: new TranslatableMarkup("Paatokset custom blocks")
+)]
+final class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
    * {@inheritDoc}
@@ -40,7 +41,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
-    return new static(
+    return new self(
       $configuration,
       $plugin_id,
       $plugin_definition,
@@ -53,7 +54,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   /**
    * {@inheritdoc}
    */
-  public function build() {
+  public function build(): array {
     $council_id = $this->config->get('paatokset_helsinki_kanava.settings')->get('city_council_id');
     $councilNode = $this->policymakerService->getPolicyMaker($council_id);
 
@@ -96,7 +97,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   /**
    * {@inheritdoc}
    */
-  public function getCacheTags() {
+  public function getCacheTags(): array {
     return ['meeting_video_list', 'node_list:meeting'];
   }
 

--- a/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/migrate/source/HelsinkiKanava.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/migrate/source/HelsinkiKanava.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  id = "helsinki_kanava"
  * )
  */
-class HelsinkiKanava extends SourcePluginBase implements ContainerFactoryPluginInterface {
+final class HelsinkiKanava extends SourcePluginBase implements ContainerFactoryPluginInterface {
   /**
    * The total count.
    *
@@ -32,6 +32,29 @@ class HelsinkiKanava extends SourcePluginBase implements ContainerFactoryPluginI
    * @var \GuzzleHttp\ClientInterface
    */
   protected ClientInterface $httpClient;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ?MigrationInterface $migration = NULL,
+  ) {
+    if ($url = self::getApiUrl($configuration['url'])) {
+      $configuration['url'] = $url;
+    }
+
+    $instance = new static($configuration, $plugin_id, $plugin_definition, $migration);
+    $instance->httpClient = $container->get('http_client');
+    if (!isset($configuration['ids'])) {
+      throw new \InvalidArgumentException('The "ids" configuration is missing.');
+    }
+
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
@@ -50,32 +73,34 @@ class HelsinkiKanava extends SourcePluginBase implements ContainerFactoryPluginI
   /**
    * {@inheritdoc}
    */
-  public function fields() {
+  public function fields(): array {
     return [];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function count($refresh = FALSE) {
+  public function count($refresh = FALSE): int {
     return -1;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function prepareRow(Row $row): void {
+  public function prepareRow(Row $row): bool {
     $recordings = $row->getSourceProperty('recordings');
 
     if (empty($recordings)) {
-      return;
+      return FALSE;
     }
     foreach ($recordings as $record) {
       if (isset($record['assetId'])) {
         $row->setSourceProperty('assetId', $record['assetId']);
-        return;
+        break;
       }
     }
+
+    return TRUE;
   }
 
   /**
@@ -104,29 +129,6 @@ class HelsinkiKanava extends SourcePluginBase implements ContainerFactoryPluginI
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public static function create(
-    ContainerInterface $container,
-    array $configuration,
-    $plugin_id,
-    $plugin_definition,
-    ?MigrationInterface $migration = NULL,
-  ) {
-    if ($url = self::getApiUrl($configuration['url'])) {
-      $configuration['url'] = $url;
-    }
-
-    $instance = new static($configuration, $plugin_id, $plugin_definition, $migration);
-    $instance->httpClient = $container->get('http_client');
-    if (!isset($configuration['ids'])) {
-      throw new \InvalidArgumentException('The "ids" configuration is missing.');
-    }
-
-    return $instance;
-  }
-
-  /**
    * Gets modified API Url with correct query parameters for fetching videos.
    *
    * @param string $base_url
@@ -138,10 +140,11 @@ class HelsinkiKanava extends SourcePluginBase implements ContainerFactoryPluginI
   protected static function getApiUrl(string $base_url): ?string {
     $council_id = \Drupal::config('paatokset_helsinki_kanava.settings')->get('city_council_id');
 
+    /** @var \Drupal\paatokset_ahjo_api\Service\MeetingService $meetingsService */
     $meetingsService = \Drupal::service('paatokset_ahjo_meetings');
     $fromTime = strtotime('-4 months') * 1000;
     $nextMeetingDate = $meetingsService->nextMeetingDate($council_id);
-    $toTime = $nextMeetingDate ? $nextMeetingDate * 1000 : round(microtime(TRUE) * 1000);
+    $toTime = $nextMeetingDate ? ((int) $nextMeetingDate) * 1000 : round(microtime(TRUE) * 1000);
 
     $version = '01';
     $languageId = 'fi_FI';

--- a/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/migrate/source/HelsinkiKanava.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/src/Plugin/migrate/source/HelsinkiKanava.php
@@ -6,7 +6,6 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
 use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
 use Drupal\migrate\Plugin\MigrationInterface;
-use Drupal\migrate\Row;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -82,25 +81,6 @@ final class HelsinkiKanava extends SourcePluginBase implements ContainerFactoryP
    */
   public function count($refresh = FALSE): int {
     return -1;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function prepareRow(Row $row): bool {
-    $recordings = $row->getSourceProperty('recordings');
-
-    if (empty($recordings)) {
-      return FALSE;
-    }
-    foreach ($recordings as $record) {
-      if (isset($record['assetId'])) {
-        $row->setSourceProperty('assetId', $record['assetId']);
-        break;
-      }
-    }
-
-    return TRUE;
   }
 
   /**

--- a/public/modules/custom/paatokset_helsinki_kanava/tests/src/Kernel/AnnouncementBlockTest.php
+++ b/public/modules/custom/paatokset_helsinki_kanava/tests/src/Kernel/AnnouncementBlockTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_helsinki_kanava\Kernel;
+
+use Drupal\block\Entity\Block;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Url;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\NodeInterface;
+use Drupal\paatokset_ahjo_api\Service\MeetingService;
+use Drupal\paatokset_helsinki_kanava\Plugin\Block\AnnouncementsBlock;
+use Drupal\paatokset_policymakers\Service\PolicymakerService;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\Loader\Configurator\Traits\PropertyTrait;
+
+/**
+ * Tests live stream announcement.
+ *
+ * @group paatokset_helsinki_kanava
+ */
+class AnnouncementBlockTest extends KernelTestBase {
+
+  use PropertyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'paatokset_helsinki_kanava',
+    'block',
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('block');
+    $this->installEntitySchema('meeting_video');
+  }
+
+  /**
+   * Tests that block max age works correctly.
+   */
+  public function testBlockMaxAge(): void {
+    $now = strtotime("1 January 2025");
+
+    $this
+      ->config('paatokset_helsinki_kanava.settings')
+      ->set('city_council_id', 'test_id')
+      ->save();
+
+    $policymakerNode = $this->prophesize(NodeInterface::class);
+    $policymakerNode->toUrl(Argument::any(), Argument::any())
+      ->willReturn(Url::fromUri('https://example.com'));
+
+    $policymakerService = $this->prophesize(PolicymakerService::class);
+    $policymakerService
+      ->getPolicyMaker('test_id')
+      ->willReturn($policymakerNode->reveal());
+
+    $meetingService = $this->prophesize(MeetingService::class);
+    $meetingService
+      ->nextMeetingDate('test_id')
+      // Note: meetings service returns timestamp in Europe/Helsinki timezone.
+      ->willReturn(
+        NULL,
+        // Next meeting started 30 seconds ago.
+        $now - 30,
+        // Next meeting starts in 30 seconds in the future.
+        $now + AnnouncementsBlock::MIN_CACHE_TTL + 30,
+        // Next meeting starts after _a long time_.
+        $now + 864000,
+      );
+
+    $time = $this->prophesize(TimeInterface::class);
+    $time->getCurrentTime()->willReturn($now);
+
+    $this->container->set('paatokset_policymakers', $policymakerService->reveal());
+    $this->container->set('paatokset_ahjo_meetings', $meetingService->reveal());
+    $this->container->set(TimeInterface::class, $time->reveal());
+
+    $block = Block::create([
+      'plugin' => 'paatokset_helsinki_kanava_announcements',
+      'region' => 'footer',
+      'id' => $this->randomMachineName(),
+    ]);
+
+    $plugin = $block->getPlugin();
+    $this->assertCacheMaxAge(AnnouncementsBlock::MIN_CACHE_TTL, $plugin->build());
+
+    // Live-stream is coming, cache until the live stream starts.
+    $this->assertCacheMaxAge(AnnouncementsBlock::MIN_CACHE_TTL, $plugin->build());
+    $this->assertCacheMaxAge(AnnouncementsBlock::MIN_CACHE_TTL + 30, $plugin->build());
+
+    // Alert is not shown yet.
+    $this->assertCacheMaxAge(864000 - AnnouncementsBlock::ALERT_OFFSET, $plugin->build());
+  }
+
+  /**
+   * Asserts render array max cache age.
+   */
+  private function assertCacheMaxAge(int $expectedMaxAge, array $build): void {
+    $this->assertEquals($expectedMaxAge, $build['#cache']['max-age']);
+  }
+
+}

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -16,7 +16,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\Core\Utility\Error;
 use Drupal\file\FileInterface;
-use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\paatokset_ahjo_api\Service\CaseService;
 use Drupal\paatokset_ahjo_api\Service\MeetingService;
@@ -202,7 +201,7 @@ class PolicymakerService {
    * @return \Drupal\node\NodeInterface|null
    *   Policymaker node or NULL.
    */
-  public function getPolicyMaker(?string $id = NULL, ?string $langcode = NULL): ?Node {
+  public function getPolicyMaker(?string $id = NULL, ?string $langcode = NULL): ?NodeInterface {
     if ($id === NULL) {
       return $this->policymaker;
     }


### PR DESCRIPTION
# [UHF-11285](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11285)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix helsinki kanava migration
* Enable phpstan for helsinki kanava module
* Fix caching for live stream announcements.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11285`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Run `drush migrate-import paatokset_meeting_videos --update --reset-threshold 1`.
* [x] Check that https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto has the latest video.
* [x] Check that "Kaikki videot" link under the video works.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR


[UHF-11285]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ