### PR TITLE
Fixed issue with policymaker sidebar navigation

### DIFF
--- a/conf/cmi/block.block.policymakermobilenavigation.yml
+++ b/conf/cmi/block.block.policymakermobilenavigation.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - node
     - paatokset_ahjo_api
     - system
   theme:
@@ -24,11 +23,3 @@ visibility:
     id: request_path
     negate: false
     pages: "/paattajat/*\r\n/beslutsfattare/*\r\n/decisionmakers/*\r\n"
-  'entity_bundle:node':
-    id: 'entity_bundle:node'
-    negate: false
-    context_mapping:
-      node: '@node.node_route_context:node'
-    bundles:
-      policymaker: policymaker
-      trustee: trustee

--- a/conf/cmi/block.block.policymakersidenavigation.yml
+++ b/conf/cmi/block.block.policymakersidenavigation.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - node
     - paatokset_ahjo_api
     - system
   theme:
@@ -24,11 +23,3 @@ visibility:
     id: request_path
     negate: false
     pages: "/paattajat/*\r\n/beslutsfattare/*\r\n/decisionmakers/*"
-  'entity_bundle:node':
-    id: 'entity_bundle:node'
-    negate: false
-    context_mapping:
-      node: '@node.node_route_context:node'
-    bundles:
-      policymaker: policymaker
-      trustee: trustee

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -401,6 +401,17 @@ function paatokset_policymakers_preprocess_page(&$variables) {
     $variables['move_before_content'] = TRUE;
     $variables['has_section_nav'] = TRUE;
 
+    // Some `page` nodes are injected into policymaker side nav, e.g.
+    // https://paatokset.hel.fi/fi/paattajat/kaupunginvaltuusto/aloitteet.
+    // Policymaker sidenavigation is set to be visible only on trustee
+    // and policymaker pages, in order to fix an issue with normal sidebar navigation.
+    // We need to force it to be visible on these `page` nodes as well.
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = \Drupal::routeMatch()->getParameter('node');
+    if (!$node instanceof \Drupal\node\NodeInterface) {
+      $variables['policymaker_navigation'] = TRUE;
+    }
+
     // Unset main navigation.
     unset($variables['page']['sidebar_first']['hdbt_subtheme_main_navigation_level_2']);
   }
@@ -409,7 +420,7 @@ function paatokset_policymakers_preprocess_page(&$variables) {
     $variables['move_before_content'] = TRUE;
     $variables['has_section_nav'] = TRUE;
 
-    // Force pm sidebar and mobile navi to be visible.
+    // Force policymaker sidebar and mobile navi to be visible.
     $variables['policymaker_navigation'] = TRUE;
 
     // Unset main navigation.

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -418,6 +418,7 @@ function paatokset_policymakers_preprocess_page(&$variables) {
   // Unset policymaker side navi.
   else {
     unset($variables['page']['sidebar_first']['policymakersidenavigation']);
+    unset($variables['page']['before_content']['policymakermobilenavigation']);
   }
 }
 

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -404,11 +404,12 @@ function paatokset_policymakers_preprocess_page(&$variables) {
     // Some `page` nodes are injected into policymaker side nav, e.g.
     // https://paatokset.hel.fi/fi/paattajat/kaupunginvaltuusto/aloitteet.
     // Policymaker sidenavigation is set to be visible only on trustee
-    // and policymaker pages, in order to fix an issue with normal sidebar navigation.
-    // We need to force it to be visible on these `page` nodes as well.
+    // and policymaker pages, in order to fix an issue with normal sidebar
+    // navigation. We need to force it to be visible on these `page`
+    // nodes as well.
     /** @var \Drupal\node\NodeInterface $node */
     $node = \Drupal::routeMatch()->getParameter('node');
-    if (!$node instanceof \Drupal\node\NodeInterface) {
+    if (!$node instanceof NodeInterface) {
       $variables['policymaker_navigation'] = TRUE;
     }
 

--- a/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
+++ b/public/modules/custom/paatokset_policymakers/paatokset_policymakers.module
@@ -401,18 +401,6 @@ function paatokset_policymakers_preprocess_page(&$variables) {
     $variables['move_before_content'] = TRUE;
     $variables['has_section_nav'] = TRUE;
 
-    // Some `page` nodes are injected into policymaker side nav, e.g.
-    // https://paatokset.hel.fi/fi/paattajat/kaupunginvaltuusto/aloitteet.
-    // Policymaker sidenavigation is set to be visible only on trustee
-    // and policymaker pages, in order to fix an issue with normal sidebar
-    // navigation. We need to force it to be visible on these `page`
-    // nodes as well.
-    /** @var \Drupal\node\NodeInterface $node */
-    $node = \Drupal::routeMatch()->getParameter('node');
-    if (!$node instanceof NodeInterface) {
-      $variables['policymaker_navigation'] = TRUE;
-    }
-
     // Unset main navigation.
     unset($variables['page']['sidebar_first']['hdbt_subtheme_main_navigation_level_2']);
   }


### PR DESCRIPTION


## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fixed issue where policymaker sidebar navigation wasn't visible on non node subpages 

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-X-policymaker-sidenav-fix`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [x] Go to https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus/asiakirjat and make sure the sidebar navigation is visible
* [x] Go to https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginhallitus and make sure the sidebar nav is visible only once
* [ ] Edit the url of this page https://helsinki-paatokset.docker.so/fi/paatoksenteko/kaupunginvaltuusto/helsingin-valtuustoryhmien-yhteystiedot to be /paattajat instead of /paatoksenteko
   * [ ] Make sure the sidebar navigation menu toggle still works (relates to this https://github.com/City-of-Helsinki/helsinki-paatokset/pull/890)
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* 
