### PR TITLE
UHF-11628: Fix paatokset_policymakers_preprocess_node__policymaker()

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -69,11 +69,6 @@ parameters:
       path: public/modules/custom/paatokset_ahjo_api/src/Routing/DecisionConverterBase.php
 
     -
-      message: "#^Call to an undefined method Drupal\\\\paatokset_policymakers\\\\Service\\\\PolicymakerService\\:\\:getDecisionsRoute\\(\\)\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
       message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:findMotionById\\(\\) has invalid return type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface\\.$#"
       count: 1
       path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -155,7 +150,7 @@ parameters:
 
     -
       message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-      count: 7
+      count: 6
       path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
 
     -
@@ -413,11 +408,6 @@ parameters:
 
     -
       message: "#^Access to an undefined property Drupal\\\\Core\\\\Field\\\\FieldItemInterface\\:\\:\\$value\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
-
-    -
-      message: "#^Call to an undefined method Drupal\\\\paatokset_policymakers\\\\Service\\\\PolicymakerService\\:\\:getDecisionsRoute\\(\\)\\.$#"
       count: 1
       path: public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
@@ -449,28 +449,6 @@ class CaseService {
   }
 
   /**
-   * Get policy maker URL for selected decision.
-   *
-   * @return \Drupal\Core\Url|null
-   *   Policy maker URL, if found.
-   */
-  public function getPolicymakerDecisionsLink(): ?Url {
-    if (!$this->selectedDecision instanceof NodeInterface) {
-      return NULL;
-    }
-
-    if (!$this->selectedDecision->hasField('field_policymaker_id') || $this->selectedDecision->get('field_policymaker_id')->isEmpty()) {
-      return NULL;
-    }
-
-    $policymaker_id = $this->selectedDecision->get('field_policymaker_id')->value;
-
-    /** @var \Drupal\paatokset_policymakers\Service\PolicymakerService $policymakerService */
-    $policymakerService = \Drupal::service('paatokset_policymakers');
-    return $policymakerService->getDecisionsRoute($policymaker_id);
-  }
-
-  /**
    * Get decision URL by native ID.
    *
    * @param string $id

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -212,7 +212,7 @@ function paatokset_policymakers_preprocess_node__policymaker(&$variables) {
       $recentDecisions = $policymakerService->getAgendasListFromElasticSearch(2, FALSE);
       if (!empty($recentDecisions)) {
         $variables['recent_decisions'] = $recentDecisions;
-        $variables['all_decisions_link'] = $policymakerService->getDecisionsRoute();
+        $variables['all_decisions_link'] = $policymaker->getDecisionsRoute(\Drupal::languageManager()->getCurrentLanguage()->getId());
         $no_content = FALSE;
       }
     }


### PR DESCRIPTION
# [UHF-11628](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11628)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

- Fix WSOD on policymakers page on test environment. Call to undefined method getDecisionsRoute introduced by #566.

Sentry issue:
https://sentry.test.hel.ninja/organizations/city-of-helsinki/issues/22491/?project=213&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0

## How to test
- Index decisions
- [policymaker page](https://helsinki-paatokset.docker.so/fi/paattajat/yksikon-paallikko-alueellinen-rakennuttaminen-yksikko) should not crash

[UHF-11628]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ