### PR TITLE
Update hdbt_subtheme.libraries.yml

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.libraries.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.libraries.yml
@@ -18,7 +18,7 @@ paatokset_submenu:
     dist/js/paatokset_submenus.min.js: {}
 
 allu-decisions-search:
-  version: 1.0.1
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/allu-decisions-search.min.js: {
       attributes: {
@@ -31,7 +31,7 @@ allu-decisions-search:
     - core/drupal
 
 decisions-search:
-  version: 2.0.0
+  version: HELFI_DEPLOYMENT_IDENTIFIER
   js:
     dist/js/decisions-search.min.js: {
       attributes: {


### PR DESCRIPTION
Subtheme libraries should use [HELFI_DEPLOYMENT_IDENTIFIER](https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/blob/main/documentation/asset-versioning.md#asset-versioning), so we bust caches on deploy.