### PR TITLE
UHF-13394: Updating ahjo_trustees migration to handle a integrity constraint violation

### DIFF
--- a/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_trustees.yml
+++ b/public/modules/custom/paatokset_ahjo_api/migrations/ahjo_trustees.yml
@@ -62,8 +62,7 @@ process:
     plugin: default_value
     default_value: fi
   nid:
-    plugin: callback
-    callable: _paatokset_ahjo_api_lookup_trustee_nid
+    plugin: ahjo_trustee_nid
     source: agent_id
   title:
     plugin: default_value

--- a/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
+++ b/public/modules/custom/paatokset_ahjo_api/paatokset_ahjo_api.module
@@ -649,29 +649,6 @@ function _paatokset_ahjo_api_lookup_decision_nid(array $values): ?string {
 }
 
 /**
- * Lookup trustee nodes by Agent ID.
- *
- * @param string $agent_id
- *   Agent ID.
- *
- * @return string|null
- *   Existing nid, if found.
- */
-function _paatokset_ahjo_api_lookup_trustee_nid(string $agent_id): ?string {
-  $query = Drupal::entityQuery('node')
-    ->accessCheck(TRUE)
-    ->condition('type', 'trustee')
-    ->condition('field_trustee_id', $agent_id)
-    ->range(0, 1)
-    ->latestRevision();
-  $ids = $query->execute();
-  if (empty($ids)) {
-    return NULL;
-  }
-  return reset($ids);
-}
-
-/**
  * Lookup meeting nodes by meeting ID.
  *
  * @param string $meeting_id

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoTrusteeNid.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoTrusteeNid.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\paatokset_ahjo_api\Plugin\migrate\process;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\Attribute\MigrateProcess;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Looks up an existing trustee nid and heals stale migrate map rows.
+ *
+ * When the migrate map destination id does not match the trustee node found by
+ * agent id (field_trustee_id), the map row is deleted so the entity destination
+ * updates the correct node instead of inserting a duplicate.
+ *
+ * Available configuration keys:
+ * - source: The Ahjo agent id.
+ *
+ * Example:
+ *
+ * @code
+ * process:
+ *   nid:
+ *     plugin: ahjo_trustee_nid
+ *     source: agent_id
+ * @endcode
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ */
+#[MigrateProcess('ahjo_trustee_nid')]
+final class AhjoTrusteeNid extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-param array<string, mixed> $configuration
+   */
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    mixed $plugin_definition,
+    private readonly MigrationInterface $migration,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerInterface $logger,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-param array<string, mixed> $configuration
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?MigrationInterface $migration = NULL): static {
+    assert($migration instanceof MigrationInterface);
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $migration,
+      $container->get('entity_type.manager'),
+      $container->get('logger.channel.paatokset_ahjo_api'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property): ?string {
+    if ($value === NULL || $value === '') {
+      return NULL;
+    }
+
+    $agent_id = (string) $value;
+    $actual_nid = $this->lookupTrusteeNid($agent_id);
+
+    $id_map = $this->migration->getIdMap();
+    $mapped = $id_map->lookupDestinationIds($row->getSourceIdValues());
+    if ($mapped) {
+      $mapped_nid = (string) reset($mapped)[0];
+      if ($mapped_nid !== ($actual_nid ?? '')) {
+        $this->logger->notice('Removing stale migrate map entry for trustee @agent_id (mapped nid @mapped, actual nid @actual).', [
+          '@agent_id' => $agent_id,
+          '@mapped' => $mapped_nid,
+          '@actual' => $actual_nid ?? 'NULL',
+        ]);
+        $id_map->delete($row->getSourceIdValues());
+      }
+    }
+
+    return $actual_nid;
+  }
+
+  /**
+   * Looks up an existing trustee node by Ahjo agent id.
+   */
+  private function lookupTrusteeNid(string $agent_id): ?string {
+    $ids = $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'trustee')
+      ->condition('field_trustee_id', $agent_id)
+      ->range(0, 1)
+      ->latestRevision()
+      ->execute();
+
+    if ($ids === []) {
+      return NULL;
+    }
+
+    return (string) reset($ids);
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoTrusteeNid.php
+++ b/public/modules/custom/paatokset_ahjo_api/src/Plugin/migrate/process/AhjoTrusteeNid.php
@@ -66,7 +66,7 @@ final class AhjoTrusteeNid extends ProcessPluginBase implements ContainerFactory
       $plugin_id,
       $plugin_definition,
       $migration,
-      $container->get('entity_type.manager'),
+      $container->get(EntityTypeManagerInterface::class),
       $container->get('logger.channel.paatokset_ahjo_api'),
     );
   }
@@ -106,7 +106,7 @@ final class AhjoTrusteeNid extends ProcessPluginBase implements ContainerFactory
     $ids = $this->entityTypeManager
       ->getStorage('node')
       ->getQuery()
-      ->accessCheck(TRUE)
+      ->accessCheck(FALSE)
       ->condition('type', 'trustee')
       ->condition('field_trustee_id', $agent_id)
       ->range(0, 1)
@@ -117,7 +117,7 @@ final class AhjoTrusteeNid extends ProcessPluginBase implements ContainerFactory
       return NULL;
     }
 
-    return (string) reset($ids);
+    return (string) array_first($ids);
   }
 
 }

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\paatokset_ahjo_api\Kernel\Migrate;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
+use Drupal\node\Entity\Node;
+use Drupal\paatokset_ahjo_api\Plugin\migrate\process\AhjoTrusteeNid;
+use Drupal\Tests\paatokset_ahjo_api\Kernel\AhjoEntityKernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use PHPUnit\Framework\Attributes\Group;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the `ahjo_trustee_nid` process plugin.
+ */
+#[Group('paatokset_ahjo_api')]
+class AhjoTrusteeNidTest extends AhjoEntityKernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // The plugin looks up trustees with accessCheck(TRUE).
+    $this->setCurrentUser($this->createUser(['access content']));
+  }
+
+  /**
+   * Empty source values return NULL and do not touch the id map.
+   */
+  public function testEmptyValue(): void {
+    $idMap = $this->prophesize(MigrateIdMapInterface::class);
+    $idMap->lookupDestinationIds(Argument::any())->shouldNotBeCalled();
+    $idMap->delete(Argument::any())->shouldNotBeCalled();
+
+    $this->assertNull($this->doTransform(NULL, $idMap));
+    $this->assertNull($this->doTransform('', $idMap));
+  }
+
+  /**
+   * Returns NULL when no trustee exists for the agent id.
+   */
+  public function testLookupMiss(): void {
+    $idMap = $this->prophesize(MigrateIdMapInterface::class);
+    $idMap->lookupDestinationIds(['agent_id' => 'missing-agent'])
+      ->willReturn([])
+      ->shouldBeCalledOnce();
+    $idMap->delete(Argument::any())->shouldNotBeCalled();
+
+    $this->assertNull($this->doTransform('missing-agent', $idMap));
+  }
+
+  /**
+   * Returns the existing trustee nid when there is no map entry.
+   */
+  public function testLookupHitWithoutMapEntry(): void {
+    $nid = $this->createTrustee('agent-1');
+
+    $idMap = $this->prophesize(MigrateIdMapInterface::class);
+    $idMap->lookupDestinationIds(['agent_id' => 'agent-1'])
+      ->willReturn([])
+      ->shouldBeCalledOnce();
+    $idMap->delete(Argument::any())->shouldNotBeCalled();
+
+    $this->assertSame($nid, $this->doTransform('agent-1', $idMap));
+  }
+
+  /**
+   * Leaves the map alone when mapped destid matches the looked-up nid.
+   */
+  public function testMatchingMapEntryIsKept(): void {
+    $nid = $this->createTrustee('agent-2');
+
+    $idMap = $this->prophesize(MigrateIdMapInterface::class);
+    $idMap->lookupDestinationIds(['agent_id' => 'agent-2'])
+      ->willReturn([[$nid]])
+      ->shouldBeCalledOnce();
+    $idMap->delete(Argument::any())->shouldNotBeCalled();
+
+    $logger = $this->prophesize(LoggerInterface::class);
+    $logger->notice(Argument::cetera())->shouldNotBeCalled();
+
+    $this->assertSame($nid, $this->doTransform('agent-2', $idMap, $logger));
+  }
+
+  /**
+   * Deletes a stale map row when destid does not match the looked-up nid.
+   */
+  public function testStaleMapEntryIsDeleted(): void {
+    $nid = $this->createTrustee('agent-3');
+
+    $idMap = $this->prophesize(MigrateIdMapInterface::class);
+    $idMap->lookupDestinationIds(['agent_id' => 'agent-3'])
+      ->willReturn([['99999']])
+      ->shouldBeCalledOnce();
+    $idMap->delete(['agent_id' => 'agent-3'])->shouldBeCalledOnce();
+
+    $logger = $this->prophesize(LoggerInterface::class);
+    $logger->notice(Argument::containingString('Removing stale migrate map entry'), Argument::any())
+      ->shouldBeCalledOnce();
+
+    $this->assertSame($nid, $this->doTransform('agent-3', $idMap, $logger));
+  }
+
+  /**
+   * Deletes a map row when a mapped node no longer exists for the agent id.
+   */
+  public function testStaleMapEntryDeletedWhenTrusteeMissing(): void {
+    $idMap = $this->prophesize(MigrateIdMapInterface::class);
+    $idMap->lookupDestinationIds(['agent_id' => 'agent-4'])
+      ->willReturn([['99999']])
+      ->shouldBeCalledOnce();
+    $idMap->delete(['agent_id' => 'agent-4'])->shouldBeCalledOnce();
+
+    $logger = $this->prophesize(LoggerInterface::class);
+    $logger->notice(Argument::cetera())->shouldBeCalledOnce();
+
+    $this->assertNull($this->doTransform('agent-4', $idMap, $logger));
+  }
+
+  /**
+   * Creates a published trustee node with the given agent id.
+   */
+  private function createTrustee(string $agent_id): string {
+    $node = Node::create([
+      'type' => 'trustee',
+      'title' => 'Test Trustee',
+      'status' => 1,
+      'field_trustee_id' => $agent_id,
+    ]);
+    $node->save();
+
+    return (string) $node->id();
+  }
+
+  /**
+   * Runs the process plugin transform.
+   *
+   * @param string|null $value
+   *   Source agent id.
+   * @param \Prophecy\Prophecy\ObjectProphecy<\Drupal\migrate\Plugin\MigrateIdMapInterface> $idMap
+   *   Id map prophecy.
+   * @param \Prophecy\Prophecy\ObjectProphecy<\Psr\Log\LoggerInterface>|null $logger
+   *   Optional logger prophecy.
+   *
+   * @return string|null
+   *   Transformed nid.
+   */
+  private function doTransform(?string $value, ObjectProphecy $idMap, ?ObjectProphecy $logger = NULL): ?string {
+    $migration = $this->prophesize(MigrationInterface::class);
+    $migration->getIdMap()->willReturn($idMap->reveal());
+
+    $logger ??= $this->prophesize(LoggerInterface::class);
+
+    $plugin = new AhjoTrusteeNid(
+      [],
+      'ahjo_trustee_nid',
+      [],
+      $migration->reveal(),
+      $this->container->get('entity_type.manager'),
+      $logger->reveal(),
+    );
+
+    $executable = $this->prophesize(MigrateExecutableInterface::class)->reveal();
+    $row = new Row(['agent_id' => $value ?? ''], ['agent_id' => []]);
+
+    return $plugin->transform($value, $executable, $row, 'nid');
+  }
+
+}

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
@@ -13,6 +13,7 @@ use Drupal\paatokset_ahjo_api\Plugin\migrate\process\AhjoTrusteeNid;
 use Drupal\Tests\paatokset_ahjo_api\Kernel\AhjoEntityKernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
@@ -21,6 +22,7 @@ use Psr\Log\LoggerInterface;
  * Tests the `ahjo_trustee_nid` process plugin.
  */
 #[Group('paatokset_ahjo_api')]
+#[RunTestsInSeparateProcesses]
 class AhjoTrusteeNidTest extends AhjoEntityKernelTestBase {
 
   use UserCreationTrait;

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
@@ -11,7 +11,6 @@ use Drupal\migrate\Row;
 use Drupal\node\Entity\Node;
 use Drupal\paatokset_ahjo_api\Plugin\migrate\process\AhjoTrusteeNid;
 use Drupal\Tests\paatokset_ahjo_api\Kernel\AhjoEntityKernelTestBase;
-use Drupal\Tests\user\Traits\UserCreationTrait;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Prophecy\Argument;
@@ -24,8 +23,6 @@ use Psr\Log\LoggerInterface;
 #[Group('paatokset_ahjo_api')]
 #[RunTestsInSeparateProcesses]
 class AhjoTrusteeNidTest extends AhjoEntityKernelTestBase {
-
-  use UserCreationTrait;
 
   /**
    * Empty source values return NULL and do not touch the id map.
@@ -153,14 +150,14 @@ class AhjoTrusteeNidTest extends AhjoEntityKernelTestBase {
     $migration->getIdMap()->willReturn($idMap->reveal());
 
     $logger ??= $this->prophesize(LoggerInterface::class);
+    $this->container->set('logger.channel.paatokset_ahjo_api', $logger->reveal());
 
-    $plugin = new AhjoTrusteeNid(
+    $plugin = AhjoTrusteeNid::create(
+      $this->container,
       [],
       'ahjo_trustee_nid',
       [],
       $migration->reveal(),
-      $this->container->get('entity_type.manager'),
-      $logger->reveal(),
     );
 
     $executable = $this->prophesize(MigrateExecutableInterface::class)->reveal();

--- a/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
+++ b/public/modules/custom/paatokset_ahjo_api/tests/src/Kernel/Migrate/AhjoTrusteeNidTest.php
@@ -28,16 +28,6 @@ class AhjoTrusteeNidTest extends AhjoEntityKernelTestBase {
   use UserCreationTrait;
 
   /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-
-    // The plugin looks up trustees with accessCheck(TRUE).
-    $this->setCurrentUser($this->createUser(['access content']));
-  }
-
-  /**
    * Empty source values return NULL and do not touch the id map.
    */
   public function testEmptyValue(): void {


### PR DESCRIPTION
# [UHF-13394](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13394)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Updates ahjo_trustees migration to gracefully handle a situation where migrate_map and nid-callback provide mismatching destination id, resulting in a integrity constraint violation
* Possible cause
  1. Trustee node is removed manually (not sure why this would happen though)
  2. `migrate-import ahjo_trustees:all` is run
    --> nid callback doesn't find a trustee with matching `field_trustee_id`-value, so a new trustee is created and assigned with the next available nid
    --> migrate_map for this source_id is updated with proper destination id. All good.
  3. `migrate-import ahjo_trustees:all_sv` is run next
    --> nid callback now finds the node created above, but migrate_map for ahjo_trustees:all_sv still has the old nid as destination id
    --> migration tries to update the node it finds in the migrate map, but since it's gone, decides to create a new node, but assigns it the nid provided by the callback
    --> `integrity constraint violation` when trying to add a new row to node-table with nid that already exists 
* Fixed here with a custom process plugin for fetching the nid, which removes the existing migrate_map row if the destination_id does not match with the resolved nid for the given source_id. Migration will then create a new migrate_map row with up-to-date values. 

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13394`
* Run code updates
  * `composer install`
  * `make drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Run the following migrations:
  ```
  drush migrate-reset-status ahjo_trustees:all
  drush migrate-import ahjo_trustees:all --update
  drush migrate-reset-status ahjo_trustees:all_sv
  drush migrate-import ahjo_trustees:all_sv --update
  ```
  You should see messages like `Removing stale migrate map entry for trustee laurhan (mapped nid 123456, actual nid 654321)`, but you should not see any integrity constraint violation errors.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->



[UHF-13394]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ