### PR TITLE
UHF-12147: Updating paatokset:decisions:delete command to allow running it in testing

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/src/Drush/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Drush/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -42,8 +42,8 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
   #[Command(name: 'paatokset:decisions:delete')]
   public function databaseCleanup(?string $dateFrom = NULL): int {
 
-    if (getenv('APP_ENV') !== 'local') {
-      $this->io()->writeln('Stopping execution. APP_ENV is not "local" or is missing.');
+    if (!in_array(getenv('APP_ENV'), ['local', 'testing'], TRUE)) {
+      $this->io()->writeln('Stopping execution. APP_ENV is not "local" or "testing".');
       return DrushCommands::EXIT_SUCCESS;
     }
 


### PR DESCRIPTION
# [UHF-12147](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12147)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* This will allow us to decrease the db size in testing by removing all decisions older than 6 months, resulting in db dump size decrease from ~9GB to ~3GB.

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->


[UHF-12147]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ