### PR TITLE
UHF-11629: Correctly import existing status for organizations

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/source/AhjoOrganizationSource.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/source/AhjoOrganizationSource.php
@@ -169,7 +169,7 @@ final class AhjoOrganizationSource extends AhjoSourceBase implements ContainerFa
       'id' => $current['ID'],
       'name' => $title,
       'langcode' => $langcode,
-      'existing' => $this->isDissolved($current),
+      'existing' => !$this->isDissolved($current),
       'organization_above' => $parent['ID'] ?? NULL,
     ];
   }

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Entity/OrganizationTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Entity/OrganizationTest.php
@@ -43,8 +43,15 @@ class OrganizationTest extends RemoteEntityAccessTestBase {
       'id' => '00400',
       'label' => 'Kaupunginhallitus',
       'organization_above' => $root,
+      'existing' => 1,
     ]);
     $child->save();
+    Organization::create([
+      'id' => '900',
+      'label' => 'Puheenjohtaja',
+      'organization_above' => $child,
+      'existing' => 0,
+    ])->save();
 
     $this->assertInstanceOf(Organization::class, $root);
     $this->assertEquals($root->id(), $child->getParentOrganization()?->id());
@@ -53,6 +60,7 @@ class OrganizationTest extends RemoteEntityAccessTestBase {
     $this->assertOrganizationHierarchyIds([$root->id()], $root->getOrganizationHierarchy());
     $this->assertOrganizationHierarchyIds([$root->id(), $child->id()], $child->getOrganizationHierarchy());
 
+    // Dissolved organizations (existing = 0) should not be visible.
     $this->assertEmpty($child->getChildOrganizations());
     $this->assertNotEmpty($root->getChildOrganizations());
   }


### PR DESCRIPTION
# [UHF-11629](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11629)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Organizations should have `existing = 1` if they are published. Previously, the migration set `existing = 1` if they were dissolved. 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11629-org-charg-component-v2`
  * `make new`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run: `drush migrate-import --reset-threshold 1 ahjo_organizations --no-progress` 4 times.
* [ ] Check: `https://helsinki-paatokset.docker.so/fi/ahjo_api/org-chart/02900/3`. It should not show dissolved organizations, like `ID 900, Puheenjohtaja`
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/955


[UHF-11629]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ