### PR TITLE
UHF-11728: Changed translations if meeting is moved

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/js/meetings_calendar.js
+++ b/public/modules/custom/paatokset_ahjo_api/js/meetings_calendar.js
@@ -217,9 +217,7 @@
             return dayjs(date).weekday();
           },
           meetingMoved(orig_time) {
-            return window.Drupal.t('meeting moved, original time: @orig_time', {
-              '@orig_time': orig_time
-            }, {context: 'Meetings calendar'});
+            return window.Drupal.t('meeting moved', {}, {context: 'Meetings calendar'});
           },
         },
         computed: {

--- a/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Service/MeetingService.php
@@ -153,9 +153,7 @@ class MeetingService {
         $additional_info = $this->t('Meeting cancelled');
       }
       elseif ($orig_timestamp && $orig_timestamp !== $timestamp) {
-        $additional_info = $this->t('Meeting moved, original time: @orig_time', [
-          '@orig_time' => date('d.m. H:i', $orig_timestamp),
-        ]);
+        $additional_info = $this->t('Meeting moved');
         $meeting_moved = TRUE;
       }
 

--- a/public/modules/custom/paatokset_ahjo_api/translations/fi.po
+++ b/public/modules/custom/paatokset_ahjo_api/translations/fi.po
@@ -9,12 +9,12 @@ msgstr "Katso äänestystulos taulukkona"
 msgid "Read motion (Opens in a new tab)"
 msgstr "Lue esitys (Avautuu uuteen välilehteen)"
 
-msgid "Meeting moved, original time: @orig_time"
-msgstr "Kokousta siirretty, alkuperäinen ajankohta: @orig_time"
+msgid "Meeting moved"
+msgstr "Kokousta siirretty"
 
 msgctxt "Meetings calendar"
-msgid "meeting moved, original time: @orig_time"
-msgstr "kokousta siirretty, alkuperäinen ajankohta: @orig_time"
+msgid "meeting moved"
+msgstr "kokousta siirretty"
 
 msgid "There's an error with this attachment. We are resolving the issue as soon as possible."
 msgstr "Liitteen julkaisussa on virhe. Korjaamme virheen mahdollisimman pian."

--- a/public/modules/custom/paatokset_ahjo_api/translations/sv.po
+++ b/public/modules/custom/paatokset_ahjo_api/translations/sv.po
@@ -9,12 +9,12 @@ msgstr "Se röstningsresultatet i tabellform"
 msgid "Read motion (Opens in a new tab)"
 msgstr "Läs motionen (Öppnas i en ny flik)"
 
-msgid "Meeting moved, original time: @orig_time"
-msgstr "Möte flyttade, gammal tid: @orig_time"
+msgid "Meeting moved"
+msgstr "Möte flyttade"
 
 msgctxt "Meetings calendar"
-msgid "meeting moved, original time: @orig_time"
-msgstr "möte flyttade, gammal tid: @orig_time"
+msgid "meeting moved"
+msgstr "möte flyttade"
 
 msgid "There's an error with this attachment. We are resolving the issue as soon as possible."
 msgstr "Det finns ett fel i den publicerade bilagan. Vi rättar till felet så fort som möjligt."


### PR DESCRIPTION
# [UHF-11728](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11728)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed translations in meetings are moved, they should only say meeting is moved and no extra info

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11728`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://helsinki-paatokset.docker.so/fi/kokouskalenteri and make sure on some moved meeting there is only "meeting moved" text
* [x] Go to https://helsinki-paatokset.docker.so/fi/paattajat/kaupunkiymparistolautakunta and make sure under lisätietoja if a meeting is moved it should only say "meeting moved"
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-11728]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ