### PR TITLE
UHF-11554 Lupapiste datetime (draft)

### DIFF
--- a/public/modules/custom/paatokset/paatokset.services.yml
+++ b/public/modules/custom/paatokset/paatokset.services.yml
@@ -18,9 +18,9 @@ services:
     public: false
     arguments:
       $defaultContext:
-        datetime_format: 'D, d M Y H:i:s T'
+        datetime_format: 'D, d M Y H:i:s O'
     tags:
-      - { name: normalizer }
+      - { name: normalizer, priority: 1 }
 
   paatokset.normalizer.object:
     class: Symfony\Component\Serializer\Normalizer\ObjectNormalizer

--- a/public/modules/custom/paatokset/src/Lupapiste/ItemsStorage.php
+++ b/public/modules/custom/paatokset/src/Lupapiste/ItemsStorage.php
@@ -60,7 +60,7 @@ final readonly class ItemsStorage {
    * @return \Drupal\paatokset\Lupapiste\DTO\Item[]
    *   The deserialized data.
    */
-  private function deserialize(string $data) : array {
+  public function deserialize(string $data) : array {
     return $this->serializer->deserialize($data, Item::class . '[]', 'json');
   }
 

--- a/public/modules/custom/paatokset/tests/src/Kernel/Lupapiste/ItemsStorageTest.php
+++ b/public/modules/custom/paatokset/tests/src/Kernel/Lupapiste/ItemsStorageTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\paatokset\Kernel\Lupapiste;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\paatokset\Lupapiste\DTO\Item;
+use Drupal\paatokset\Lupapiste\ItemsImporter;
 use Drupal\paatokset\Lupapiste\ItemsStorage;
 use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 use GuzzleHttp\Psr7\Response;
@@ -102,7 +103,7 @@ class ItemsStorageTest extends KernelTestBase {
       new Response(body: $this->getFixture('paatokset', 'rss_fi.xml')),
     ]));
 
-    // Last fetched timestamp is less than treshold, and latest published
+    // Last fetched timestamp is less than threshold, and latest published
     // date is the same as latest feed; should not clear cache.
     $this->state->set(ItemsStorage::LAST_FETCH_TIMESTAMP, $this->time->getRequestTime() - self::CACHE_MAX_AGE + 1);
     $this->state->set(ItemsStorage::LAST_PUBDATE_TIMESTAMP, strtotime('Wed, 12 Mar 2025 08:54:15 +0200'));
@@ -155,6 +156,49 @@ class ItemsStorageTest extends KernelTestBase {
     $itemStorage = $this->container->get(ItemsStorage::class);
     $is_cleared = $itemStorage->purgeCacheIfNeeded(self::CACHE_MAX_AGE);
     $this->assertTrue($is_cleared);
+  }
+
+  /**
+   * Test the custom DateTimeNormalizer.
+   */
+  public function testDateTimeNormalizer(): void {
+    /** @var \Symfony\Component\Serializer\Serializer $serializer */
+    $serializer = $this->container->get('serializer');
+
+    $dateString = 'Wed, 12 Mar 2025 08:54:15 +0200';
+
+    // Deserialize to a \DateTimeInterface using the custom format.
+    $date = $serializer->denormalize($dateString, \DateTimeInterface::class, 'json');
+
+    $this->assertInstanceOf(\DateTimeInterface::class, $date);
+    $this->assertEquals('2025-03-12 08:54:15', $date->format('Y-m-d H:i:s'));
+
+    // Serialize back — it should use the custom format.
+    $normalized = $serializer->normalize($date);
+    $this->assertEquals($dateString, $normalized);
+  }
+
+  /**
+   * Test deserialize method.
+   */
+  public function testDeserialize(): void {
+    $httpClient = $this->createMockHttpClient([
+      new Response(body: $this->getFixture('paatokset', 'rss_fi.xml')),
+    ]);
+    $importer = new ItemsImporter($httpClient);
+    $data = $importer->fetch('fi');
+
+    /** @var \Drupal\paatokset\Lupapiste\ItemsStorage $storage */
+    $storage = $this->container->get(ItemsStorage::class);
+    $items = $storage->deserialize(json_encode($data['items']));
+
+    $this->assertContainsOnlyInstancesOf(Item::class, $items);
+    $publicationStart = new \DateTime('2025-03-13 00:00:00', new \DateTimeZone('+2'));
+    $publicationEnd = new \DateTime('2025-04-22 23:59:59', new \DateTimeZone('+3'));
+    $this->assertEquals($publicationStart, $items[0]->julkaisuAlkaa);
+    $this->assertEquals($publicationEnd, $items[0]->julkaisuPaattyy);
+    $this->assertEquals('Rakennustarkastaja', $items[0]->paattaja);
+    $this->assertEquals('fi Asuinkerrostalon tai rivitalon rakentaminen', $items[0]->title);
   }
 
 }


### PR DESCRIPTION
# [UHF-11554](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11554)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed the datetime format to use "O" timezone and set the priority higher than the original datetime service.
* Test the datetime normalizer and the deserialize method.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11554`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the starting and ending dates are correctly rendered and not `now()`
   * https://helsinki-paatokset.docker.so/fi/kuulutukset-ja-ilmoitukset/rakennusvalvonnan-lupapaatokset
* [ ] Check that code follows our standards


[UHF-11554]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ