### PR TITLE
UHF-13250: Updating database clear command

### DIFF
--- a/docker/openshift/hooks/db-replace/99-clean.sh
+++ b/docker/openshift/hooks/db-replace/99-clean.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+drush paatokset:decisions:delete

--- a/public/modules/custom/paatokset_ahjo_api/src/Drush/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Drush/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -7,45 +7,66 @@ namespace Drupal\paatokset_ahjo_api\Drush\Commands;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
-use Drush\Attributes\Command;
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drush\Commands\AutowireTrait;
-use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * A drush command to clean up database for development purpose.
  */
-final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
+#[AsCommand(
+  name: self::NAME,
+  description: 'Deletes old decision nodes from the database.',
+)]
+final class DevelopmentDatabaseCleanerCommand extends Command {
 
   use AutowireTrait;
 
-  /**
-   * Constructs a new instance.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager service.
-   */
+  public const NAME = 'paatokset:decisions:delete';
+
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly EnvironmentResolverInterface $environmentResolver,
   ) {
     parent::__construct();
   }
 
   /**
-   * Deletes the old decisions.
-   *
-   * @param ?string $dateFrom
-   *   Decisions older than given date will be removed from database.
-   *
-   * @return int
-   *   The exit code.
+   * {@inheritdoc}
    */
-  #[Command(name: 'paatokset:decisions:delete')]
-  public function databaseCleanup(?string $dateFrom = NULL): int {
+  protected function configure(): void {
+    $this->addArgument(
+      'date-from',
+      InputArgument::OPTIONAL,
+      'Decisions older than given date will be removed from database.',
+    );
+  }
 
-    if (getenv('APP_ENV') !== 'local') {
-      $this->io()->writeln('Stopping execution. APP_ENV is not "local" or is missing.');
-      return DrushCommands::EXIT_SUCCESS;
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output): int {
+    try {
+      $appEnv = $this->environmentResolver->getActiveEnvironmentName();
     }
+    catch (\InvalidArgumentException) {
+      $output->writeln('Stopping execution. No active environment found.');
+      return self::SUCCESS;
+    }
+
+    // Only allowed in local and test environments.
+    if (!in_array($appEnv, [EnvironmentEnum::Local->value, EnvironmentEnum::Test->value], TRUE)) {
+      $output->writeln('Stopping execution. App environment is not "local" or "test".');
+      return self::SUCCESS;
+    }
+
+    /** @var ?string $dateFrom */
+    $dateFrom = $input->getArgument('date-from');
 
     $nodeStorage = $this->entityTypeManager->getStorage('node');
     $query = $nodeStorage->getQuery()->accessCheck(FALSE);
@@ -67,7 +88,7 @@ final class DevelopmentDatabaseCleanerCommand extends DrushCommands {
       }
     }
 
-    return DrushCommands::EXIT_SUCCESS;
+    return self::SUCCESS;
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Unit/Commands/DevelopmentDatabaseCleanerCommandTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Unit/Commands/DevelopmentDatabaseCleanerCommandTest.php
@@ -218,7 +218,7 @@ class DevelopmentDatabaseCleanerCommandTest extends UnitTestCase {
 
   /**
    * Mocks node storage that returns and deletes the given node ids.
-   * 
+   *
    * @phpstan-param list<int> $nodeIds
    *
    * @phpstan-return \Prophecy\Prophecy\ObjectProphecy<\Drupal\Core\Entity\EntityStorageInterface>

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Unit/Commands/DevelopmentDatabaseCleanerCommandTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Unit/Commands/DevelopmentDatabaseCleanerCommandTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_ahjo_api\Unit\Commands;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
+use Drupal\paatokset_ahjo_api\Drush\Commands\DevelopmentDatabaseCleanerCommand;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Tests DevelopmentDatabaseCleanerCommand.
+ */
+#[Group('paatokset_ahjo_api')]
+class DevelopmentDatabaseCleanerCommandTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('en');
+
+    $languageManager = $this->createMock(LanguageManagerInterface::class);
+    $languageManager->method('getCurrentLanguage')->willReturn($language);
+
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('language_manager', $languageManager);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Tests that missing environment stops execution.
+   */
+  public function testStopsWhenNoActiveEnvironment(): void {
+    $environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $environmentResolver->getActiveEnvironmentName()
+      ->willThrow(new \InvalidArgumentException());
+
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage(Argument::any())->shouldNotBeCalled();
+
+    $tester = $this->createCommandTester(
+      $environmentResolver->reveal(),
+      $entityTypeManager->reveal(),
+    );
+
+    $tester->execute([]);
+    $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+    $this->assertStringContainsString(
+      'Stopping execution. No active environment found.',
+      $tester->getDisplay(),
+    );
+  }
+
+  /**
+   * Tests that disallowed environments stop execution.
+   */
+  #[DataProvider('disallowedEnvironmentProvider')]
+  public function testStopsWhenEnvironmentIsNotLocalOrTest(string $environment): void {
+    $environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $environmentResolver->getActiveEnvironmentName()->willReturn($environment);
+
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage(Argument::any())->shouldNotBeCalled();
+
+    $tester = $this->createCommandTester(
+      $environmentResolver->reveal(),
+      $entityTypeManager->reveal(),
+    );
+
+    $tester->execute([]);
+    $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+    $this->assertStringContainsString(
+      'Stopping execution. App environment is not "local" or "test".',
+      $tester->getDisplay(),
+    );
+  }
+
+  /**
+   * Data provider for disallowed environments.
+   *
+   * @phpstan-return array<string, array{string}>
+   */
+  public static function disallowedEnvironmentProvider(): array {
+    return [
+      'dev' => [EnvironmentEnum::Dev->value],
+      'stage' => [EnvironmentEnum::Stage->value],
+      'prod' => [EnvironmentEnum::Prod->value],
+    ];
+  }
+
+  /**
+   * Tests that decisions are deleted in local environment.
+   */
+  public function testDeletesDecisionsInLocalEnvironment(): void {
+    $this->assertDecisionsAreDeleted(EnvironmentEnum::Local->value);
+  }
+
+  /**
+   * Tests that decisions are deleted in test environment.
+   */
+  public function testDeletesDecisionsInTestEnvironment(): void {
+    $this->assertDecisionsAreDeleted(EnvironmentEnum::Test->value);
+  }
+
+  /**
+   * Tests that a custom date argument is used in the query.
+   */
+  public function testUsesCustomDateFrom(): void {
+    $dateFrom = '2020-06-15';
+    $formattedDate = $this->formatDecisionDate($dateFrom);
+
+    $environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $environmentResolver->getActiveEnvironmentName()->willReturn(EnvironmentEnum::Local->value);
+
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage('node')->willReturn(
+      $this->mockNodeStorage([42], $formattedDate)->reveal(),
+    );
+
+    $tester = $this->createCommandTester(
+      $environmentResolver->reveal(),
+      $entityTypeManager->reveal(),
+    );
+
+    $tester->execute(['date-from' => $dateFrom]);
+    $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+  }
+
+  /**
+   * Tests that deletion continues in batches until no ids are returned.
+   */
+  public function testDeletesDecisionsInBatches(): void {
+    $environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $environmentResolver->getActiveEnvironmentName()->willReturn(EnvironmentEnum::Local->value);
+
+    $query = $this->prophesize(QueryInterface::class);
+    $query->accessCheck(FALSE)->willReturn($query->reveal());
+    $query->condition('type', 'decision')->willReturn($query->reveal());
+    $query->condition('field_decision_date', Argument::type('string'), '<')->willReturn($query->reveal());
+    $query->range(0, 100)->willReturn($query->reveal());
+    $query->execute()->willReturn([1], [2], []);
+
+    $nodeStorage = $this->prophesize(EntityStorageInterface::class);
+    $nodeStorage->getQuery()->willReturn($query->reveal());
+
+    foreach ([1, 2] as $id) {
+      $node = $this->prophesize(ContentEntityInterface::class);
+      $node->delete()->shouldBeCalled();
+      $nodeStorage->load($id)->willReturn($node->reveal());
+    }
+
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage('node')->willReturn($nodeStorage->reveal());
+
+    $tester = $this->createCommandTester(
+      $environmentResolver->reveal(),
+      $entityTypeManager->reveal(),
+    );
+
+    $tester->execute([]);
+    $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+  }
+
+  /**
+   * Asserts that matching decision nodes are deleted for given environment.
+   */
+  private function assertDecisionsAreDeleted(string $environment): void {
+    $environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $environmentResolver->getActiveEnvironmentName()->willReturn($environment);
+
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage('node')->willReturn(
+      $this->mockNodeStorage([1, 2])->reveal(),
+    );
+
+    $tester = $this->createCommandTester(
+      $environmentResolver->reveal(),
+      $entityTypeManager->reveal(),
+    );
+
+    $tester->execute([]);
+    $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+  }
+
+  /**
+   * Creates a command tester for the database cleaner command.
+   */
+  private function createCommandTester(
+    EnvironmentResolverInterface $environmentResolver,
+    EntityTypeManagerInterface $entityTypeManager,
+  ): CommandTester {
+    $command = new DevelopmentDatabaseCleanerCommand($entityTypeManager, $environmentResolver);
+
+    return new CommandTester($command);
+  }
+
+  /**
+   * Mocks node storage that returns and deletes the given node ids.
+   * 
+   * @phpstan-param list<int> $nodeIds
+   *
+   * @phpstan-return \Prophecy\Prophecy\ObjectProphecy<\Drupal\Core\Entity\EntityStorageInterface>
+   */
+  private function mockNodeStorage(array $nodeIds, ?string $expectedDate = NULL): object {
+    $query = $this->prophesize(QueryInterface::class);
+    $query->accessCheck(FALSE)->willReturn($query->reveal());
+    $query->condition('type', 'decision')->willReturn($query->reveal());
+
+    if ($expectedDate !== NULL) {
+      $query->condition('field_decision_date', $expectedDate, '<')
+        ->shouldBeCalled()
+        ->willReturn($query->reveal());
+    }
+    else {
+      $query->condition('field_decision_date', Argument::type('string'), '<')
+        ->willReturn($query->reveal());
+    }
+
+    $query->range(0, 100)->willReturn($query->reveal());
+    $query->execute()->willReturn($nodeIds, []);
+
+    $nodeStorage = $this->prophesize(EntityStorageInterface::class);
+    $nodeStorage->getQuery()->willReturn($query->reveal());
+
+    foreach ($nodeIds as $id) {
+      $node = $this->prophesize(ContentEntityInterface::class);
+      $node->delete()->shouldBeCalled();
+      $nodeStorage->load($id)->willReturn($node->reveal());
+    }
+
+    return $nodeStorage;
+  }
+
+  /**
+   * Formats a date the same way as the command does.
+   */
+  private function formatDecisionDate(string $dateFrom): string {
+    $date = new \DateTime($dateFrom);
+    $date->setTimezone(new \DateTimezone(DateTimeItemInterface::STORAGE_TIMEZONE));
+
+    return $date->format(DateTimeItemInterface::DATETIME_STORAGE_FORMAT);
+  }
+
+}


### PR DESCRIPTION
# [UHF-13250](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13250)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Updated `drush paatokset:decisions:delete` to work in `local` and `test` -environments.
* Refactored the command to extend Symfony console command instead of DrushCommands.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13250`
* Run code updates
  * `composer install`
  * `make drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] OPTIONAL (this will take a long time): Run `drush paatokset:decisions:delete` and make sure decisions older than 6 months were removed.
* [ ] Final test is to run the `database-management`-pipeline in paatokset after merging both PR's, and make sure old decisions are removed in test environment.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* https://dev.azure.com/City-of-Helsinki/paatokset/_git/paatokset-pipelines/pullrequest/16311


[UHF-13250]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ