### PR TITLE
UHF-11474: Fix accordion memory function in Decisions

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -496,6 +496,7 @@ function hdbt_subtheme_preprocess_node__article(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_subtheme_preprocess_html(&$variables): void {
+  // TODO: This should be removed if UHF-11699 is done.
   // Set instance name manually to be used as a JS variable.
   $variables['#attached']['drupalSettings']['helfi_instance_name'] = 'paatokset';
 }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -496,7 +496,7 @@ function hdbt_subtheme_preprocess_node__article(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_subtheme_preprocess_html(&$variables): void {
-  // TODO: This should be removed if UHF-11699 is done.
+  // @todo This should be removed if UHF-11699 is done.
   // Set instance name manually to be used as a JS variable.
   $variables['#attached']['drupalSettings']['helfi_instance_name'] = 'paatokset';
 }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -491,3 +491,11 @@ function hdbt_subtheme_preprocess_node__article(&$variables) {
     $variables['unpublish_on'] = $node->get('unpublish_on')->getString();
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function hdbt_subtheme_preprocess_html(&$variables): void {
+  // Set instance name manually to be used as a JS variable.
+  $variables['#attached']['drupalSettings']['helfi_instance_name'] = 'paatokset';
+}


### PR DESCRIPTION
# [UHF-11474](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11474)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add Decisions instance name manually to js-variable as a quick fix for the issue of missing instance name.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11474`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to any page with accordion paragraph like this for example https://helsinki-paatokset.docker.so/fi/tietoa-paatoksenteosta/paatoksenteon-sanakirja and make sure that if you open an accordion item and refresh the page it still remembers what items you had open.
* [x] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

[UHF-11474]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ