### PR TITLE
UHF-11554: Enable change tracking for ahjo_org_composition migration

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_org_composition.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_org_composition.yml
@@ -18,6 +18,7 @@ source:
   orgs: active
   # Some url is required by HttpSourcePluginBase.
   url: 'https://ahjo.hel.fi:9802/ahjorest/v1/organization/decisionmakingorganizations'
+  track_changes: true
 process:
   type:
     plugin: default_value


### PR DESCRIPTION
# [UHF-11554](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11554)
<!-- What problem does this solve? -->

Some organization data was not imported correctly due to changes in the source API that were not detected by the migration. Adding `track_changes: true` ensures that modified entries are re-imported even if they already exist.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] If your DB dump is not from today, org composition on [/fi/paattajat/U480310](https://helsinki-paatokset.docker.so/[fi/paattajat/U480310) should [not match the API](https://paatokset.hel.fi/fi/ahjo-proxy/decisionmaker/single/U480310).
* [ ] Run [org migrate command](https://github.com/City-of-Helsinki/helsinki-paatokset/blob/dev/docker/openshift/crons/run-aggregated-ahjo-integrations.sh#L57), the org composition on [/fi/paattajat/U480310](https://helsinki-paatokset.docker.so/[fi/paattajat/U480310) should match the api.
* [ ] Check that code follows our standards

[UHF-11554]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ