### PR TITLE
UHF-11016: Removed duplicate big pipe patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,9 +114,6 @@
         "patches": {
             "drupal/default_content": {
                 "Don't reimport translations": "https://www.drupal.org/files/issues/2020-10-14/default_content-3176839-2.patch"
-            },
-            "drupal/core": {
-                "[UHF-10839]: Fix missing theme suggestions for status messages in BigPipe https://www.drupal.org/i/3456176": "https://raw.githubusercontent.com/City-of-Helsinki/helsinki-paatokset/8abc6661bb216ae19b9c6e1cd461d00493f9617b/patches/big_pipe_status_message_fix.patch"
             }
         },
         "patchLevel": {


### PR DESCRIPTION
# [UHF-11016](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11016)

There's another patch in the Platform config module that fixes this issue.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11016
  * `composer install`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Edit any node and save it
* [ ] Make sure the status message doesn't show html tags

