### PR TITLE
UHF-11527: Enabling search operators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "josdejong/jsoneditor": "^5.29",
         "laminas/laminas-feed": "^2.23",
         "league/csv": "^9.8",
-        "paatokset/paatokset_search": "^1.3.3",
+        "paatokset/paatokset_search": "^1.3.4",
         "symfony/property-access": "^7.2"
     },
     "require-dev": {
@@ -146,9 +146,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "1.3.3",
+                "version": "1.3.4",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.3/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.4/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43d33b783e85b670e142c6d33179feb1",
+    "content-hash": "152c156bafecb17d4fb692ab5743d583",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10380,10 +10380,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.3/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.4/paatokset_search.zip"
             },
             "type": "library"
         },

--- a/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
@@ -1,6 +1,6 @@
 paatokset-search:
   remote: https://github.com/City-of-Helsinki/paatokset-search
-  version: 1.3.2
+  version: 1.3.4
   license:
     name: MIT
     url: https://github.com/City-of-Helsinki/asuntomyynti-search/blob/develop/README.md

--- a/public/modules/custom/paatokset_search/paatokset_search.services.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.services.yml
@@ -1,4 +1,8 @@
 services:
+  _defaults:
+    autoconfigure: true
+    autowire: true
+
   Drupal\paatokset_search\EventSubscriber\PrepareIndex:
     tags:
       - { name: 'event_subscriber' }
@@ -6,3 +10,5 @@ services:
     arguments: ['@cache_tags.invalidator']
     tags:
       - { name: 'event_subscriber' }
+
+  Drupal\paatokset_search\SearchManager: ~

--- a/public/modules/custom/paatokset_search/src/Controller/SearchController.php
+++ b/public/modules/custom/paatokset_search/src/Controller/SearchController.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\paatokset_search\Controller;
 
-use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\paatokset_search\SearchManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -14,14 +14,11 @@ class SearchController extends ControllerBase {
   /**
    * Controller for policymaker subpages.
    *
-   * @param \Drupal\Core\Config\ImmutableConfig $proxyConfig
-   *   The elastic config.
-   * @param \Drupal\Core\Config\ImmutableConfig $searchConfig
-   *   The search config.
+   * @param \Drupal\paatokset_search\SearchManager $searchManager
+   *   The search manager.
    */
   final public function __construct(
-    private ImmutableConfig $proxyConfig,
-    private ImmutableConfig $searchConfig,
+    private SearchManager $searchManager,
   ) {
   }
 
@@ -30,8 +27,7 @@ class SearchController extends ControllerBase {
    */
   public static function create(ContainerInterface $container): static {
     return new static(
-      $container->get('config.factory')->get('elastic_proxy.settings'),
-      $container->get('config.factory')->get('paatokset_search.settings'),
+      $container->get(SearchManager::class),
     );
   }
 
@@ -39,22 +35,7 @@ class SearchController extends ControllerBase {
    * Return markup for search page.
    */
   public function decisions(): array {
-    $proxyUrl = $this->proxyConfig->get('elastic_proxy_url') ?: '';
-
-    $build = [
-      '#markup' => '<div id="paatokset_search" class="paatokset-search--decisions" data-type="decisions" data-url="' . $proxyUrl . '"></div>',
-      '#attached' => [
-        'library' => [
-          'paatokset_search/paatokset-search',
-        ],
-      ],
-    ];
-
-    if ($sentryDsnReact = $this->searchConfig->get('sentry_dsn_react')) {
-      $build['#attached']['drupalSettings']['paatokset_react_search']['sentry_dsn_react'] = $sentryDsnReact;
-    }
-
-    return $build;
+    return $this->searchManager->build('decisions', ['paatokset-search--decisions']);
   }
 
 }

--- a/public/modules/custom/paatokset_search/src/Controller/SearchController.php
+++ b/public/modules/custom/paatokset_search/src/Controller/SearchController.php
@@ -4,7 +4,6 @@ namespace Drupal\paatokset_search\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\paatokset_search\SearchManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller class for decisions search page.
@@ -17,18 +16,9 @@ class SearchController extends ControllerBase {
    * @param \Drupal\paatokset_search\SearchManager $searchManager
    *   The search manager.
    */
-  final public function __construct(
-    private SearchManager $searchManager,
+  public function __construct(
+    private readonly SearchManager $searchManager,
   ) {
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container): static {
-    return new static(
-      $container->get(SearchManager::class),
-    );
   }
 
   /**

--- a/public/modules/custom/paatokset_search/src/Plugin/Block/PolicymakerSearchBlock.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/Block/PolicymakerSearchBlock.php
@@ -6,9 +6,9 @@ namespace Drupal\paatokset_search\Plugin\Block;
 
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\paatokset_search\SearchManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -28,7 +28,7 @@ class PolicymakerSearchBlock extends BlockBase implements ContainerFactoryPlugin
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    private ConfigFactoryInterface $configFactory,
+    private SearchManager $searchManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -41,7 +41,7 @@ class PolicymakerSearchBlock extends BlockBase implements ContainerFactoryPlugin
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get(ConfigFactoryInterface::class),
+      $container->get(SearchManager::class),
     );
   }
 
@@ -49,25 +49,18 @@ class PolicymakerSearchBlock extends BlockBase implements ContainerFactoryPlugin
    * {@inheritDoc}
    */
   public function build(): array {
-    $proxyConfig = $this->configFactory->get('elastic_proxy.settings');
-    $searchConfig = $this->configFactory->get('paatokset_search.settings');
-    $proxyUrl = $proxyConfig->get('elastic_proxy_url') ?: '';
-
     $build = [
-      '#markup' => '<div class="paatokset-search-wrapper"><div id="paatokset_search" data-type="policymakers" data-url="' . $proxyUrl . '"></div></div>',
       '#attributes' => [
         'class' => ['policymaker-search'],
       ],
-      '#attached' => [
-        'library' => [
-          'paatokset_search/paatokset-search',
+      'search_wrapper' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['paatokset-search-wrapper'],
         ],
+        'search' => $this->searchManager->build('policymakers'),
       ],
     ];
-
-    if ($sentryDsnReact = $searchConfig->get('sentry_dsn_react')) {
-      $build['#attached']['drupalSettings']['paatokset_react_search']['sentry_dsn_react'] = $sentryDsnReact;
-    }
 
     return $build;
   }

--- a/public/modules/custom/paatokset_search/src/Plugin/Block/PolicymakerSearchBlock.php
+++ b/public/modules/custom/paatokset_search/src/Plugin/Block/PolicymakerSearchBlock.php
@@ -19,30 +19,23 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   admin_label: new TranslatableMarkup('Paatokset policymaker search'),
   category: new TranslatableMarkup('Paatokset custom blocks')
 )]
-class PolicymakerSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
+final class PolicymakerSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
-   * {@inheritDoc}
+   * The search manager.
+   *
+   * @var \Drupal\paatokset_search\SearchManager
    */
-  final public function __construct(
-    array $configuration,
-    $plugin_id,
-    $plugin_definition,
-    private SearchManager $searchManager,
-  ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
+  private SearchManager $searchManager;
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get(SearchManager::class),
-    );
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->searchManager = $container->get(SearchManager::class);
+
+    return $instance;
   }
 
   /**

--- a/public/modules/custom/paatokset_search/src/SearchManager.php
+++ b/public/modules/custom/paatokset_search/src/SearchManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\paatokset_search;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -11,20 +13,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
  * Search manager class.
  */
 class SearchManager {
-
-  /**
-   * The search config.
-   *
-   * @var \Drupal\Core\Config\ImmutableConfig
-   */
-  private $proxyConfig;
-
-  /**
-   * The search config.
-   *
-   * @var \Drupal\Core\Config\ImmutableConfig
-   */
-  private $searchConfig;
 
   /**
    * Constructor.
@@ -41,8 +29,6 @@ class SearchManager {
     private readonly LanguageManagerInterface $languageManager,
     private readonly EntityTypeManagerInterface $entityTypeManager,
   ) {
-    $this->proxyConfig = $this->configFactory->get('elastic_proxy.settings');
-    $this->searchConfig = $this->configFactory->get('paatokset_search.settings');
   }
 
   /**
@@ -58,7 +44,7 @@ class SearchManager {
    *   The render array.
    */
   public function build($type, $classes = []): array {
-    $proxyUrl = $this->proxyConfig->get('elastic_proxy_url') ?: '';
+    $proxyUrl = $this->configFactory->get('elastic_proxy.settings')->get('elastic_proxy_url') ?: '';
     $operatorGuideUrl = $this->getOperatorGuideUrl();
 
     $build = [
@@ -81,7 +67,7 @@ class SearchManager {
       $build['#attributes']['class'] = $classes;
     }
 
-    if ($sentryDsnReact = $this->searchConfig->get('sentry_dsn_react')) {
+    if ($sentryDsnReact = $this->configFactory->get('paatokset_search.settings')->get('sentry_dsn_react')) {
       $build['#attached']['drupalSettings']['paatokset_react_search']['sentry_dsn_react'] = $sentryDsnReact;
     }
 
@@ -99,7 +85,7 @@ class SearchManager {
     $currentLanguage = $this->languageManager->getCurrentLanguage();
     // Operator guide node id is set in an environment variable
     // OPERATOR_GUIDE_NODE_ID.
-    $operatorGuideNodeId = $this->searchConfig->get('operator_guide_node_id');
+    $operatorGuideNodeId = $this->configFactory->get('paatokset_search.settings')->get('operator_guide_node_id');
     $operatorGuideNode = $operatorGuideNodeId
       ? $this->entityTypeManager->getStorage('node')->load($operatorGuideNodeId)
       : NULL;

--- a/public/modules/custom/paatokset_search/src/SearchManager.php
+++ b/public/modules/custom/paatokset_search/src/SearchManager.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\paatokset_search;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\node\NodeInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Search manager class.
+ */
+class SearchManager {
+
+  /**
+   * The search config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  private $proxyConfig;
+
+  /**
+   * The search config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  private $searchConfig;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly LanguageManagerInterface $languageManager,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    $this->proxyConfig = $this->configFactory->get('elastic_proxy.settings');
+    $this->searchConfig = $this->configFactory->get('paatokset_search.settings');
+  }
+
+  /**
+   * Return markup for search page.
+   *
+   * @param string $type
+   *   The type of search page. Should one of the following:
+   *   'decisions', 'policymakers' or 'frontpage'.
+   * @param array $classes
+   *   The classes to add to the search page.
+   *
+   * @return array
+   *   The render array.
+   */
+  public function build($type, $classes = []): array {
+    $proxyUrl = $this->proxyConfig->get('elastic_proxy_url') ?: '';
+    $operatorGuideUrl = $this->getOperatorGuideUrl();
+
+    $build = [
+      '#type' => 'html_tag',
+      '#tag' => 'div',
+      '#attributes' => [
+        'id' => 'paatokset_search',
+        'data-type' => $type,
+        'data-url' => $proxyUrl,
+        'data-operator-guide-url' => $operatorGuideUrl,
+      ],
+      '#attached' => [
+        'library' => [
+          'paatokset_search/paatokset-search',
+        ],
+      ],
+    ];
+
+    if ($classes) {
+      $build['#attributes']['class'] = $classes;
+    }
+
+    if ($sentryDsnReact = $this->searchConfig->get('sentry_dsn_react')) {
+      $build['#attached']['drupalSettings']['paatokset_react_search']['sentry_dsn_react'] = $sentryDsnReact;
+    }
+
+    return $build;
+  }
+
+  /**
+   * Get operator guide URL.
+   *
+   * @return string
+   *   The operator guide URL or empty string if the node does not exist or
+   *   user does not have access.
+   */
+  private function getOperatorGuideUrl(): string {
+    $currentLanguage = $this->languageManager->getCurrentLanguage();
+    // Operator guide node id is set in an environment variable
+    // OPERATOR_GUIDE_NODE_ID.
+    $operatorGuideNodeId = $this->searchConfig->get('operator_guide_node_id');
+    $operatorGuideNode = $operatorGuideNodeId
+      ? $this->entityTypeManager->getStorage('node')->load($operatorGuideNodeId)
+      : NULL;
+    $operatorGuideUrl = $operatorGuideNode instanceof NodeInterface && $operatorGuideNode->access('view')
+      ? $operatorGuideNode->toUrl('canonical', ['language' => $currentLanguage])->toString()
+      : '';
+
+    return $operatorGuideUrl;
+  }
+
+}

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/Controller/SearchControllerTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/Controller/SearchControllerTest.php
@@ -24,6 +24,8 @@ class SearchControllerTest extends KernelTestBase {
   /**
    * Tests block render.
    *
+   * @covers ::__construct
+   * @covers ::create
    * @covers ::decisions
    */
   public function testDecisions(): void {

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/Controller/SearchControllerTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/Controller/SearchControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_search\Kernel\Controller;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\paatokset_search\Controller\SearchController;
+
+/**
+ * Tests search controller.
+ *
+ * @coversDefaultClass \Drupal\paatokset_search\Controller\SearchController
+ */
+class SearchControllerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'paatokset_search',
+  ];
+
+  /**
+   * Tests block render.
+   *
+   * @covers ::decisions
+   */
+  public function testDecisions(): void {
+    $controller = SearchController::create($this->container);
+    $build = $controller->decisions();
+
+    $this->assertNotEmpty($build);
+  }
+
+}

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/Controller/SearchControllerTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/Controller/SearchControllerTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\paatokset_search\Kernel\Controller;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\paatokset_search\Controller\SearchController;
+use Drupal\paatokset_search\SearchManager;
 
 /**
  * Tests search controller.
@@ -25,11 +26,10 @@ class SearchControllerTest extends KernelTestBase {
    * Tests block render.
    *
    * @covers ::__construct
-   * @covers ::create
    * @covers ::decisions
    */
   public function testDecisions(): void {
-    $controller = SearchController::create($this->container);
+    $controller = new SearchController($this->container->get(SearchManager::class));
     $build = $controller->decisions();
 
     $this->assertNotEmpty($build);

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/Plugin/Block/PolicymakerSearchBlockTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/Plugin/Block/PolicymakerSearchBlockTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_search\Kernel\Plugin\Block;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\paatokset_search\Plugin\Block\PolicymakerSearchBlock;
+
+/**
+ * Tests policymaker search block.
+ *
+ * @coversDefaultClass \Drupal\paatokset_search\Plugin\Block\PolicymakerSearchBlock
+ */
+class PolicymakerSearchBlockTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'block',
+    'paatokset_search',
+  ];
+
+  /**
+   * Tests block render.
+   *
+   * @covers ::build
+   */
+  public function testBuild(): void {
+    $block = PolicymakerSearchBlock::create($this->container, [], '', ['provider' => 'paatokset_search']);
+    $build = $block->build();
+
+    $this->assertContains('paatokset-search-wrapper', $build['search_wrapper']['#attributes']['class']);
+    $this->assertContains('policymaker-search', $build['#attributes']['class']);
+    $this->assertArrayHasKey('search', $build['search_wrapper']);
+  }
+
+}

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/Plugin/Block/PolicymakerSearchBlockTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/Plugin/Block/PolicymakerSearchBlockTest.php
@@ -25,6 +25,8 @@ class PolicymakerSearchBlockTest extends KernelTestBase {
   /**
    * Tests block render.
    *
+   * @covers ::__construct
+   * @covers ::create
    * @covers ::build
    */
   public function testBuild(): void {

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/Plugin/Block/PolicymakerSearchBlockTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/Plugin/Block/PolicymakerSearchBlockTest.php
@@ -25,7 +25,6 @@ class PolicymakerSearchBlockTest extends KernelTestBase {
   /**
    * Tests block render.
    *
-   * @covers ::__construct
    * @covers ::create
    * @covers ::build
    */

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/SearchManagerTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/SearchManagerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_search\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\paatokset_search\SearchManager;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\RoleInterface;
+
+/**
+ * Tests search manager.
+ *
+ * @coversDefaultClass \Drupal\paatokset_search\SearchManager
+ */
+class SearchManagerTest extends EntityKernelTestBase {
+
+  use NodeCreationTrait {
+    createNode as drupalCreateNode;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'paatokset_search',
+    'node',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $configSchemaCheckerExclusions = [
+    'elastic_proxy.settings',
+    'paatokset_search.settings',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // $this->strictConfigSchema = FALSE;
+    $this->installConfig(['system']);
+    $this->installSchema('node', ['node_access']);
+
+    // Clear permissions for authenticated users.
+    $this->config('user.role.' . RoleInterface::AUTHENTICATED_ID)
+      ->set('permissions', [])
+      ->save();
+    // Create user 1 who has special permissions.
+    $this->drupalCreateUser();
+
+    $user = $this->drupalCreateUser([
+      'access content',
+    ]);
+    $this->container->get('current_user')->setAccount($user);
+
+    NodeType::create([
+      'name' => $this->randomMachineName(),
+      'type' => 'page',
+    ]);
+  }
+
+  /**
+   * Tests search manager build with defaults.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithDefaults(): void {
+    $this->setConfiguration([
+      'elastic_proxy_url' => 'https://example.com',
+    ], [
+      'sentry_dsn_react' => 'https://sentry.example.com',
+    ]);
+    $manager = $this->container->get(SearchManager::class);
+
+    $build = $manager->build('decisions');
+
+    $this->assertContains('paatokset_search/paatokset-search', $build['#attached']['library']);
+    $this->assertEquals('https://sentry.example.com', $build['#attached']['drupalSettings']['paatokset_react_search']['sentry_dsn_react']);
+    $this->assertEquals('decisions', $build['#attributes']['data-type']);
+    $this->assertEquals('https://example.com', $build['#attributes']['data-url']);
+    $this->assertEmpty($build['#attributes']['data-operator-guide-url']);
+  }
+
+  /**
+   * Tests search manager build with operator guide.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithOperatorGuide(): void {
+    $node = $this->drupalCreateNode([
+      'type' => 'page',
+      'title' => 'Test node',
+    ]);
+    $node->save();
+
+    $this->setConfiguration([], [
+      'operator_guide_node_id' => $node->id(),
+    ]);
+    $manager = $this->container->get(SearchManager::class);
+
+    $build = $manager->build('decisions');
+
+    $this->assertEquals('/node/' . $node->id(), $build['#attributes']['data-operator-guide-url']);
+  }
+
+  /**
+   * Tests search manager build with unpublished operator guide.
+   *
+   * @covers ::build
+   */
+  public function testBuildWithUnpublishedOperatorGuide(): void {
+    $node = $this->drupalCreateNode([
+      'type' => 'page',
+      'title' => 'Test node',
+      'uid' => '1',
+      'status' => 0,
+    ]);
+    $node->save();
+
+    $this->setConfiguration([], [
+      'operator_guide_node_id' => $node->id(),
+    ]);
+    $manager = $this->container->get(SearchManager::class);
+
+    $build = $manager->build('decisions');
+
+    $this->assertEmpty($build['#attributes']['data-operator-guide-url']);
+  }
+
+  /**
+   * Helper function to set configuration.
+   *
+   * @param array $elastic_proxy
+   *   The elastic proxy configuration.
+   * @param array $paatokset_search
+   *   The paatokset search configuration.
+   */
+  private function setConfiguration(array $elastic_proxy = [], array $paatokset_search = []): void {
+    $elastic_proxy_config = $this->config('elastic_proxy.settings');
+    foreach ($elastic_proxy as $key => $value) {
+      $elastic_proxy_config->set($key, $value);
+    }
+    $elastic_proxy_config->save();
+
+    $paatokset_search_config = $this->config('paatokset_search.settings');
+    foreach ($paatokset_search as $key => $value) {
+      $paatokset_search_config->set($key, $value);
+    }
+    $paatokset_search_config->save();
+  }
+
+}

--- a/public/modules/custom/paatokset_search/tests/src/Kernel/SearchManagerTest.php
+++ b/public/modules/custom/paatokset_search/tests/src/Kernel/SearchManagerTest.php
@@ -44,7 +44,6 @@ class SearchManagerTest extends EntityKernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    // $this->strictConfigSchema = FALSE;
     $this->installConfig(['system']);
     $this->installSchema('node', ['node_access']);
 
@@ -69,7 +68,9 @@ class SearchManagerTest extends EntityKernelTestBase {
   /**
    * Tests search manager build with defaults.
    *
+   * @covers ::__construct
    * @covers ::build
+   * @covers ::getOperatorGuideUrl
    */
   public function testBuildWithDefaults(): void {
     $this->setConfiguration([
@@ -79,19 +80,22 @@ class SearchManagerTest extends EntityKernelTestBase {
     ]);
     $manager = $this->container->get(SearchManager::class);
 
-    $build = $manager->build('decisions');
+    $build = $manager->build('decisions', ['test-class']);
 
     $this->assertContains('paatokset_search/paatokset-search', $build['#attached']['library']);
     $this->assertEquals('https://sentry.example.com', $build['#attached']['drupalSettings']['paatokset_react_search']['sentry_dsn_react']);
     $this->assertEquals('decisions', $build['#attributes']['data-type']);
     $this->assertEquals('https://example.com', $build['#attributes']['data-url']);
+    $this->assertContains('test-class', $build['#attributes']['class']);
     $this->assertEmpty($build['#attributes']['data-operator-guide-url']);
   }
 
   /**
    * Tests search manager build with operator guide.
    *
+   * @covers ::__construct
    * @covers ::build
+   * @covers ::getOperatorGuideUrl
    */
   public function testBuildWithOperatorGuide(): void {
     $node = $this->drupalCreateNode([
@@ -113,7 +117,9 @@ class SearchManagerTest extends EntityKernelTestBase {
   /**
    * Tests search manager build with unpublished operator guide.
    *
+   * @covers ::__construct
    * @covers ::build
+   * @covers ::getOperatorGuideUrl
    */
   public function testBuildWithUnpublishedOperatorGuide(): void {
     $node = $this->drupalCreateNode([

--- a/public/modules/custom/paatokset_search_form/src/Plugin/Block/SearchBlock.php
+++ b/public/modules/custom/paatokset_search_form/src/Plugin/Block/SearchBlock.php
@@ -20,7 +20,7 @@ class SearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
   /**
    * {@inheritDoc}
    */
-  public function __construct(
+  final public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,

--- a/public/modules/custom/paatokset_search_form/src/Plugin/Block/SearchBlock.php
+++ b/public/modules/custom/paatokset_search_form/src/Plugin/Block/SearchBlock.php
@@ -15,30 +15,23 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  admin_label=@Translation("Search block")
  * )
  */
-class SearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
+final class SearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
-   * {@inheritDoc}
+   * The search manager.
+   *
+   * @var \Drupal\paatokset_search\SearchManager
    */
-  final public function __construct(
-    array $configuration,
-    $plugin_id,
-    $plugin_definition,
-    private SearchManager $searchManager,
-  ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
+  private SearchManager $searchManager;
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get(SearchManager::class),
-    );
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->searchManager = $container->get(SearchManager::class);
+
+    return $instance;
   }
 
   /**

--- a/public/modules/custom/paatokset_search_form/tests/src/Kernel/Plugin/Block/SearchBlockTest.php
+++ b/public/modules/custom/paatokset_search_form/tests/src/Kernel/Plugin/Block/SearchBlockTest.php
@@ -26,7 +26,6 @@ class SearchBlockTest extends KernelTestBase {
   /**
    * Tests block render.
    *
-   * @covers ::__construct
    * @covers ::create
    * @covers ::build
    */

--- a/public/modules/custom/paatokset_search_form/tests/src/Kernel/Plugin/Block/SearchBlockTest.php
+++ b/public/modules/custom/paatokset_search_form/tests/src/Kernel/Plugin/Block/SearchBlockTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_search_form\Kernel\Plugin\Block;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\paatokset_search_form\Plugin\Block\SearchBlock;
+
+/**
+ * Tests search block.
+ *
+ * @coversDefaultClass \Drupal\paatokset_search_form\Plugin\Block\SearchBlock
+ */
+class SearchBlockTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'block',
+    'paatokset_search',
+    'paatokset_search_form',
+  ];
+
+  /**
+   * Tests block render.
+   *
+   * @covers ::build
+   */
+  public function testBuild(): void {
+    $block = SearchBlock::create($this->container, [], '', ['provider' => 'paatokset_search_form']);
+    $build = $block->build();
+
+    $this->assertContains('paatokset-search-wrapper', $build['search_wrapper']['#attributes']['class']);
+    $this->assertContains('paatokset-search--frontpage', $build['#attributes']['class']);
+    $this->assertArrayHasKey('search', $build['search_wrapper']);
+  }
+
+}

--- a/public/modules/custom/paatokset_search_form/tests/src/Kernel/Plugin/Block/SearchBlockTest.php
+++ b/public/modules/custom/paatokset_search_form/tests/src/Kernel/Plugin/Block/SearchBlockTest.php
@@ -26,6 +26,8 @@ class SearchBlockTest extends KernelTestBase {
   /**
    * Tests block render.
    *
+   * @covers ::__construct
+   * @covers ::create
    * @covers ::build
    */
   public function testBuild(): void {

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -14,6 +14,9 @@ $config['elastic_proxy.settings']['elastic_proxy_url'] = drupal_get_env(['REACT_
 // Sentry DSN for React.
 $config['paatokset_search.settings']['sentry_dsn_react'] = getenv('SENTRY_DSN_REACT');
 
+// Search operator guide node id.
+$config['paatokset_search.settings']['operator_guide_node_id'] = getenv('OPERATOR_GUIDE_NODE_ID');
+
 // AD role mapping.
 $config['openid_connect.client.tunnistamo']['settings']['ad_roles'] = [
   [
@@ -69,6 +72,7 @@ $additionalEnvVars = [
   'ELASTIC_USER',
   'ELASTIC_PASSWORD',
   'SENTRY_DSN_REACT',
+  'OPERATOR_GUIDE_NODE_ID',
 ];
 
 foreach ($additionalEnvVars as $var) {


### PR DESCRIPTION
# [UHF-11527](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11527)

## What was done

This PR enables the use of search operators in decision search:

- Updates `paatokset/paatokset_search` to a version that has support for search operators (see https://github.com/City-of-Helsinki/paatokset-search/pull/49)
- Adds support for providing a url for instructions on how to use the operators:
  - The node id is provided via an environment variable
  - If the node exists and current user has access to view it, a url for current language version is generated and provided for the search root dom-element.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11527_operators`
  * `make fresh`
* Run `make drush-cr`

## How to test

List of search operator characters: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax

* If the `make fresh` failed to import a db, leaving you with no content, we need to set up a few test pages:
  * Add a new landing page for the frontpage search: enable hero with layout "Paatokset decision search"
  * Add a new landing page for the pollicymakers search: make sure the url alias is `paattajat`, `beslutsfattare`or `decisionmakers`
* Add a new node (any content type) for the instructions page and leave it unpublished. Add the node id for that page in the root `.env.local`-file like this: `OPERATOR_GUIDE_NODE_ID=[nid]` (for example `OPERATOR_GUIDE_NODE_ID=1`)
* Test frontpage search
  * Go to https://helsinki-paatokset.docker.so/ (or the test page for frontpage search you created above).
  * [x] Using a search phrase without operator characters should not display a status message
  * [x] Using a search phrase with one of the operator characters should display a status message above the search input
  * [x] On incognito (not logged in) the status message should not include the link to instructions (as we left it unpublished), but logged in as an administrator should show it
  * [x] Setting the instructions node published should make the link appear for anonymous users as well
* Test decisions main search
  * Go to https://helsinki-paatokset.docker.so/fi/asia
  * [x] Using a search phrase without operator characters should not display a status message
  * [x] Using a search phrase with one of the operator characters should display a status message above the search input
  * [x] Submitting a search should follow the same guidelines for a status message on top of the results
  * [x] Status message link visibility should follow the same guidelines as the frontpage search
* Test policymakers search
  * Go to https://helsinki-paatokset.docker.so/fi/paattajat (or the test page for policymaker search you created above)
  * [x] No status message should appear anywhere even if using one of the operator characters in the search phrase


[UHF-11527]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ