### PR TITLE
UHF-11721

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
@@ -41,3 +41,6 @@ services:
     tags:
         - { name: event_subscriber }
 
+  Drupal\paatokset_ahjo_api\AhjoRequestLoggerMiddleware:
+    tags:
+      - { name: http_client_middleware }

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.services.yml
@@ -36,3 +36,8 @@ services:
     arguments: [ "@paatokset_ahjo_cases" ]
 
   Drupal\paatokset_ahjo_api\Service\OrganizationPathBuilder: ~
+
+  Drupal\paatokset_ahjo_api\EventSubscriber\RequestLoggerEventSubscriber:
+    tags:
+        - { name: event_subscriber }
+

--- a/public/modules/custom/paatokset_ahjo_api/src/AhjoRequestLoggerMiddleware.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/AhjoRequestLoggerMiddleware.php
@@ -28,18 +28,25 @@ class AhjoRequestLoggerMiddleware {
   /**
    * The invoke-method.
    *
+   * @param callable $handler
+   *   The handler.
+   *
    * @return callable
    *   The callable
    */
   public function __invoke(): callable {
-    return function (RequestInterface $request) {
-      $uri = $request->getUri();
-      if (
-        !str_contains($uri->getHost(), 'proxy') &&
-        str_contains($uri->getHost(), 'ahjo')
-      ) {
-        $this->logger->debug('Sending Ahjo migration request to ' . $uri);
-      }
+    $logger = $this->logger;
+    return function (callable $handler) use ($logger) {
+      return function (RequestInterface $request, array $options) use ($handler, $logger) {
+        $uri = $request->getUri();
+        if (
+          !str_contains($uri->getHost(), 'proxy') &&
+          str_contains($uri->getHost(), 'ahjo')
+        ) {
+          $logger->debug('Sending Ahjo migration request to ' . $uri);
+        }
+        return $handler($request, $options);
+      };
     };
   }
 

--- a/public/modules/custom/paatokset_ahjo_api/src/AhjoRequestLoggerMiddleware.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/AhjoRequestLoggerMiddleware.php
@@ -28,9 +28,6 @@ class AhjoRequestLoggerMiddleware {
   /**
    * The invoke-method.
    *
-   * @param callable $handler
-   *   The handler.
-   *
    * @return callable
    *   The callable
    */

--- a/public/modules/custom/paatokset_ahjo_api/src/AhjoRequestLoggerMiddleware.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/AhjoRequestLoggerMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\paatokset_ahjo_api;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Guzzle middleware for logging Ahjo-requests.
+ */
+class AhjoRequestLoggerMiddleware {
+
+  /**
+   * The constructor.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger channel.
+   */
+  public function __construct(
+    #[Autowire(service: 'logger.channel.paatokset_ahjo_api')]
+    private readonly LoggerChannelInterface $logger,
+  ) {
+  }
+
+  /**
+   * The invoke-method.
+   *
+   * @return callable
+   *   The callable
+   */
+  public function __invoke(): callable {
+    return function (RequestInterface $request) {
+      $uri = $request->getUri();
+      if (
+        !str_contains($uri->getHost(), 'proxy') &&
+        str_contains($uri->getHost(), 'ahjo')
+      ) {
+        $this->logger->debug('Sending Ahjo migration request to ' . $uri);
+      }
+    };
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
@@ -10,10 +10,14 @@ use Drupal\migrate\Event\MigrateImportEvent;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * Ahjo api eventsubscriber.
+ */
 class RequestLoggerEventSubscriber implements EventSubscriberInterface {
 
   /**
    * The constructor.
+   *
    * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
    */
   public function __construct(

--- a/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\paatokset_ahjo_api\EventSubscriber;
+
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\migrate\Event\MigrateEvents;
+use Drupal\migrate\Event\MigrateImportEvent;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class RequestLoggerEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The constructor.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   */
+  public function __construct(
+    #[Autowire(service: 'logger.channel.paatokset_ahjo_api')]
+    private readonly LoggerChannelInterface $logger,
+  ) {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [MigrateEvents::PRE_IMPORT => 'preImport'];
+  }
+
+  /**
+   * Temporary logging to find out used ahjo api endpoints.
+   *
+   * @param \Drupal\migrate\Event\MigrateImportEvent $event
+   *   The event.
+   */
+  public function preImport(MigrateImportEvent $event): void {
+    $sourceUrls = $event->getMigration()->getSourceConfiguration()['urls'];
+
+    foreach ($sourceUrls as $url) {
+      if (
+        !str_contains($url, 'ahjo-proxy') &&
+        str_contains($url, 'ahjo')
+      ) {
+        $this->logger->debug('Sending Ahjo migration request to ' . $url);
+        break;
+      }
+    }
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
@@ -19,6 +19,7 @@ class RequestLoggerEventSubscriber implements EventSubscriberInterface {
    * The constructor.
    *
    * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   The logger.
    */
   public function __construct(
     #[Autowire(service: 'logger.channel.paatokset_ahjo_api')]

--- a/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/EventSubscriber/RequestLoggerEventSubscriber.php
@@ -44,7 +44,6 @@ class RequestLoggerEventSubscriber implements EventSubscriberInterface {
         str_contains($url, 'ahjo')
       ) {
         $this->logger->debug('Sending Ahjo migration request to ' . $url);
-        break;
       }
     }
   }


### PR DESCRIPTION
# [UHF-11721](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11721)

## What was done

Added eventlistener which writes ahjo api requests to log.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11721`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Run a migration
- The Eventsubscriber should trigger

The guzzle middleware:
If you don't figure a better way:
- Change the middleware code a bit, change the if statement to accept google and add an echo before the logging.
- run `drush-cr`
- run `drush php:cli`
  - run `\Drupal::service('http_client')->get('https://www.google.fi');`
- url should be logger (or the echo should be printed).

[UHF-11721]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ