### PR TITLE
UHF-10949: Add custom logic to handle head links. Remove duplicate canonical URL

### DIFF
--- a/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerNodeViewController.php
+++ b/public/modules/custom/paatokset_policymakers/src/Controller/PolicymakerNodeViewController.php
@@ -72,6 +72,22 @@ class PolicymakerNodeViewController extends NodeViewController {
   }
 
   /**
+   * Apply custom logic for handling head links.
+   *
+   * @param array &$page
+   *   The page render array.
+   */
+  protected function handleHeadLinks(array &$page) {
+    // Remove canonical URL from the policymaker node that is being rendered to
+    // avoid duplicate canonical URLs.
+    array_walk($page['#attached']['html_head_link'], function ($item, $key) use (&$page) {
+      if ($item[0]['rel'] == 'canonical') {
+        unset($page['#attached']['html_head_link'][$key]);
+      }
+    });
+  }
+
+  /**
    * Return untranslated policymaker node on other languages.
    */
   public function policymaker(string $organization) {
@@ -83,7 +99,9 @@ class PolicymakerNodeViewController extends NodeViewController {
     }
 
     if ($node instanceof EntityInterface) {
-      return parent::view($node, 'full');
+      $page = parent::view($node, 'full');
+      $this->handleHeadLinks($page);
+      return $page;
     }
 
     throw new NotFoundHttpException();


### PR DESCRIPTION
# [UHF-10949](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10949)

## What was done

* Fix the double canonical link that appears in decisions page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10949-canonical-url`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Find and existing Policymaker node/entity
* [ ] Find its Open Ahjo ID
* [ ] Open the page through the policy maker page (with this format https://helsinki-paatokset.docker.so/fi/paattajat/<Open Ahjo ID>
* [ ] Inspect the head links, there should only be one canonical URL

## Continuous documentation

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation


[UHF-10949]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ