### PR TITLE
UHF-X: Fix default color for decision when policymaker is missing

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -292,7 +292,7 @@ function paatokset_ahjo_api_preprocess_block__frontpage_calendar(array &$variabl
   $meetings_with_color = [];
   foreach ($all_meetings as $meeting) {
     $policymaker = $policymakerService->getPolicyMaker($meeting['policymaker']);
-    $meeting['organization_color'] = Html::cleanCssIdentifier($policymaker?->getPolicymakerClass() ?? 'color-none');
+    $meeting['organization_color'] = Html::cleanCssIdentifier($policymaker?->getPolicymakerClass() ?? 'color-sumu');
     $meetings_with_color[] = $meeting;
   }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/search_api/processor/ColorClass.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/search_api/processor/ColorClass.php
@@ -54,7 +54,7 @@ class ColorClass extends ProcessorPluginBase {
 
     $colorClass = NULL;
     if ($node instanceof Decision) {
-      $colorClass = $node->getPolicymaker($node->language()->getId())?->getPolicymakerClass();
+      $colorClass = $node->getPolicymaker($node->language()->getId())?->getPolicymakerClass() ?? 'color-sumu';
     }
     elseif ($node instanceof Policymaker) {
       $colorClass = $node->getPolicymakerClass();

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/SearchApi/Processor/ColorClassTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/SearchApi/Processor/ColorClassTest.php
@@ -44,7 +44,6 @@ class ColorClassTest extends AhjoSearchApiKernelTestBase {
       'title' => 'Test decision',
       'field_policymaker_id' => '123',
     ]);
-    $decision->save();
 
     $policymaker = $storage->create([
       'type' => 'policymaker',
@@ -58,6 +57,15 @@ class ColorClassTest extends AhjoSearchApiKernelTestBase {
 
     $this->assertColorClassField('test-color', 'test_color_class', $decision);
     $this->assertColorClassField('test-color', 'test_color_class', $policymaker);
+
+    // If policymaker is missing, should get 'color-sumu'.
+    $decision = $storage->create([
+      'type' => 'decision',
+      'title' => 'Test decision',
+      'field_policymaker_id' => 'missing',
+    ]);
+
+    $this->assertColorClassField('color-sumu', 'test_color_class', $decision);
   }
 
   /**


### PR DESCRIPTION
This bug was introduced in #566, when some methods from Policymaker service were moved to a Policymaker bundle class. Policymaker::getPolicymakerClass and Policymaker::getPolicymakerClassById had a different default values, so if a decision is missing a policymaker, it should get 'color-sumu'.

https://github.com/City-of-Helsinki/helsinki-paatokset/pull/566/files#diff-5e6c90a5f4f18266e2d99314d0af3738668a4d6a94c45d7fd0296f56e76cc2c3L1980-L1995