### PR TITLE
Add --update flag to datapumppu migration

### DIFF
--- a/docker/openshift/crons/run-datapumppu-integrations.sh
+++ b/docker/openshift/crons/run-datapumppu-integrations.sh
@@ -7,7 +7,7 @@ while true
 do
   echo "Running Datapumppu migration: $(date)"
   # Interval 6 hours, reset threshold 10 minutes.
-  drush migrate:import datapumppu_statements --interval 21600 --reset-threshold 600 --no-progress
+  drush migrate:import datapumppu_statements --interval 21600 --reset-threshold 600 --no-progress --update
 
   # Sleep for 24 hours.
   sleep 86400


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

Sometimes, the API contains mistakes that are fixed by hand by datapumppu team. Without --update flag, changed results in api are not automatically synced to paatokset.hel.fi.

The migration only looks for statements made during the current year, so this should not update the whole database every time the migration is run.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards
