### PR TITLE
UHF-13250: Removing the database cleanup hook.

### DIFF
--- a/docker/openshift/hooks/db-replace/99-clean.sh
+++ b/docker/openshift/hooks/db-replace/99-clean.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Clear maintenance mode to allow access to the site while cleaning up
-# the database.
-drush state:set system.maintenance_mode 0 --input-format=integer
-
-# Delete old decisions. Allow it to run for max 5 hours.
-drush paatokset:decisions:delete --timeout=18000


### PR DESCRIPTION
# [UHF-13250](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13250)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Removing the CPU limit on `drupal-cron`-pods made `make fresh` a lot faster. Removing the database cleanup hook to test the difference with a full db. Cleanup currently takes 5 hours as part of the `database-management` pipeline, so this helps us evaluate if it's actually worth it.

[UHF-13250]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ