### PR TITLE
UHF-X: Fix language selector v2

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/includes/paatokset_lang_switcher.php
+++ b/public/modules/custom/paatokset_ahjo_api/includes/paatokset_lang_switcher.php
@@ -143,7 +143,7 @@ function _paatokset_lang_switcher_get_alt_urls_for_routes(RouteMatchInterface $r
     /** @var \Drupal\paatokset_ahjo_api\Entity\CaseBundle|\Drupal\paatokset_ahjo_api\Entity\Decision $caseOrDecision */
     $caseOrDecision = $route->getParameter('case');
 
-    $diaryNumber = $caseOrDecision->getDiaryNumber();
+    $diaryNumber = $caseOrDecision->get('field_diary_number')->value;
 
     // Optimization: Cache guessing so we save on DB queries. This
     // function will be called multiple time for different languages.


### PR DESCRIPTION
I was testing `main` at staging. My language selector fix from #597 does not work properly.

The issue was caused by me rebasing commits to a different order. The issue should not happen after d2560cc510839030a434d3d6d76d2fd525cdd043, which is merged to `dev`, but #592 is not ready for release yet.

This fixes https://sentry.hel.fi/organizations/city-of-helsinki/issues/44982.