### PR TITLE
UHF-13250: Adding a timeout database cleanup hook

### DIFF
--- a/docker/openshift/hooks/db-replace/99-clean.sh
+++ b/docker/openshift/hooks/db-replace/99-clean.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-drush paatokset:decisions:delete
+# Clear maintenance mode to allow access to the site while cleaning up
+# the database.
+drush state:set system.maintenance_mode 0 --input-format=integer
+
+# Delete old decisions. Allow it to run for max 5 hours.
+drush paatokset:decisions:delete --timeout=18000

--- a/public/modules/custom/paatokset_ahjo_api/src/Drush/Commands/DevelopmentDatabaseCleanerCommand.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Drush/Commands/DevelopmentDatabaseCleanerCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -45,12 +46,22 @@ final class DevelopmentDatabaseCleanerCommand extends Command {
       InputArgument::OPTIONAL,
       'Decisions older than given date will be removed from database.',
     );
+    $this->addOption(
+      name: 'timeout',
+      shortcut: 't',
+      description: 'Timeout in seconds. If the command takes longer than the timeout, it will be stopped.',
+      mode: InputOption::VALUE_REQUIRED,
+      default: 0,
+    );
   }
 
   /**
    * {@inheritdoc}
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
+    $start = time();
+    $timeout = (int) $input->getOption('timeout');
+
     try {
       $appEnv = $this->environmentResolver->getActiveEnvironmentName();
     }
@@ -82,9 +93,16 @@ final class DevelopmentDatabaseCleanerCommand extends Command {
       ->range(0, 100);
 
     while ($ids = $query->execute()) {
+      if ($timeout > 0 && time() - $start > $timeout) {
+        $output->writeln('Stopping execution. Timeout reached.');
+        return self::SUCCESS;
+      }
+
       foreach ($ids as $id) {
         $node = $nodeStorage->load($id);
-        $node->delete();
+        if ($node) {
+          $node->delete();
+        }
       }
     }
 

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Unit/Commands/DevelopmentDatabaseCleanerCommandTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Unit/Commands/DevelopmentDatabaseCleanerCommandTest.php
@@ -184,6 +184,82 @@ class DevelopmentDatabaseCleanerCommandTest extends UnitTestCase {
   }
 
   /**
+   * Tests that execution stops when the timeout is reached.
+   */
+  public function testStopsWhenTimeoutReached(): void {
+    $environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $environmentResolver->getActiveEnvironmentName()->willReturn(EnvironmentEnum::Local->value);
+
+    $query = $this->prophesize(QueryInterface::class);
+    $query->accessCheck(FALSE)->willReturn($query->reveal());
+    $query->condition('type', 'decision')->willReturn($query->reveal());
+    $query->condition('field_decision_date', Argument::type('string'), '<')->willReturn($query->reveal());
+    $query->range(0, 100)->willReturn($query->reveal());
+    // Sleep past the timeout before returning the first batch.
+    $query->execute()->will(function (): array {
+      sleep(2);
+      return [1];
+    });
+
+    $nodeStorage = $this->prophesize(EntityStorageInterface::class);
+    $nodeStorage->getQuery()->willReturn($query->reveal());
+    $nodeStorage->load(Argument::any())->shouldNotBeCalled();
+
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage('node')->willReturn($nodeStorage->reveal());
+
+    $tester = $this->createCommandTester(
+      $environmentResolver->reveal(),
+      $entityTypeManager->reveal(),
+    );
+
+    $tester->execute(['--timeout' => 1]);
+    $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+    $this->assertStringContainsString(
+      'Stopping execution. Timeout reached.',
+      $tester->getDisplay(),
+    );
+  }
+
+  /**
+   * Tests that non-positive timeout values are ignored.
+   */
+  #[DataProvider('nonPositiveTimeoutProvider')]
+  public function testIgnoresNonPositiveTimeout(int $timeout): void {
+    $environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $environmentResolver->getActiveEnvironmentName()->willReturn(EnvironmentEnum::Local->value);
+
+    $entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $entityTypeManager->getStorage('node')->willReturn(
+      $this->mockNodeStorage([1, 2])->reveal(),
+    );
+
+    $tester = $this->createCommandTester(
+      $environmentResolver->reveal(),
+      $entityTypeManager->reveal(),
+    );
+
+    $tester->execute(['--timeout' => $timeout]);
+    $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+    $this->assertStringNotContainsString(
+      'Stopping execution. Timeout reached.',
+      $tester->getDisplay(),
+    );
+  }
+
+  /**
+   * Data provider for non-positive timeout values.
+   *
+   * @phpstan-return array<string, array{int}>
+   */
+  public static function nonPositiveTimeoutProvider(): array {
+    return [
+      'zero' => [0],
+      'negative' => [-1],
+    ];
+  }
+
+  /**
    * Asserts that matching decision nodes are deleted for given environment.
    */
   private function assertDecisionsAreDeleted(string $environment): void {


### PR DESCRIPTION
# [UHF-13250](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13250)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Added a timeout option to database cleaner drush command
* Updated the db replace cleanup hook script to disable maintenance mode before starting the lengthy cleanup process, and using the timeout option to allow it to run for max 5 hours

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13250_p2`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Try running the cleanup command with the new timeout option: `drush paatokset:decisions:delete --timeout=10`; the command loops in batches of 100 decisions and always checks the timeout before starting a new batch, so the actual runtime will be a bit more than 10 seconds, but shouldn't be much more.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->


[UHF-13250]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ