### PR TITLE
UHF-11863: Added support for open all accordions

### DIFF
--- a/public/modules/custom/paatokset_policymakers/templates/component/policymaker-accordions.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/component/policymaker-accordions.html.twig
@@ -5,11 +5,15 @@
     'component--accordion',
     'component--accordion-bg-white',
     'component--accordion-policymakers',
-    'component--hardcoded',
   ],
   component_content_class: 'accordion',
 } %}
   {% block component_content %}
+
+    <button type="button" class="accordion-item__button js-accordion__button--toggle-all accordion__button--is-open is-hidden">
+      <span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Open all'|t({}, {'context': 'Accordion open all'}) }}</span>
+    </button>
+
     {% for accordion in accordions|filter(accordion => accordion is not empty) %}
 
       {% set accordion_content %}

--- a/public/modules/custom/paatokset_policymakers/templates/content/minutes.html.twig
+++ b/public/modules/custom/paatokset_policymakers/templates/content/minutes.html.twig
@@ -88,11 +88,13 @@
           'component--accordion',
           'component--accordion-bg-white',
           'component--accordion-minutes',
-          'component--hardcoded'
         ],
         component_content_class: 'accordion',
       } %}
         {% block component_content %}
+          <button type="button" class="accordion-item__button js-accordion__button--toggle-all accordion__button--is-open is-hidden">
+            <span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Open all'|t({}, {'context': 'Accordion open all'}) }}</span>
+          </button>
           {% for accordion in decision_announcement.accordions %}
             {% set accordion_content %}
               {{ accordion.content }}

--- a/public/themes/custom/hdbt_subtheme/templates/components/decision-content.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/components/decision-content.html.twig
@@ -63,11 +63,13 @@
       component_classes: [
         'component--accordion',
         'component--accordion-bg-white',
-        'component--hardcoded'
       ],
       component_content_class: 'accordion',
     } %}
       {% block component_content %}
+        <button type="button" class="accordion-item__button js-accordion__button--toggle-all accordion__button--is-open is-hidden">
+          <span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Open all'|t({}, {'context': 'Accordion open all'}) }}</span>
+        </button>
         {% if vote_results %}
           {% include '@hdbt_subtheme/components/decision-voting-results.html.twig' %}
         {% endif %}

--- a/public/themes/custom/hdbt_subtheme/templates/components/decision-voting-results.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/components/decision-voting-results.html.twig
@@ -6,13 +6,15 @@
         'component--accordion',
         'component--accordion-bg-white',
         'component--accordion--voting-result',
-        'component--hardcoded',
       ],
       component_content_class: 'accordion',
       component_title_level: 'h4',
       component_title: 'Voting'|t({}, {'context': 'Voting results'}) ~ ' ' ~ loop.index,
     } %}
       {% block component_content %}
+        <button type="button" class="accordion-item__button js-accordion__button--toggle-all accordion__button--is-open is-hidden">
+          <span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Open all'|t({}, {'context': 'Accordion open all'}) }}</span>
+        </button>
         {% if results.accordions.Ayes.Content %}
           <p><strong>{{ 'Ayes'|t }}:</strong> {{ results.accordions.Ayes.Content }}</p>
         {% endif %}

--- a/public/themes/custom/hdbt_subtheme/templates/content/node--trustee.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/node--trustee.html.twig
@@ -161,12 +161,13 @@
       'component--accordion',
       'component--accordion-bg-white',
       'component--accordion-trustee',
-      'component--hardcoded'
     ],
     component_content_class: 'accordion',
   } %}
     {% block component_content %}
-
+      <button type="button" class="accordion-item__button js-accordion__button--toggle-all accordion__button--is-open is-hidden">
+        <span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Open all'|t({}, {'context': 'Accordion open all'}) }}</span>
+      </button>
       {% if speaking_turns.content is not empty %}
         {% set speaking_turns_content %}
           {% for year, statements in speaking_turns.content %}


### PR DESCRIPTION
# [UHF-11863](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11863)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed component--hardcoded class since it prevents open all from working
* Added Open all accordion buttons to all hdbt accordions

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11863`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11863`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Make sure the "Avaa kaikki" functionality works for the accordions listed below. Test also that localStorage works by refreshing the page etc.
  * [x] https://helsinki-paatokset.docker.so/fi/asia/hel-2018-010750?paatos=bd99664f-394e-c115-a3a1-91c115f00006
  * [x] https://helsinki-paatokset.docker.so/fi/paattajat/kasvatus-ja-koulutuslautakunta/asiakirjat/U42020255#paatostiedote
  * [x] https://helsinki-paatokset.docker.so/fi/paattajat/exlhilkkaahde
  * [x] https://helsinki-paatokset.docker.so/fi/paattajat
  * [x] Check that code follows our standards
* [x] Make sure "Avaa kaikki" button has color black defined (fixes issue on iOS safari and chrome)

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1295


[UHF-11863]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ