### PR TITLE
UHF-11986: Fix lupapiste items without link.

### DIFF
--- a/public/modules/custom/paatokset/README.md
+++ b/public/modules/custom/paatokset/README.md
@@ -5,7 +5,7 @@ Lupapiste RSS block shows the RSS feed from lupapiste. It's set to be visible in
 As a default the block is shown on /kuulutukset-ja-ilmoitukset/rakennusvalvonnan-lupapaatokset but it can be changed with drush command
 
 ``
-drush state:set lupapiste '/new-value-here'
+drush state:set lupapiste_url '/new-value-here'
 ``
 
 To check what value is set

--- a/public/themes/custom/hdbt_subtheme/templates/misc/lupapiste-rss-item.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/misc/lupapiste-rss-item.html.twig
@@ -13,7 +13,11 @@
 {% set link_title = item.description ?? item.title ~ ' ' ~ '(download pdf)'|t({}, {'context': 'Lupapiste rss'}) %}
 
 <div class="rss-item__container">
+  {% if item.asiakirjaLink %}
   <h3>{{ link(link_title, item.asiakirjaLink, link_attributes) }}</h3>
+  {% else %}
+  <h3>{{ item.title }}</h3>
+  {% endif %}
   <div>
     <div class="rss-item__row-container">
       <div class="rss-item__item">
@@ -38,7 +42,7 @@
       <div class="rss-item__item">
         <span>{{ 'Decision maker'|t({}, {'context': 'Lupapiste rss'}) }}:</span> {{ item.paattaja }}
       </div>
-    </div>    
+    </div>
   </div>
   <div class="rss-item__publication-date">
     <span>{{ 'Publication starts'|t({}, {'context': 'Lupapiste rss'}) }} {{ item.julkaisuAlkaa.date|date('U')|format_date('publication_date_format')}}.</span>


### PR DESCRIPTION
# [UHF-11986](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11986)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* [LP-091-2025-00674](https://www.lupapiste.fi/app/fi/local-bulletins?organization=091-R#!/r-bulletin/LP-091-2025-00674_68a69a466cc3366d2ccce034) does not contain asiakirjaLink field, which crashed the rendering.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11986-lupapiste`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] [/kuulutukset-ja-ilmoitukset/rakennusvalvonnan-lupapaatokset](https://helsinki-paatokset.docker.so/fi/kuulutukset-ja-ilmoitukset/rakennusvalvonnan-lupapaatokset) should work
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR
