### PR TITLE
UHF-11775: Kuulutukset cache purging

### DIFF
--- a/public/modules/custom/paatokset/paatokset.module
+++ b/public/modules/custom/paatokset/paatokset.module
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Drupal\paatokset\Lupapiste\ItemsStorage;
+
 /**
  * Implements hook_theme().
  */
@@ -27,4 +29,16 @@ function paatokset_theme() : array {
       'template' => 'lupapiste-rss-item',
     ],
   ];
+}
+
+/**
+ * Implements hook_cron().
+ */
+function paatokset_cron() : void {
+  // Clear lupapiste RSS-feed cache if it's over 24 hours old (failsafe) or if
+  // the RSS feed was updated since the last fetch.
+  $lupapiste_storage = \Drupal::getContainer()->get(ItemsStorage::class);
+  if ($lupapiste_storage->purgeCacheIfNeeded()) {
+    \Drupal::logger('paatokset')->notice('Cleared caches for Lupapiste RSS feed.');
+  }
 }

--- a/public/modules/custom/paatokset/src/Lupapiste/ItemsImporter.php
+++ b/public/modules/custom/paatokset/src/Lupapiste/ItemsImporter.php
@@ -64,6 +64,7 @@ final class ItemsImporter {
       return $feed->getXpath()->evaluate(sprintf('string(%s/lupapiste:%s)', $prefix, $field));
     };
 
+    $pubDate = $feed->getXpath()->evaluate('string(//channel/pubDate)');
     $items = [];
     $keys = get_class_vars(Item::class);
 
@@ -75,7 +76,10 @@ final class ItemsImporter {
         $items[$delta][$k] = $evaluateXpath($k, $item->getXpathPrefix());
       }
     }
-    return $items;
+    return [
+      'pubDate' => $pubDate,
+      'items' => $items,
+    ];
   }
 
 }

--- a/public/modules/custom/paatokset/src/Lupapiste/ItemsLazyBuilder.php
+++ b/public/modules/custom/paatokset/src/Lupapiste/ItemsLazyBuilder.php
@@ -38,6 +38,7 @@ final class ItemsLazyBuilder implements TrustedCallbackInterface {
     $build = [
       '#cache' => [
         'contexts' => ['languages:language_content', 'url.query_args.pagers'],
+        'tags' => [ItemsStorage::CACHE_TAG],
       ],
       'items' => [
         '#theme' => 'lupapiste_rss_list',

--- a/public/modules/custom/paatokset/src/Lupapiste/ItemsStorage.php
+++ b/public/modules/custom/paatokset/src/Lupapiste/ItemsStorage.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\paatokset\Lupapiste;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\Core\Url;
 use Drupal\paatokset\Lupapiste\DTO\Collection;
 use Drupal\paatokset\Lupapiste\DTO\Item;
@@ -17,6 +20,9 @@ use Symfony\Component\Serializer\SerializerInterface;
 final readonly class ItemsStorage {
 
   public const PER_PAGE = 10;
+  public const CACHE_KEY = 'paatokset.lupapiste_data';
+  public const CACHE_TAG = 'paatokset.lupapiste_data';
+  public const LAST_FETCH_TIMESTAMP = 'paatokset.lupapiste_rss_last_fetch';
 
   /**
    * Constructs a new instance.
@@ -25,13 +31,22 @@ final readonly class ItemsStorage {
    *   The importer.
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache
    *   The cache.
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cacheTagsInvalidator
+   *   The cache tags invalidator.
    * @param \Symfony\Component\Serializer\SerializerInterface $serializer
    *   The serializer.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time.
    */
   public function __construct(
     private ItemsImporter $importer,
     #[Autowire('@cache.default')] private CacheBackendInterface $cache,
+    #[Autowire('@cache_tags.invalidator')] private CacheTagsInvalidatorInterface $cacheTagsInvalidator,
     #[Autowire('@serializer')] private SerializerInterface $serializer,
+    #[Autowire('@state')] private StateInterface $state,
+    #[Autowire('@datetime.time')] private TimeInterface $time,
   ) {
   }
 
@@ -49,6 +64,18 @@ final readonly class ItemsStorage {
   }
 
   /**
+   * Get current RSS feed published timestamp.
+   *
+   * @return int
+   *   The timestamp.
+   */
+  private function getCurrentPublishedTimestamp() : int {
+    $data = $this->importer->fetch('fi');
+    $pubDateTimestamp = $data['pubDate'] ? strtotime($data['pubDate']) : 0;
+    return $pubDateTimestamp;
+  }
+
+  /**
    * Gets the data.
    *
    * @param string $langcode
@@ -58,13 +85,18 @@ final readonly class ItemsStorage {
    *   The data.
    */
   private function getData(string $langcode) : array {
-    $key = sprintf('lupapiste_data_%s', $langcode);
-
-    if ($data = $this->cache->get($key)) {
-      return $data->data;
+    $from_cache = $this->cache->get(self::CACHE_KEY);
+    if ($from_cache && isset($from_cache->data[$langcode])) {
+      return $from_cache->data[$langcode];
     }
-    $items = $this->importer->fetch($langcode);
-    $this->cache->set($key, $items);
+
+    $data = $this->importer->fetch($langcode);
+    $items = $data['items'] ?? [];
+
+    $to_cache = $from_cache ? $from_cache->data : [];
+    $to_cache[$langcode] = $items;
+    $this->cache->set(self::CACHE_KEY, $to_cache);
+    $this->state->set(self::LAST_FETCH_TIMESTAMP, $this->time->getRequestTime());
 
     return $items;
   }
@@ -94,6 +126,31 @@ final readonly class ItemsStorage {
       items: $this->deserialize(json_encode($data)),
       url: Url::fromUri($this->importer->getUri($langcode)),
     );
+  }
+
+  /**
+   * Purge cache if needed.
+   *
+   * @param int $max_age_seconds
+   *   The maximum age of the cache in seconds. Defaults to 24 hours.
+   *
+   * @return bool
+   *   TRUE if cache was purged, FALSE otherwise.
+   */
+  public function purgeCacheIfNeeded(int $max_age_seconds = 86400) : bool {
+    $last_fetched = $this->state->get(self::LAST_FETCH_TIMESTAMP);
+
+    if (
+      $last_fetched < $this->time->getRequestTime() - $max_age_seconds
+      || $last_fetched < $this->getCurrentPublishedTimestamp()
+    ) {
+      $this->cache->delete(self::CACHE_KEY);
+      $this->cacheTagsInvalidator->invalidateTags([self::CACHE_TAG]);
+
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
 }

--- a/public/modules/custom/paatokset/src/Lupapiste/ItemsStorage.php
+++ b/public/modules/custom/paatokset/src/Lupapiste/ItemsStorage.php
@@ -93,7 +93,7 @@ final readonly class ItemsStorage {
 
     $data = $this->importer->fetch($langcode);
     $items = $data['items'] ?? [];
-    $pubDate = $data['pubDate'] ? strtotime($data['pubDate']) : 0;
+    $pubDate = isset($data['pubDate']) ? strtotime($data['pubDate']) : 0;
 
     // Save fetched items to cache.
     $to_cache = $from_cache ? $from_cache->data : [];

--- a/public/modules/custom/paatokset/templates/lupapiste-rss-item.html.twig
+++ b/public/modules/custom/paatokset/templates/lupapiste-rss-item.html.twig
@@ -11,7 +11,7 @@
 } %}
 
 <div class="rss-item__container">
-  <h3>{{ link(item.title, item.link, link_attributes) }}</h3>
+  <h3>{{ link(item.description ?? item.title, item.link, link_attributes) }}</h3>
   <div>
     <div class="rss-item__row-container">
       <div class="rss-item__item">

--- a/public/modules/custom/paatokset/tests/fixtures/rss_en.xml
+++ b/public/modules/custom/paatokset/tests/fixtures/rss_en.xml
@@ -19,13 +19,7 @@
       <lupapiste:paatoksenPykala xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">13</lupapiste:paatoksenPykala>
       <lupapiste:paattaja xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">Rakennustarkastaja</lupapiste:paattaja>
       <lupapiste:asiakirjaLink xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">https://www-qa.lupapiste.fi/api/raw/download-bulletin-doc?bulletinId=LP-049-2025-90341_67d12f9be5770069ee7a654c</lupapiste:asiakirjaLink>
-      <description>Rakennuslupa:
-        Pientalo
-
-        (tarvittaessa:)
-        Aloittamisoikeus
-
-        *****</description>
+      <description>en Rakennuslupa: Pientalo (tarvittaessa:) Aloittamisoikeus *****</description>
       <guid isPermaLink="false">LP-049-2025-90341_67d12f9be5770069ee7a654c</guid>
       <link>https://www-qa.lupapiste.fi/app/fi/local-bulletins?organization=049-R#!/r-bulletin/LP-049-2025-90341_67d12f9be5770069ee7a654c</link>
       <pubDate>Wed, 12 Mar 2025 08:54:15 +0200</pubDate>

--- a/public/modules/custom/paatokset/tests/fixtures/rss_fi.xml
+++ b/public/modules/custom/paatokset/tests/fixtures/rss_fi.xml
@@ -19,13 +19,7 @@
       <lupapiste:paatoksenPykala xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">13</lupapiste:paatoksenPykala>
       <lupapiste:paattaja xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">Rakennustarkastaja</lupapiste:paattaja>
       <lupapiste:asiakirjaLink xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">https://www-qa.lupapiste.fi/api/raw/download-bulletin-doc?bulletinId=LP-049-2025-90341_67d12f9be5770069ee7a654c</lupapiste:asiakirjaLink>
-      <description>Rakennuslupa:
-        Pientalo
-
-        (tarvittaessa:)
-        Aloittamisoikeus
-
-        *****</description>
+      <description>fi Rakennuslupa: Pientalo (tarvittaessa:) Aloittamisoikeus *****</description>
       <guid isPermaLink="false">LP-049-2025-90341_67d12f9be5770069ee7a654c</guid>
       <link>https://www-qa.lupapiste.fi/app/fi/local-bulletins?organization=049-R#!/r-bulletin/LP-049-2025-90341_67d12f9be5770069ee7a654c</link>
       <pubDate>Wed, 12 Mar 2025 08:54:15 +0200</pubDate>

--- a/public/modules/custom/paatokset/tests/fixtures/rss_sv.xml
+++ b/public/modules/custom/paatokset/tests/fixtures/rss_sv.xml
@@ -19,13 +19,7 @@
       <lupapiste:paatoksenPykala xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">13</lupapiste:paatoksenPykala>
       <lupapiste:paattaja xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">Rakennustarkastaja</lupapiste:paattaja>
       <lupapiste:asiakirjaLink xmlns:lupapiste="https://www.lupapiste.fi/rss/extensions">https://www-qa.lupapiste.fi/api/raw/download-bulletin-doc?bulletinId=LP-049-2025-90341_67d12f9be5770069ee7a654c</lupapiste:asiakirjaLink>
-      <description>Rakennuslupa:
-        Pientalo
-
-        (tarvittaessa:)
-        Aloittamisoikeus
-
-        *****</description>
+      <description>sv Rakennuslupa: Pientalo (tarvittaessa:) Aloittamisoikeus *****</description>
       <guid isPermaLink="false">LP-049-2025-90341_67d12f9be5770069ee7a654c</guid>
       <link>https://www-qa.lupapiste.fi/app/fi/local-bulletins?organization=049-R#!/r-bulletin/LP-049-2025-90341_67d12f9be5770069ee7a654c</link>
       <pubDate>Wed, 12 Mar 2025 08:54:15 +0200</pubDate>

--- a/public/modules/custom/paatokset/tests/src/Kernel/Lupapiste/ItemsImporterTest.php
+++ b/public/modules/custom/paatokset/tests/src/Kernel/Lupapiste/ItemsImporterTest.php
@@ -66,21 +66,18 @@ class ItemsImporterTest extends KernelTestBase {
       'paatoksenPykala' => '13',
       'paattaja' => 'Rakennustarkastaja',
       'asiakirjaLink' => 'https://www-qa.lupapiste.fi/api/raw/download-bulletin-doc?bulletinId=LP-049-2025-90341_67d12f9be5770069ee7a654c',
-      'description' => 'Rakennuslupa:
-        Pientalo
-
-        (tarvittaessa:)
-        Aloittamisoikeus
-
-        *****',
+      'description' => 'fi Rakennuslupa: Pientalo (tarvittaessa:) Aloittamisoikeus *****',
       'link' => 'https://www-qa.lupapiste.fi/app/fi/local-bulletins?organization=049-R#!/r-bulletin/LP-049-2025-90341_67d12f9be5770069ee7a654c',
       'pubDate' => 'Wed, 12 Mar 2025 08:54:15 +0200',
       'title' => 'fi Asuinkerrostalon tai rivitalon rakentaminen',
     ];
 
     $data = $importer->fetch('fi');
-    $this->assertCount(2, $data);
-    $this->assertEquals($expected, $data[0]);
+    $items = $data['items'];
+    $pubDate = $data['pubDate'];
+    $this->assertCount(2, $items);
+    $this->assertEquals($expected, $items[0]);
+    $this->assertEquals('Wed, 12 Mar 2025 08:54:15 +0200', $pubDate);
   }
 
 }

--- a/public/modules/custom/paatokset/tests/src/Kernel/Plugin/Block/LupapisteRssBlockTest.php
+++ b/public/modules/custom/paatokset/tests/src/Kernel/Plugin/Block/LupapisteRssBlockTest.php
@@ -69,7 +69,7 @@ class LupapisteRssBlockTest extends KernelTestBase {
       $block = LupapisteRssBlock::create($this->container, [], '', ['provider' => 'paatokset']);
       $build = $block->build();
       $rendered = $renderer->renderInIsolation($build);
-      $this->assertStringContainsString($expected . ' Asuinkerrostalon tai rivitalon rakentaminen', (string) $rendered);
+      $this->assertStringContainsString($expected . ' Rakennuslupa: Pientalo (tarvittaessa:) Aloittamisoikeus *****', (string) $rendered);
     }
   }
 

--- a/public/themes/custom/hdbt_subtheme/templates/misc/lupapiste-rss-item.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/misc/lupapiste-rss-item.html.twig
@@ -10,7 +10,7 @@
   ]
 } %}
 
-{% set link_title = item.title ~ ' ' ~ '(download pdf)'|t({}, {'context': 'Lupapiste rss'}) %}
+{% set link_title = item.description ?? item.title ~ ' ' ~ '(download pdf)'|t({}, {'context': 'Lupapiste rss'}) %}
 
 <div class="rss-item__container">
   <h3>{{ link(link_title, item.asiakirjaLink, link_attributes) }}</h3>


### PR DESCRIPTION
# [UHF-11775](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11775)

RSS-feed based content in https://paatokset.hel.fi/fi/kuulutukset-ja-ilmoitukset/rakennusvalvonnan-lupapaatokset is currently not updated when RSS feed is, and instead a manual cache clear is needed.

## What was done

A cron based cache clear method was added, which purges relevant caches when

- The RSS-feed has updated (tracked via a state variable)
- The last update was more than 24 hours ago (tracked via a state variable, serves as a failsafe)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11775_rss-cache-purging`
  * `make fresh`
* Run `make drush-cr`

## How to test

- Check that you have the required taxonomy term "Rakennusvalvonnan lupapäätökset" with url-alias `/kuulutukset-ja-ilmoitukset/rakennusvalvonnan-lupapaatokset` in "Article keywords"-vocabulary, create if needed.
- Go to https://helsinki-paatokset.docker.so/fi/kuulutukset-ja-ilmoitukset/rakennusvalvonnan-lupapaatokset as an anonymous user
  - [ ] You should see a list of announcements
  - [ ] Reload the page and check the response headers; `X-Drupal-Cache` should say `HIT`
- Test caches are not cleared when content is up-to-date
  - Run `drush cron`
  - [ ] You should NOT see a message "Cleared caches for Lupapiste RSS feed."
  - [ ] Reload the page and check the response headers; `X-Drupal-Cache` should say `HIT`
- Test caches are cleared when the last fetch was over 24 hours ago
  - Run `drush state:set paatokset.lupapiste_rss_last_fetch 0`
  - Run `drush cron`
  - [ ] You SHOULD see a message "Cleared caches for Lupapiste RSS feed."
  - [ ] Reload the page and check the response headers; `X-Drupal-Cache` should say `UNCACHEABLE`
  - [ ] Reload the page again and check the response headers; `X-Drupal-Cache` should now say `HIT`
  - [ ] Run `drush state:get paatokset.lupapiste_rss_last_fetch`; you should see a value other than 0.
- Test caches are cleared when the RSS-feed is updated
  - Run `drush state:set paatokset.lupapiste_rss_last_pubdate 0`
  - Run `drush cron`
  - [ ] You SHOULD see a message "Cleared caches for Lupapiste RSS feed."
  - [ ] Reload the page and check the response headers; `X-Drupal-Cache` should say `UNCACHEABLE`
  - [ ] Reload the page again and check the response headers; `X-Drupal-Cache` should now say `HIT`
  - [ ] Run `drush state:get paatokset.lupapiste_rss_last_pubdate`; you should see a value other than 0.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation
