### PR TITLE
UHF-11644: Create indexes for ID fields

### DIFF
--- a/conf/cmi/field.storage.node.field_decision_native_id.yml
+++ b/conf/cmi/field.storage.node.field_decision_native_id.yml
@@ -16,6 +16,8 @@ module: core
 locked: false
 cardinality: 1
 translatable: true
-indexes: {  }
+indexes:
+  node__field_decision_native_id__value:
+    - value
 persist_with_no_fields: false
 custom_storage: false

--- a/conf/cmi/field.storage.node.field_diary_number.yml
+++ b/conf/cmi/field.storage.node.field_diary_number.yml
@@ -16,6 +16,8 @@ module: core
 locked: false
 cardinality: 1
 translatable: true
-indexes: {  }
+indexes:
+  field_diary_number__value:
+    - value
 persist_with_no_fields: false
 custom_storage: false

--- a/conf/cmi/field.storage.node.field_policymaker_id.yml
+++ b/conf/cmi/field.storage.node.field_policymaker_id.yml
@@ -17,6 +17,8 @@ module: core
 locked: false
 cardinality: 1
 translatable: true
-indexes: {  }
+indexes:
+  field_policymaker_id__value:
+    - value
 persist_with_no_fields: false
 custom_storage: false

--- a/conf/cmi/field.storage.node.field_unique_id.yml
+++ b/conf/cmi/field.storage.node.field_unique_id.yml
@@ -16,6 +16,8 @@ module: core
 locked: false
 cardinality: 1
 translatable: true
-indexes: {  }
+indexes:
+  field_unique_id__value:
+    - value
 persist_with_no_fields: false
 custom_storage: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -69,88 +69,13 @@ parameters:
       path: public/modules/custom/paatokset_ahjo_api/src/Routing/DecisionConverterBase.php
 
     -
-      message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:findMotionById\\(\\) has invalid return type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:findOrCreateMotionByMeetingData\\(\\) has invalid return type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:getDecisionFromQuery\\(\\) has invalid return type Drupal\\\\node\\\\Entity\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:getDecisionUrlByTitle\\(\\) has invalid return type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\Core\\\\Url\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:getDecisionUrlFromNode\\(\\) has invalid return type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\Core\\\\Url\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:guessDecisionFromPath\\(\\) should return Drupal\\\\paatokset_ahjo_api\\\\Entity\\\\Decision\\|null but returns Drupal\\\\node\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:guessDecisionFromPath\\(\\) should return Drupal\\\\paatokset_ahjo_api\\\\Entity\\\\Decision\\|null but returns Drupal\\\\node\\\\NodeInterface\\|null\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^PHPDoc tag @param for parameter \\$case with type Drupal\\\\node\\\\Entity\\\\NodeInterface is not subtype of native type Drupal\\\\node\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^PHPDoc tag @param for parameter \\$decision with type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface\\|null is not subtype of native type Drupal\\\\node\\\\NodeInterface\\|null\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^PHPDoc tag @return with type Drupal\\\\node\\\\Entity\\\\NodeInterface\\|null is not subtype of native type Drupal\\\\node\\\\NodeInterface\\|null\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^PHPDoc tag @return with type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\Core\\\\Url\\|null is not subtype of native type Drupal\\\\Core\\\\Url\\|null\\.$#"
-      count: 2
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^PHPDoc tag @return with type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface\\|null is not subtype of native type Drupal\\\\node\\\\NodeInterface\\|null\\.$#"
-      count: 2
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Parameter \\$case of method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:getDecisionFromQuery\\(\\) has invalid type Drupal\\\\node\\\\Entity\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
-      message: "#^Parameter \\$decision of method Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:getDecisionUrlFromNode\\(\\) has invalid type Drupal\\\\paatokset_ahjo_api\\\\Service\\\\Drupal\\\\node\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
       message: "#^Property Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:\\$case \\(Drupal\\\\node\\\\Entity\\\\Node\\) does not accept Drupal\\\\node\\\\NodeInterface\\.$#"
       count: 1
       path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
 
     -
-      message: "#^Variable \\$decision in PHPDoc tag @var does not exist\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
       message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-      count: 6
+      count: 2
       path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
 
     -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -69,11 +69,6 @@ parameters:
       path: public/modules/custom/paatokset_ahjo_api/src/Routing/DecisionConverterBase.php
 
     -
-      message: "#^Property Drupal\\\\paatokset_ahjo_api\\\\Service\\\\CaseService\\:\\:\\$case \\(Drupal\\\\node\\\\Entity\\\\Node\\) does not accept Drupal\\\\node\\\\NodeInterface\\.$#"
-      count: 1
-      path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php
-
-    -
       message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
       count: 2
       path: public/modules/custom/paatokset_ahjo_api/src/Service/CaseService.php

--- a/public/modules/custom/paatokset_ahjo_api/config/install/field.field.node.case.field_no_title_for_case.yml
+++ b/public/modules/custom/paatokset_ahjo_api/config/install/field.field.node.case.field_no_title_for_case.yml
@@ -1,0 +1,23 @@
+uuid: 9715ed4c-3b0a-4dc8-9cd0-c028cd0f4d46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_no_title_for_case
+    - node.type.case
+id: node.case.field_no_title_for_case
+field_name: field_no_title_for_case
+entity_type: node
+bundle: case
+label: 'No title for case'
+description: 'This is set if the case does not have a title, and uses the first decision title instead.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/public/modules/custom/paatokset_ahjo_api/config/install/field.field.node.decision.field_decision_case_title.yml
+++ b/public/modules/custom/paatokset_ahjo_api/config/install/field.field.node.decision.field_decision_case_title.yml
@@ -1,0 +1,19 @@
+uuid: e5e05c79-5dc2-4aae-8b1e-aa6f3b87d036
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_decision_case_title
+    - node.type.decision
+id: node.decision.field_decision_case_title
+field_name: field_decision_case_title
+entity_type: node
+bundle: decision
+label: 'Case title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/public/modules/custom/paatokset_ahjo_api/config/install/field.storage.node.field_decision_case_title.yml
+++ b/public/modules/custom/paatokset_ahjo_api/config/install/field.storage.node.field_decision_case_title.yml
@@ -1,0 +1,21 @@
+uuid: 4aa3e565-d8de-45ec-aedc-3832c9b1f058
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_decision_case_title
+field_name: field_decision_case_title
+entity_type: node
+type: string
+settings:
+  max_length: 800
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_ahjo_api/config/install/field.storage.node.field_no_title_for_case.yml
+++ b/public/modules/custom/paatokset_ahjo_api/config/install/field.storage.node.field_no_title_for_case.yml
@@ -1,0 +1,18 @@
+uuid: 5110386e-8dfd-491a-8372-53b1f0e8dd97
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_no_title_for_case
+field_name: field_no_title_for_case
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -505,23 +505,37 @@ function paatokset_ahjo_api_preprocess_block__decision_tree(array &$variables): 
 /**
  * Preprocess variables for case and decision pages.
  */
-function _paatokset_ahjo_api_get_decision_variables(&$variables, CaseService $caseService): void {
-  $decision = $caseService->getSelectedDecision();
+function _paatokset_ahjo_api_get_decision_variables(&$variables, ?CaseBundle $case, ?Decision $decision): void {
+  /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
+  $caseService = \Drupal::service('paatokset_ahjo_cases');
   $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
   $policymaker = $decision?->getPolicymaker($langcode);
 
-  $variables['no_title_for_case'] = $caseService->checkIfNoCaseTitle();
+  $variables['no_title_for_case'] = $case?->checkIfNoCaseTitle() ?? FALSE;
   $variables['decision_pdf'] = $decision?->getDecisionPdf();
-  $variables['selectedDecision'] = $caseService->getSelectedDecision();
+  $variables['selectedDecision'] = $decision;
   $variables['policymaker_is_active'] = $policymaker?->isActive() ?? FALSE;
   $variables['decision_section'] = $decision?->getFormattedDecisionSection();
   $variables['decision_org_name'] = $policymaker?->getPolicymakerName() ?? $decision?->getDecisionMakerOrgName();
-  $variables['selected_label'] = $decision ? $caseService->formatDecisionLabel($decision) : NULL;
+  $variables['selected_label'] = $decision ? $caseService->formatDecisionLabel($decision, $policymaker) : NULL;
   $variables['selected_class'] = Html::cleanCssIdentifier($policymaker?->getPolicymakerClass() ?? 'color-sumu');
   $variables['attachments'] = $decision?->getAttachments() ?? [];
-  $variables['all_decisions'] = $caseService->getDecisionsList();
-  $variables['next_decision'] = $decision ? $caseService->getNextDecision($decision) : NULL;
-  $variables['previous_decision'] = $decision ? $caseService->getPrevDecision($decision) : NULL;
+  $variables['all_decisions'] = $case ? $caseService->getDecisionsList($case) : NULL;
+
+  if ($adjacent = $case?->getNextDecision($decision)) {
+    $variables['next_decision'] = [
+      'title' => $adjacent->label(),
+      'id' => $caseService->normalizeNativeId($adjacent->getNativeId()),
+    ];
+  }
+
+  if ($adjacent = $case?->getPrevDecision($decision)) {
+    $variables['previous_decision'] = [
+      'title' => $adjacent->label(),
+      'id' => $caseService->normalizeNativeId($adjacent->getNativeId()),
+    ];
+  }
+
   $variables['decision_content'] = $decision?->parseContent() ?? [];
   $variables['all_decisions_link'] = $decision?->getDecisionMeetingLink();
   $variables['other_decisions_link'] = $policymaker?->getDecisionsRoute($langcode);
@@ -532,12 +546,17 @@ function _paatokset_ahjo_api_get_decision_variables(&$variables, CaseService $ca
  * Preprocess Case nodes.
  */
 function paatokset_ahjo_api_preprocess_node__case__full(&$variables): void {
+  $case = $variables['node'];
+  assert($case instanceof CaseBundle);
+
   /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
   $caseService = \Drupal::service('paatokset_ahjo_cases');
-  $caseService->setEntitiesByPath();
 
-  _paatokset_ahjo_api_get_decision_variables($variables, $caseService);
+  $decision = $caseService->guessDecisionFromPath($case);
 
+  _paatokset_ahjo_api_get_decision_variables($variables, $case, $decision);
+
+  // @fixme should not case all cases with node_list:decision.
   $variables['#cache'] = [
     'tags' => ['node_list:decision'],
     'contexts' => [
@@ -553,18 +572,13 @@ function paatokset_ahjo_api_preprocess_node__case__full(&$variables): void {
  * Preprocess Decision nodes.
  */
 function paatokset_ahjo_api_preprocess_node__decision__full(&$variables): void {
-  $node = $variables['node'];
-  if (!$node instanceof NodeInterface) {
-    return;
-  }
+  $decision = $variables['node'];
+  assert($decision instanceof Decision);
 
-  /** @var \Drupal\paatokset_ahjo_api\Service\CaseService $caseService */
-  $caseService = \Drupal::service('paatokset_ahjo_cases');
-  $caseService->setEntitiesFromDecision($node);
+  $variables['main_heading'] = $decision->getDecisionHeading();
+  _paatokset_ahjo_api_get_decision_variables($variables, $decision->getCase(), $decision);
 
-  $variables['main_heading'] = $caseService->getDecisionHeading();
-  _paatokset_ahjo_api_get_decision_variables($variables, $caseService);
-
+  // @fixme should not case all decisions with node_list:decision & node_list:case.
   $variables['#cache'] = [
     'tags' => [
       'node_list:decision',

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -522,14 +522,14 @@ function _paatokset_ahjo_api_get_decision_variables(&$variables, ?CaseBundle $ca
   $variables['attachments'] = $decision?->getAttachments() ?? [];
   $variables['all_decisions'] = $case ? $caseService->getDecisionsList($case) : NULL;
 
-  if ($adjacent = $case?->getNextDecision($decision)) {
+  if ($decision && $adjacent = $case?->getNextDecision($decision)) {
     $variables['next_decision'] = [
       'title' => $adjacent->label(),
       'id' => $caseService->normalizeNativeId($adjacent->getNativeId()),
     ];
   }
 
-  if ($adjacent = $case?->getPrevDecision($decision)) {
+  if ($decision && $adjacent = $case?->getPrevDecision($decision)) {
     $variables['previous_decision'] = [
       'title' => $adjacent->label(),
       'id' => $caseService->normalizeNativeId($adjacent->getNativeId()),

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -389,45 +389,6 @@ function paatokset_ahjo_api_preprocess_block__policymaker_listing(array &$variab
 }
 
 /**
- * Get english version of finnish sector name.
- *
- * @param string $sector
- *   Sector name.
- *
- * @return string
- *   English translation of sector, or original value.
- */
-function _paatokset_ahjo_api_get_sector_english_translation(string $sector): string {
-  switch ($sector) {
-    case 'Kasvatuksen ja koulutuksen toimiala':
-      $value = 'Education Division';
-      break;
-
-    case 'Kaupunkiympäristön toimiala':
-      $value = 'Urban Environment Division';
-      break;
-
-    case 'Keskushallinto':
-      $value = 'Central Administration';
-      break;
-
-    case 'Kulttuurin ja vapaa-ajan toimiala':
-      $value = 'Culture and Leisure Division';
-      break;
-
-    case 'Sosiaali- ja terveystoimiala':
-      $value = 'Social Services and Health Care Division';
-      break;
-
-    default:
-      $value = $sector;
-      break;
-  }
-
-  return $value;
-}
-
-/**
  * Preprocess all initiatives block.
  */
 function paatokset_ahjo_api_preprocess_block__all_initiatives(array &$variables): void {
@@ -874,7 +835,7 @@ function _paatokset_ahjo_api_string_to_boolean(mixed $value): bool {
  *   An array of meeting documents.
  *
  * @return bool
- *   TRUE is thee minutes are found, FALSE if they are not.
+ *   TRUE is the minutes are found, FALSE if they are not.
  */
 function _paatokset_ahjo_api_meeting_minutes_published($documents): bool {
   if (empty($documents) || !is_array($documents)) {

--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/CaseController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/CaseController.php
@@ -55,13 +55,23 @@ final class CaseController extends ControllerBase {
 
     $langcode = $this->languageManager()->getCurrentLanguage()->getId();
     $policymaker = $decision->getPolicyMaker($langcode);
+    $case = $decision->getCase();
 
     $content = $this->renderDecisionContent($decision, $policymaker);
     $attachments = $this->renderCaseAttachments($decision);
+    $next = $case?->getNextDecision($decision);
+    $prev = $case?->getPrevDecision($decision);
+
     $navigation = [
       '#theme' => 'decision_navigation',
-      '#next_decision' => $this->caseService->getNextDecision($decision),
-      '#previous_decision' => $this->caseService->getPrevDecision($decision),
+      '#next_decision' => $next ? [
+        'title' => $next->label(),
+        'id' => $this->caseService->normalizeNativeId($next->getNativeId()),
+      ] : NULL,
+      '#previous_decision' => $prev ? [
+        'title' => $prev->label(),
+        'id' => $this->caseService->normalizeNativeId($prev->getNativeId()),
+      ] : NULL,
     ];
 
     $response = new CacheableJsonResponse([

--- a/public/modules/custom/paatokset_ahjo_api/src/Entity/CaseBundle.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Entity/CaseBundle.php
@@ -10,4 +10,164 @@ use Drupal\node\Entity\Node;
  * Bundle class for decisions.
  */
 class CaseBundle extends Node {
+
+  /**
+   * Memoized result for self::getCase().
+   *
+   * @var \Drupal\paatokset_ahjo_api\Entity\Decision[]|null
+   */
+  private ?array $allDecisions = NULL;
+
+  /**
+   * Get diary (case) number.
+   */
+  public function getDiaryNumber(): string {
+    return $this->get('field_diary_number')->getString();
+  }
+
+  /**
+   * Check if selected case has no title.
+   *
+   * @return bool
+   *   TRUE if case is set but has no own title.
+   */
+  public function checkIfNoCaseTitle(): bool {
+    return (bool) $this->get('field_no_title_for_case')->value;
+  }
+
+  /**
+   * Get all decisions for this case.
+   *
+   * @return \Drupal\paatokset_ahjo_api\Entity\Decision[]
+   *   Array of decision nodes.
+   */
+  public function getAllDecisions(): array {
+    if (isset($this->allDecisions)) {
+      return $this->allDecisions;
+    }
+
+    $currentLanguage = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $ids = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->getQuery()
+      ->accessCheck()
+      ->condition('type', 'decision')
+      ->condition('status', 1)
+      ->condition('field_diary_number', $this->getDiaryNumber())
+      ->sort('field_meeting_date')
+      ->execute();
+
+    $results = Decision::loadMultiple($ids);
+
+    $native_results = [];
+    foreach ($results as $node) {
+      // Store all unique IDs for current language decisions.
+      if ($node->language()->getId() === $currentLanguage) {
+        $native_results[$node->field_unique_id->value] = $results;
+      }
+    }
+
+    // Remove any decisions where:
+    // - The language is not the currently active language.
+    // - Another decision with the same ID exists in the active language.
+    $results = array_filter($results, fn (Decision $decision) =>
+      $decision->language()->getId() === $currentLanguage || !isset($native_results[$decision->field_unique_id->value])
+    );
+
+    // Sort decisions by timestamp and then again by section numbering.
+    // Has to be done here because query sees sections as text, not numbers.
+    usort($results, static function ($item1, $item2) {
+      if ($item1->get('field_meeting_date')->isEmpty()) {
+        $item1_timestamp = 0;
+        $item1_date = NULL;
+      }
+      else {
+        $item1_timestamp = strtotime($item1->get('field_meeting_date')->value);
+        $item1_date = date('d.m.Y', $item1_timestamp);
+      }
+      if ($item2->get('field_meeting_date')->isEmpty()) {
+        $item2_timestamp = 0;
+        $item2_date = NULL;
+      }
+      else {
+        $item2_timestamp = strtotime($item2->get('field_meeting_date')->value);
+        $item2_date = date('d.m.Y', $item2_timestamp);
+      }
+      if ($item1->get('field_decision_section')->isEmpty()) {
+        $item1_section = 0;
+      }
+      else {
+        $item1_section = (int) $item1->get('field_decision_section')->value;
+      }
+      if ($item2->get('field_decision_section')->isEmpty()) {
+        $item2_section = 0;
+      }
+      else {
+        $item2_section = (int) $item2->get('field_decision_section')->value;
+      }
+
+      if ($item1_date === $item2_date) {
+        return $item2_section - $item1_section;
+      }
+
+      return $item2_timestamp - $item1_timestamp;
+    });
+
+    return $this->allDecisions = $results;
+  }
+
+  /**
+   * Get next decision, if one exists.
+   *
+   * @param \Drupal\paatokset_ahjo_api\Entity\Decision $decision
+   *   Current decision.
+   *
+   * @return \Drupal\paatokset_ahjo_api\Entity\Decision|null
+   *   Next decision in list.
+   */
+  public function getNextDecision(Decision $decision): ?Decision {
+    return $this->getAdjacentDecision(-1, $decision);
+  }
+
+  /**
+   * Get previous decision, if one exists.
+   *
+   * @param \Drupal\paatokset_ahjo_api\Entity\Decision $decision
+   *   Current decision.
+   *
+   * @return \Drupal\paatokset_ahjo_api\Entity\Decision|null
+   *   Previous decision in list.
+   */
+  public function getPrevDecision(Decision $decision): ?Decision {
+    return $this->getAdjacentDecision(1, $decision);
+  }
+
+  /**
+   * Get adjacent decision in list, if one exists.
+   *
+   * @param int $offset
+   *   Which offset to use (1 for previous, -1 for next).
+   * @param \Drupal\paatokset_ahjo_api\Entity\Decision $decision
+   *   Current decision.
+   *
+   * @return Decision|null
+   *   Adjacent decision in list.
+   */
+  private function getAdjacentDecision(int $offset, Decision $decision): ?Decision {
+    $all_decisions = array_values($this->getAllDecisions());
+    $found_node = NULL;
+    foreach ($all_decisions as $key => $value) {
+      if ((string) $value->id() !== $decision->id()) {
+        continue;
+      }
+
+      if (isset($all_decisions[$key + $offset])) {
+        $found_node = $all_decisions[$key + $offset];
+      }
+      break;
+    }
+
+    return $found_node;
+  }
+
 }

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/CaseServiceTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/CaseServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_ahjo_api\Kernel;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\paatokset_ahjo_api\Entity\CaseBundle;
+use Drupal\paatokset_ahjo_api\Service\CaseService;
+
+/**
+ * Tests case service.
+ */
+class CaseServiceTest extends AhjoKernelTestBase {
+
+  /**
+   * Tests decision list generation.
+   */
+  public function testDecisionList(): void {
+    $sut = $this->container->get(CaseService::class);
+
+    /** @var \Drupal\Core\Entity\EntityStorageInterface $storage */
+    $storage = $this->container->get(EntityTypeManagerInterface::class)
+      ->getStorage('node');
+
+    $case = $storage->create([
+      'type' => 'case',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+    ]);
+
+    $this->assertInstanceOf(CaseBundle::class, $case);
+
+    $storage->create([
+      'type' => 'decision',
+      'title' => 'Test decision 0',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+      'field_policymaker_id' => '????',
+      'field_meeting_date' => '2010-01-01',
+    ])->save();
+    $storage->create([
+      'type' => 'decision',
+      'title' => 'Test decision 1',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+      'field_policymaker_id' => '1234',
+      'field_meeting_date' => '2017-01-01',
+    ])->save();
+    $storage->create([
+      'type' => 'decision',
+      'title' => 'Test decision 2',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+      'field_policymaker_id' => '4321',
+      'field_meeting_date' => '2018-01-01',
+    ])->save();
+
+    $this->assertNotEmpty($sut->getDecisionsList($case));
+
+    $storage->create([
+      'type' => 'policymaker',
+      'status' => '1',
+      'langcode' => 'en',
+      'title' => 'Test policymaker 1',
+      'field_policymaker_id' => '1234',
+    ])->save();
+    $storage->create([
+      'type' => 'policymaker',
+      'status' => '1',
+      'langcode' => 'en',
+      'title' => 'Test policymaker 2',
+      'field_policymaker_id' => '4321',
+    ])->save();
+
+    $list = $sut->getDecisionsList($case);
+    $this->assertNotEmpty($list);
+    foreach ($list as $item) {
+      $this->assertStringStartsWith('Test decision', $item['title']);
+    }
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Entity/CaseTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Entity/CaseTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_ahjo_api\Kernel\Entity;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\paatokset_ahjo_api\Entity\CaseBundle;
+use Drupal\paatokset_ahjo_api\Entity\Decision;
+use Drupal\Tests\paatokset_ahjo_api\Kernel\AhjoKernelTestBase;
+
+/**
+ * Tests case bundle class.
+ */
+class CaseTest extends AhjoKernelTestBase {
+
+  /**
+   * Tests bundle class.
+   */
+  public function testBundleClass(): void {
+    /** @var \Drupal\Core\Entity\EntityStorageInterface $storage */
+    $storage = $this->container->get(EntityTypeManagerInterface::class)
+      ->getStorage('node');
+
+    $case = $storage->create([
+      'type' => 'case',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+      'field_no_title_for_case' => '1',
+    ]);
+
+    $this->assertInstanceOf(CaseBundle::class, $case);
+
+    $this->assertEquals('123', $case->getDiaryNumber());
+    $this->assertTrue($case->checkIfNoCaseTitle());
+
+    // Create a bunch of decisions.
+    $middle = $storage->create([
+      'type' => 'decision',
+      'title' => 'Test decision 2',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+      'field_meeting_date' => '2018-01-01',
+    ]);
+    $first = $storage->create([
+      'type' => 'decision',
+      'title' => 'Test decision 1',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+      'field_meeting_date' => '2017-01-01',
+    ]);
+    $last = $storage->create([
+      'type' => 'decision',
+      'title' => 'Test decision 3',
+      'status' => '1',
+      'langcode' => 'en',
+      'field_diary_number' => '123',
+      'field_meeting_date' => '2019-01-01',
+    ]);
+
+    $first->save();
+    $middle->save();
+    $last->save();
+
+    $this->assertInstanceOf(Decision::class, $first);
+    $this->assertInstanceOf(Decision::class, $middle);
+    $this->assertInstanceOf(Decision::class, $last);
+
+    $this->assertEmpty($case->getPrevDecision($first));
+    $this->assertEquals('Test decision 1', $case->getPrevDecision($middle)?->label());
+    $this->assertEquals('Test decision 3', $case->getNextDecision($middle)?->label());
+    $this->assertEmpty($case->getNextDecision($last));
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Entity/DecisionTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Entity/DecisionTest.php
@@ -27,12 +27,12 @@ class DecisionTest extends AhjoKernelTestBase {
       'title' => 'Test decision',
       'field_diary_number' => 'test-diary-number',
       'field_decision_native_id' => 'test-native-id',
+      'field_decision_case_title' => 'test-case-title',
       'field_dm_org_name' => 'test-dm-org-name',
       'field_policymaker_id' => '123',
     ]);
     $this->assertInstanceOf(Decision::class, $decision);
 
-    $this->assertEquals('test-diary-number', $decision->getDiaryNumber());
     $this->assertEquals('test-native-id', $decision->getNativeId());
     $this->assertEquals('test-dm-org-name', $decision->getDecisionMakerOrgName());
 
@@ -46,7 +46,24 @@ class DecisionTest extends AhjoKernelTestBase {
       'field_policymaker_id' => '123',
     ])->save();
 
+    $this->assertEquals('123', $decision->getPolicymakerId());
     $this->assertNotEmpty($decision->getPolicymaker('en'));
+
+    $this->assertEmpty($decision->getCase());
+    $this->assertEquals('test-case-title', $decision->getDecisionHeading());
+
+    $storage->create([
+      'type' => 'case',
+      'status' => '1',
+      'langcode' => 'en',
+      'title' => 'Test case',
+      'field_full_title' => 'test-full-title',
+      'field_diary_number' => 'test-diary-number',
+    ])->save();
+
+    $this->assertEquals('test-diary-number', $decision->getDiaryNumber());
+    $this->assertNotEmpty($decision->getCase());
+    $this->assertEquals('test-full-title', $decision->getDecisionHeading());
   }
 
   /**

--- a/public/modules/custom/paatokset_ahjo_api/translations/fi.po
+++ b/public/modules/custom/paatokset_ahjo_api/translations/fi.po
@@ -27,3 +27,6 @@ msgstr "Salassa pidettävä: @reasons"
 
 msgid "The attachment will not be published on the internet."
 msgstr "Liitettä ei julkaista internetissä."
+
+msgid: "More recent handlings"
+msgstr "Asialla on uudempia käsittelyjä"

--- a/public/modules/custom/paatokset_ahjo_api/translations/sv.po
+++ b/public/modules/custom/paatokset_ahjo_api/translations/sv.po
@@ -27,3 +27,6 @@ msgstr "Sekretessbelagd: @reasons"
 
 msgid "The attachment will not be published on the internet."
 msgstr "Bilagan publiceras inte på internet."
+
+msgid: "More recent handlings"
+msgstr "Ärendet har nyare handläggningar"

--- a/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
+++ b/public/modules/custom/paatokset_policymakers/src/Service/PolicymakerService.php
@@ -158,12 +158,7 @@ class PolicymakerService {
    *   of policymakers.
    */
   public function query(array $params = []) : array {
-    if (isset($params['sort'])) {
-      $sort = $params['sort'];
-    }
-    else {
-      $sort = 'ASC';
-    }
+    $sort = $params['sort'] ?? 'ASC';
 
     $query = $this->nodeStorage
       ->getQuery()


### PR DESCRIPTION
# [UHF-11644](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11644)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Paatokset makes some heavy DB queries to node fields. This change attempts to optimize this.

This PR should address the following issues:
 - https://sentry.hel.fi/organizations/city-of-helsinki/issues/49485/?environment=production&project=177
 - https://sentry.hel.fi/organizations/city-of-helsinki/issues/50519/?environment=production&project=177
 - https://sentry.hel.fi/organizations/city-of-helsinki/issues/50241/?environment=production&project=177
 - https://sentry.hel.fi/organizations/city-of-helsinki/issues/50375/?environment=production&project=177
 - https://sentry.hel.fi/organizations/city-of-helsinki/issues/50042/?environment=production&project=177


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11644-create-indexes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run: `drush sql:cli`, `SHOW INDEXES FROM node__field_diary_number;`. The database should have an index for field value.
* [ ] Check that decision and case URLs render everything correctly
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR


[UHF-11644]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ