### PR TITLE
UHF-11628: Fix paatokset_ahjo_api_preprocess_block__frontpage_calendar()

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,11 +14,6 @@ parameters:
   treatPhpDocTypesAsCertain: false
   ignoreErrors:
     -
-      message: "#^Call to an undefined method Drupal\\\\paatokset_policymakers\\\\Service\\\\PolicymakerService\\:\\:getPolicymakerClassById\\(\\)\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
-
-    -
       message: "#^Cannot access property \\$created on object\\|true\\.$#"
       count: 1
       path: public/modules/custom/paatokset_ahjo_api/src/Drush/Commands/AhjoCallbackCommands.php

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -269,6 +269,7 @@ function paatokset_ahjo_api_theme_suggestions_block__policymaker_calendar(array 
  */
 function paatokset_ahjo_api_preprocess_block__frontpage_calendar(array &$variables): void {
   $meetingService = \Drupal::service('paatokset_ahjo_meetings');
+  /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
   $policymakerService = \Drupal::service('paatokset_policymakers');
   $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
@@ -290,7 +291,8 @@ function paatokset_ahjo_api_preprocess_block__frontpage_calendar(array &$variabl
 
   $meetings_with_color = [];
   foreach ($all_meetings as $meeting) {
-    $meeting['organization_color'] = $policymakerService->getPolicymakerClassById($meeting['policymaker']);
+    $policymaker = $policymakerService->getPolicyMaker($meeting['policymaker']);
+    $meeting['organization_color'] = Html::cleanCssIdentifier($policymaker?->getPolicymakerClass() ?? 'color-none');
     $meetings_with_color[] = $meeting;
   }
 


### PR DESCRIPTION
# [UHF-11628](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11628)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix WSOD on frontpage on test environment. Call to undefined method `getPolicymakerClassById` introduced by #566

Sentry issue:
https://sentry.test.hel.ninja/organizations/city-of-helsinki/issues/22491/?project=213&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0

[UHF-11628]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ