### PR TITLE
UHF-11429: Added alter hooks to use non-core navigation, branding and  top header

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -76,11 +76,11 @@ function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions, $variables) 
     $suggestions[] = 'block__views_block__news_latest_news';
   }
 
-  if($element['#plugin_id'] === 'system_branding_block') {
+  if ($element['#plugin_id'] === 'system_branding_block') {
     $suggestions[] = 'block__system_branding_block__non_core';
   }
 
-  if($element['#id'] === 'hdbt_subtheme_mainnavigation') {
+  if ($element['#id'] === 'hdbt_subtheme_mainnavigation') {
     $suggestions[] = 'block__mainnavigation__non_core';
   }
 }
@@ -147,7 +147,7 @@ function hdbt_subtheme_preprocess_region(&$variables) {
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function hdbt_subtheme_theme_suggestions_region_alter(array &$suggestions, array $variables) {
-  if($variables['elements']['#region'] === 'header_top') {
+  if ($variables['elements']['#region'] === 'header_top') {
     $suggestions[] = 'region__header_top__non_core';
   }
 }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -75,6 +75,14 @@ function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions, $variables) 
   ) {
     $suggestions[] = 'block__views_block__news_latest_news';
   }
+
+  if($element['#plugin_id'] === 'system_branding_block') {
+    $suggestions[] = 'block__system_branding_block__non_core';
+  }
+
+  if($element['#id'] === 'hdbt_subtheme_mainnavigation') {
+    $suggestions[] = 'block__mainnavigation__non_core';
+  }
 }
 
 /**
@@ -133,6 +141,15 @@ function hdbt_subtheme_preprocess_region(&$variables) {
   $user = User::load(\Drupal::currentUser()->id());
   $variables['username'] = $user->getAccountName();
   $variables['logged_in'] = \Drupal::currentUser()->isAuthenticated();
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function hdbt_subtheme_theme_suggestions_region_alter(array &$suggestions, array $variables) {
+  if($variables['elements']['#region'] === 'header_top') {
+    $suggestions[] = 'region__header_top__non_core';
+  }
 }
 
 /**


### PR DESCRIPTION
# [UHF-11429](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11429)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added alter hooks to use new non-core site branding, navigation etc

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11429`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11429`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to frontpage and make sure that:
    * [x] There is now external city of helsinki link in the top header left side
    * [x] Next to Helsinki logo is päätökset and the link goes to päätökset frontpage, the title should be visible in mobile view
    * [x] There isn't "Päätökset" text above main navigation any more
* [x] Check that code follows our standards

**Test also in a core site just to make sure no styles were broken there**

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1205


[UHF-11429]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ