### PR TITLE
UHF-X: Fix double-encoding issue in discussion minutes list

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -11,6 +11,8 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
 use Drupal\node\Entity\Node;
 use Drupal\paatokset_ahjo_api\Entity\Initiative;
 use Drupal\paatokset_ahjo_api\Entity\Trustee;
@@ -70,6 +72,25 @@ function hdbt_subtheme_theme_suggestions_media_alter(array &$suggestions, array 
   $entity = $variables['elements']['#media'];
   if (!empty($entity->view) && $entity->view->storage->id()) {
     $suggestions[] = 'media__view__' . $entity->view->storage->id();
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Provides a Url object for the discussion minutes file link so it is encoded
+ * exactly once. The pre-encoded string from Twig's file_url() would be
+ * re-encoded when passed through link()/Url::fromUri() (e.g. %20 -> %2520).
+ */
+function hdbt_subtheme_preprocess_media__view__policymaker_discussion_minutes(array &$variables): void {
+  $media = $variables['media'] ?? $variables['elements']['#media'] ?? NULL;
+  if (!$media instanceof MediaInterface) {
+    return;
+  }
+
+  $file = $media->get('field_document')->entity;
+  if ($file instanceof FileInterface) {
+    $variables['document_url'] = \Drupal::service('file_url_generator')->generate($file->getFileUri());
   }
 }
 

--- a/public/themes/custom/hdbt_subtheme/templates/content/media--view--policymaker-discussion-minutes.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/media--view--policymaker-discussion-minutes.html.twig
@@ -14,7 +14,7 @@
   card_modifier_class: 'card--border',
   card_title_level: 'h4',
   card_title: name ~ ' (PDF)',
-  card_url: 'internal:' ~ file_url(media.field_document.entity.uri.value),
+  card_url: document_url,
   card_url_external: true,
   card_metas: card_metas,
 } %}


### PR DESCRIPTION
# [UHF-X](https://helsinkisolutionoffice.atlassian.net/browse/UHF-X)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fix double-encoding issue that caused malformed links in disucssion minutes list

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-X-fix-discussions-minutes-list`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* Open up this list https://helsinki-paatokset.docker.so/fi/paattajat/kaupunginvaltuusto/asiakirjat?year=2024
* Check out formatting of the link
  * They should look like: `/sites/default/files/2024-07/11 Kvsto 19062024.pdf`
  * What they shouldn't look like: `/sites/default/files/2024-07/11%2520Kvsto%252019062024.pdf`
  * The links still won't work locally unless you pull the correct data

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

