### PR TITLE
UHF-11863: Removed open all from voting results

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/components/decision-voting-results.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/components/decision-voting-results.html.twig
@@ -12,9 +12,6 @@
       component_title: 'Voting'|t({}, {'context': 'Voting results'}) ~ ' ' ~ loop.index,
     } %}
       {% block component_content %}
-        <button type="button" class="accordion-item__button js-accordion__button--toggle-all accordion__button--is-open is-hidden">
-          <span {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>{{ 'Open all'|t({}, {'context': 'Accordion open all'}) }}</span>
-        </button>
         {% if results.accordions.Ayes.Content %}
           <p><strong>{{ 'Ayes'|t }}:</strong> {{ results.accordions.Ayes.Content }}</p>
         {% endif %}


### PR DESCRIPTION
# [UHF-11863](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11863)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed open all from voting result accordion as per requested by client

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11863-remove-open-all`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://helsinki-paatokset.docker.so/fi/asia/hel-2018-010750?paatos=bd99664f-394e-c115-a3a1-91c115f00006 and test the accordion. 
  * [ ] The outer "avaa kaikki" should also open the voting results accordion and close it as well
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-11863]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ