### PR TITLE
UHF-12020

### DIFF
--- a/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
+++ b/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
@@ -329,10 +329,8 @@ class InfoImportForm extends FormBase {
       count($results['items']),
       count($results['failed']),
     );
-    $logger = \Drupal::logger('paatokset_council_info');
-    $logger->info($message);
-    $messenger = \Drupal::messenger();
-    $messenger->addMessage($message);
+    \Drupal::logger('paatokset_council_info')->info($message);
+    \Drupal::messenger()->addMessage($message);
   }
 
 }

--- a/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
+++ b/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
@@ -301,32 +301,14 @@ class InfoImportForm extends FormBase {
    *   Mapped field ID or NULL.
    */
   public static function getFieldKey(string $header): ?string {
-    switch ($header) {
-      case "Kotikaupunginosa":
-        $key = 'field_trustee_home_district';
-        break;
-
-      case "Puhelinnumero verkossa":
-        $key = 'field_trustee_phone';
-        break;
-
-      case "Sähköposti verkossa":
-        $key = 'field_trustee_email';
-        break;
-
-      case "Kotisivu":
-        $key = 'field_trustee_homepage';
-        break;
-
-      case "Ammatti":
-        $key = 'field_trustee_profession';
-        break;
-
-      default:
-        $key = NULL;
-        break;
-    }
-    return $key;
+    return match($header) {
+      'Kotikaupunginosa' => 'field_trustee_home_district',
+      'Puhelinnumero verkossa' => 'field_trustee_phone',
+      'Sähköposti verkossa' => 'field_trustee_email',
+      'Kotisivu' => 'field_trustee_homepage',
+      'Ammatti' => 'field_trustee_profession',
+      default => NULL,
+    };
   }
 
   /**
@@ -340,7 +322,13 @@ class InfoImportForm extends FormBase {
    *   Operations with errors.
    */
   public static function finishedCallback($success, array $results, array $operations) {
-    $message = 'Processed ' . count($results['items']) . ' items with ' . count($results['failed']) . ' items failed.';
+    $total = count($results['items']) + count($results['failed']);
+    $message = sprintf(
+      'Total items: %d. Updated %d items and %d items failed',
+      $total,
+      count($results['items']),
+      count($results['failed']),
+    );
     $logger = \Drupal::logger('paatokset_council_info');
     $logger->info($message);
     $messenger = \Drupal::messenger();

--- a/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
+++ b/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
@@ -114,7 +114,7 @@ class InfoImportForm extends FormBase {
       $file_id = $form_state->getValue('existing_info_file');
     }
     else {
-      $this->messenger->addError('File missing.');
+      $this->messenger()->addError('File missing.');
       return;
     }
 
@@ -122,12 +122,12 @@ class InfoImportForm extends FormBase {
     $file = $file_storage->load($file_id);
 
     if (!$file instanceof FileInterface) {
-      $this->messenger->addError('File could not be loaded.');
+      $this->messenger()->addError('File could not be loaded.');
       return;
     }
 
     if ($file->get('filemime')->value !== 'text/csv') {
-      $this->messenger->addError('File must be a CSV file.');
+      $this->messenger()->addError('File must be a CSV file.');
       return;
     }
 
@@ -135,19 +135,19 @@ class InfoImportForm extends FormBase {
     if ($file_setting === 'permanent') {
       $file->setPermanent();
       $file->save();
-      $this->messenger->addMessage('File is now stored permanently.');
+      $this->messenger()->addMessage('File is now stored permanently.');
     }
     elseif ($file_setting === 'temporary') {
       $file->setTemporary();
       $file->save();
-      $this->messenger->addMessage('File storage set to temporary.');
+      $this->messenger()->addMessage('File storage set to temporary.');
     }
 
     try {
       $csv_reader = $this->getCsvReader($file);
     }
     catch (\Exception $e) {
-      $this->messenger->addMessage($e->getMessage(), 'error');
+      $this->messenger()->addMessage($e->getMessage(), 'error');
       return;
     }
 
@@ -164,7 +164,7 @@ class InfoImportForm extends FormBase {
     }
 
     if (empty($operations)) {
-      $this->messenger->addWarning('Nothing to import');
+      $this->messenger()->addWarning('Nothing to import');
       return;
     }
 

--- a/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
+++ b/public/modules/custom/paatokset_council_info/src/Form/InfoImportForm.php
@@ -191,6 +191,14 @@ class InfoImportForm extends FormBase {
    */
   protected function getCsvReader(FileInterface $file): Reader {
     $contents = file_get_contents($file->getFileUri());
+
+    // #UHF-12020 Contents would not contain scandics.
+    $contents = mb_convert_encoding(
+      $contents,
+      'UTF-8',
+      mb_detect_encoding($contents, 'UTF-8, ISO-8859-1', TRUE)
+    );
+
     $reader = Reader::createFromString($contents);
     $reader->setDelimiter(';');
     $reader->setHeaderOffset(0);
@@ -257,7 +265,7 @@ class InfoImportForm extends FormBase {
       }
 
       // Trim whitespace.
-      if ($value instanceof string) {
+      if (is_string($value)) {
         $value = trim($value);
       }
 


### PR DESCRIPTION
# [UHF-12020](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12020)
CSV importer to update trustees did not work because file data was missing scandics. 

## What was done
* Fixed the file upload
* Fixed the messenger-messages
* Minor code fixes

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12020`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Ask the author for proper csv-file
* Go check [node 767](https://helsinki-paatokset.docker.so/fi/node/767/edit) email address field value
  * should be "something at gmail.com"
* Go to [this page](https://helsinki-paatokset.docker.so/fi/admin/config/system/council-import)
* Upload the csv file, select No change
* Run uploader
* Go check that the node 767 email field has updated

