### PR TITLE
UHF-11178: Add policymaker urls to ahjo org chart responses

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoApiController.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Controller/AhjoApiController.php
@@ -6,9 +6,11 @@ namespace Drupal\paatokset_ahjo_api\Controller;
 
 use Drupal\Core\Cache\CacheableJsonResponse;
 use Drupal\Core\Cache\CacheableMetadata;
-use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\paatokset_ahjo_api\Entity\Organization;
+use Drupal\paatokset_ahjo_api\Entity\Policymaker;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
@@ -21,13 +23,21 @@ class AhjoApiController extends ControllerBase {
    * Get org chart.
    */
   public function getOrgChart(Organization $ahjo_organization, int $steps): Response {
-    $language = $this->languageManager()->getCurrentLanguage()->getId();
+    $language = $this->languageManager()->getCurrentLanguage();
+    $langcode = $language->getId();
+
+    $organisationIds = [];
+    $cacheMetadata = new CacheableMetadata();
+    $organisations = $this->buildOrgCharg($ahjo_organization, $organisationIds, $cacheMetadata, $steps, $langcode);
+
+    // Recursively iterate the organization chart
+    // and add policymakers node URLs to the response.
+    $this->addUrlsToOrgChart($organisations, $this->loadPolicymakers($organisationIds), $language);
 
     $response = new CacheableJsonResponse();
-    $response->setData($this->buildOrgCharg($ahjo_organization, $response, $steps, $language));
+    $response->setData($organisations);
 
     // Cache by current language.
-    $cacheMetadata = new CacheableMetadata();
     $cacheMetadata->addCacheContexts(['languages:language_content']);
     $response->addCacheableDependency($cacheMetadata);
 
@@ -37,18 +47,20 @@ class AhjoApiController extends ControllerBase {
   /**
    * Build org chart.
    */
-  private function buildOrgCharg(Organization $organization, CacheableResponseInterface $response, int $steps, string $langcode): array {
+  private function buildOrgCharg(Organization $organization, array &$ids, RefinableCacheableDependencyInterface $cacheMetadata, int $steps, string $langcode): array {
     // Do not allow too expensive requests.
     if ($steps > 5) {
       throw new BadRequestHttpException();
     }
+
+    $ids[] = $organization->id();
 
     $data = [
       'id' => $organization->id(),
       'title' => $organization->label(),
     ];
 
-    $response->addCacheableDependency($organization);
+    $cacheMetadata->addCacheableDependency($organization);
 
     if ($steps > 1) {
       foreach ($organization->getChildOrganizations() as $child) {
@@ -56,11 +68,70 @@ class AhjoApiController extends ControllerBase {
           $child = $child->getTranslation($langcode);
         }
 
-        $data['children'][] = $this->buildOrgCharg($child, $response, $steps - 1, $langcode);
+        $data['children'][] = $this->buildOrgCharg($child, $ids, $cacheMetadata, $steps - 1, $langcode);
       };
     }
 
     return $data;
+  }
+
+  /**
+   * Alter org chart by adding policymaker node urls.
+   *
+   * @param array $orgChart
+   *   Organization chart.
+   * @param array<string,\Drupal\paatokset_ahjo_api\Entity\Policymaker> $policymakers
+   *   Policymakers keyed by organization ids.
+   * @param \Drupal\Core\Language\LanguageInterface $language
+   *   The link language.
+   */
+  private function addUrlsToOrgChart(array &$orgChart, array $policymakers, LanguageInterface $language): void {
+    $policymaker = $policymakers[$orgChart['id']] ?? NULL;
+
+    // Not all organizations have policymaker pages.
+    if ($policymaker instanceof Policymaker) {
+      $orgChart['url'] = $policymaker->toUrl('canonical', ['absolute' => TRUE, 'language' => $language])->toString();
+    }
+
+    if (!empty($orgChart['children'])) {
+      foreach ($orgChart['children'] as &$child) {
+        $this->addUrlsToOrgChart($child, $policymakers, $language);
+      }
+    }
+  }
+
+  /**
+   * Load policymakers.
+   *
+   * @param array $organisationIds
+   *   List of organization ids.
+   *
+   * @return array<string,\Drupal\paatokset_ahjo_api\Entity\Policymaker>
+   *   Policymakers keyed by organization ids.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function loadPolicymakers(array $organisationIds): array {
+    $nodeStorage = $this->entityTypeManager()
+      ->getStorage('node');
+
+    // Load all policymakers from the org chart.
+    $ids = $nodeStorage
+      ->getQuery()
+      ->accessCheck()
+      ->condition('type', 'policymaker')
+      ->condition('field_policymaker_id', $organisationIds, 'IN')
+      ->condition('status', '1')
+      ->execute();
+
+    $policymakers = $nodeStorage->loadMultiple($ids);
+
+    // Change array keys to organization id.
+    $keys = array_map(static fn (Policymaker $policymaker) => $policymaker->getPolicymakerId(), $policymakers);
+
+    /** @var array<string, \Drupal\paatokset_ahjo_api\Entity\Policymaker> */
+    return array_combine($keys, $policymakers);
   }
 
 }


### PR DESCRIPTION
# [UHF-11178](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11178`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that https://helsinki-paatokset.docker.so/fi/ahjo_api/org-chart/00400/4 returns urls to policymaker nodes.
* [x] Check that code follows our standards


[UHF-11178]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ