### PR TITLE
UHF-11708: Fixing an issue where search results didn't update when search phrase was changed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,9 +146,9 @@
             "type": "package",
             "package": {
                 "name": "paatokset/paatokset_search",
-                "version": "1.3.4",
+                "version": "1.3.5",
                 "dist": {
-                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.4/paatokset_search.zip",
+                    "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.5/paatokset_search.zip",
                     "type": "zip"
                 }
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "152c156bafecb17d4fb692ab5743d583",
+    "content-hash": "fd93d7d037609606839f119ebc99b7ce",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10379,10 +10379,10 @@
         },
         {
             "name": "paatokset/paatokset_search",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.4/paatokset_search.zip"
+                "url": "https://github.com/City-of-Helsinki/paatokset-search/releases/download/1.3.5/paatokset_search.zip"
             },
             "type": "library"
         },

--- a/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
+++ b/public/modules/custom/paatokset_search/paatokset_search.libraries.yml
@@ -1,6 +1,6 @@
 paatokset-search:
   remote: https://github.com/City-of-Helsinki/paatokset-search
-  version: 1.3.4
+  version: 1.3.5
   license:
     name: MIT
     url: https://github.com/City-of-Helsinki/asuntomyynti-search/blob/develop/README.md


### PR DESCRIPTION
# [UHF-11708](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11708)

This PR fixes an issue where changing the search phrase would sometimes result in stale results being displayed. This would happen especially after first submitting a search phrase with special operators (like `"`, `*`, `-`, `+` etc.) and then attempting to submit a different phrase (with or without special operators); the results from the previous search would be displayed.

## What was done

A fix was introduced in https://github.com/City-of-Helsinki/paatokset-search/pull/50 and this PR updates to a version of that library with the fix included.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11708_operators`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Make sure the result set is always updated when a new search phrase is submitted
  * Go to https://helsinki-paatokset.docker.so/fi/asia
  * Submit search phrase `viikki +kaava`
  * Then submit `viikki kaava` --> results should update
  * Then submit `viikki +-kaava` --> results should update again
